### PR TITLE
feat: refine mobile guestbook and ranking layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,15 +68,18 @@
         <button id="languageBtn">Language</button>
       </div>
       <div id="guestbookArea">
-        <h3 id="guestbookTitle">📝 개발자(이현준)한테 글 남기기</h3>
-        <p class="info-text" id="guestNicknameLabel">닉네임: <b id="guestUsername"></b></p>
-        <br>
-        <textarea id="guestMessage" rows="4"
-          placeholder="남기고 싶은 말..."></textarea>
-        <br>
-        <button id="guestSubmitBtn" onclick="submitGuestEntry()">등록</button>
-
-        <div id="guestbookList"></div>
+        <div id="guestbookContent">
+          <div id="guestbookForm">
+            <h3 id="guestbookTitle">📝 개발자(이현준)한테 글 남기기</h3>
+            <p class="info-text" id="guestNicknameLabel">닉네임: <b id="guestUsername"></b></p>
+            <br>
+            <textarea id="guestMessage" rows="4"
+              placeholder="남기고 싶은 말..."></textarea>
+            <br>
+            <button id="guestSubmitBtn" onclick="submitGuestEntry()">등록</button>
+          </div>
+          <div id="guestbookList"></div>
+        </div>
         <button id="coffeeBtn" style="margin-top:16px;">
           ☕ 개발자(이현준)한테 커피 사주기
         </button>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -763,6 +763,24 @@ html, body {
     box-sizing: border-box;
   }
 
+  @media (max-width: 768px) {
+    #guestbookContent {
+      display: flex;
+    }
+    #guestbookForm,
+    #guestbookList {
+      flex: 1;
+    }
+    #guestbookForm {
+      padding-right: 0.5rem;
+    }
+    #guestbookList {
+      margin-top: 0;
+      border-left: 1px solid #ddd;
+      padding-left: 0.5rem;
+    }
+  }
+
   .modal {
     position: fixed;
     top: 0;
@@ -1298,6 +1316,7 @@ html, body {
     /* 원하는 최대 높이로 조정 */
     display: flex;
     flex-direction: column;
+    overflow: hidden;
   }
 
   #overallRankingArea h3 {
@@ -1310,6 +1329,7 @@ html, body {
     /* 남은 공간 전부 사용 */
     overflow-y: auto;
     /* 세로 스크롤 */
+    min-height: 0;
   }
 
   #overallRankingList table {


### PR DESCRIPTION
## Summary
- Adjust mobile guestbook layout to split form and entries with divider
- Ensure overall ranking list scrolls within its area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f8515474833286f249cd5fbc88af