### PR TITLE
Use flex layout for guestbook and ranking screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,18 +73,16 @@
         </div>
       </div>
       <div id="guestbookArea">
-        <div id="guestbookContent">
-          <div id="guestbookForm">
-            <h3 id="guestbookTitle">📝 개발자(이현준)한테 글 남기기</h3>
-            <p class="info-text" id="guestNicknameLabel">닉네임: <b id="guestUsername"></b></p>
-            <br>
-            <textarea id="guestMessage" rows="4"
-              placeholder="남기고 싶은 말..."></textarea>
-            <br>
-            <button id="guestSubmitBtn" onclick="submitGuestEntry()">등록</button>
-          </div>
-          <div id="guestbookList"></div>
+        <div id="guestbookForm">
+          <h3 id="guestbookTitle">📝 개발자(이현준)한테 글 남기기</h3>
+          <p class="info-text" id="guestNicknameLabel">닉네임: <b id="guestUsername"></b></p>
+          <br>
+          <textarea id="guestMessage" rows="4"
+            placeholder="남기고 싶은 말..."></textarea>
+          <br>
+          <button id="guestSubmitBtn" onclick="submitGuestEntry()">등록</button>
         </div>
+        <div id="guestbookList"></div>
         <button id="coffeeBtn" style="margin-top:16px;">
           ☕ 개발자(이현준)한테 커피 사주기
         </button>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -941,7 +941,7 @@ if (mobileNav) {
     mainScreenSection.style.display = "none";
     guestbookAreaEl.style.display = "none";
     const target = document.getElementById(targetId);
-    if (target) target.style.display = (targetId === 'mainArea') ? 'flex' : 'block';
+    if (target) target.style.display = 'flex';
   }
 
   mobileNav.querySelectorAll(".nav-item").forEach(item => {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -794,6 +794,9 @@ html, body {
     border: 1px solid #ccc;
     border-radius: 12px;
     max-width: 600px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
   }
 
   #guestbookArea textarea,
@@ -804,28 +807,22 @@ html, body {
     box-sizing: border-box;
   }
 
-  @media (max-width: 768px) {
-    #guestbookArea {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      align-items: flex-start;
-    }
-    #guestbookContent {
-      display: contents;
-    }
-    #guestbookForm {
-      grid-column: 1;
-      padding-right: 0.5rem;
-    }
-    #guestbookList {
-      grid-column: 2;
-      margin-top: 0;
-      border-left: 1px solid #ddd;
-      padding-left: 0.5rem;
-    }
-    #coffeeBtn {
-      grid-column: 2;
-    }
+  #guestbookForm {
+    flex: 1 1 50%;
+    padding-right: 0.5rem;
+  }
+
+  #guestbookList {
+    flex: 1 1 50%;
+    margin-top: 0;
+    border-left: 1px solid #ddd;
+    padding-left: 0.5rem;
+  }
+
+  #coffeeBtn {
+    flex: 1 1 50%;
+    margin-left: auto;
+    align-self: flex-start;
   }
 
   .modal {


### PR DESCRIPTION
## Summary
- show first screen sections using flex instead of block
- remove guestbookContent wrapper and arrange form left, list and coffee button right
- style guestbook area with flex-wrap for two-column layout

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689707143a408332a2660ef144d53325