### PR TITLE
feat: add mobile bottom navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,11 @@
           </div>
         </div>
       </div>
+      <div id="mobileNav">
+        <div class="nav-item" data-target="overallRankingArea">랭킹</div>
+        <div class="nav-item" data-target="mainScreen">메인</div>
+        <div class="nav-item" data-target="guestbookArea">방명록</div>
+      </div>
     </div>
     <div id="module-management-screen" class="screen module-management-screen"
       style="display:none;">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -929,6 +929,29 @@ const gameScreen = document.getElementById("gameScreen");
 const chapterListEl = document.getElementById("chapterList");
 const stageListEl = document.getElementById("stageList");
 
+// 모바일 내비게이션을 통한 firstScreen 전환
+const overallRankingAreaEl = document.getElementById("overallRankingArea");
+const mainScreenSection = document.getElementById("mainScreen");
+const guestbookAreaEl = document.getElementById("guestbookArea");
+const mobileNav = document.getElementById("mobileNav");
+
+if (mobileNav) {
+  function showFirstScreenSection(targetId) {
+    overallRankingAreaEl.style.display = "none";
+    mainScreenSection.style.display = "none";
+    guestbookAreaEl.style.display = "none";
+    const target = document.getElementById(targetId);
+    if (target) target.style.display = "block";
+  }
+
+  mobileNav.querySelectorAll(".nav-item").forEach(item => {
+    item.addEventListener("click", () => {
+      const target = item.getAttribute("data-target");
+      showFirstScreenSection(target);
+    });
+  });
+}
+
 function lockOrientationLandscape() {
   if (screen.orientation && screen.orientation.lock) {
     screen.orientation.lock('landscape').catch(err => {
@@ -947,7 +970,7 @@ document.getElementById("startBtn").onclick = () => {
 
 document.getElementById("backToMainFromChapter").onclick = () => {
   chapterStageScreen.style.display = "none";
-  document.getElementById("firstScreen").style.display = "flex";
+  document.getElementById("firstScreen").style.display = "";
 };
 
 document.getElementById("toggleChapterList").onclick = () => {
@@ -3790,7 +3813,7 @@ manageModulesBtn.addEventListener('click', () => {
 //— ② 모듈 관리 → 메인  
 backToMainFromManagement.addEventListener('click', () => {
   managementScreen.style.display = 'none';
-  firstScreen.style.display      = 'flex';
+  firstScreen.style.display      = '';
 });
 
 //— ③ 모듈 관리 → 새 제작창  
@@ -3816,7 +3839,7 @@ backToMainFromProblem.addEventListener('click', () => {
   if (problemScreenPrev === 'userProblems') {
     userProblemsScreen.style.display = 'block';
   } else if (problemScreenPrev === 'main') {
-    firstScreen.style.display = 'flex';
+    firstScreen.style.display = '';
   } else {
     chapterStageScreen.style.display = 'block';
   }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1949,3 +1949,49 @@ html, body {
   font-size: 12px;
   margin-top: 4px;
 }
+
+/* 모바일 하단 내비게이션 및 firstScreen 전환 */
+#mobileNav {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  #firstScreen {
+    display: block;
+    padding-bottom: 60px;
+  }
+
+  #firstScreen > #overallRankingArea,
+  #firstScreen > #mainScreen,
+  #firstScreen > #guestbookArea {
+    display: none;
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    box-sizing: border-box;
+  }
+
+  #firstScreen > #mainScreen {
+    display: block;
+  }
+
+  #mobileNav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: #ddd;
+  }
+
+  #mobileNav .nav-item {
+    flex: 1;
+    padding: 10px;
+    text-align: center;
+    cursor: pointer;
+  }
+
+  #mobileNav .nav-item:hover {
+    background-color: #ccc;
+  }
+}


### PR DESCRIPTION
## Summary
- show ranking, main, and guestbook screens via a bottom navigation bar on small screens
- hide inactive sections and expand visible screen to full width on mobile while keeping desktop layout untouched
- add JavaScript handlers for navigation items and adapt display logic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_6896f38f5770833299d66627358c9bd5