### PR TITLE
feat: show orientation modal on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,16 @@
             </div>
           </div>
         </div>
+    <div id="orientationModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <p>⚠️Bitwiser는 가로 모드를 권장합니다</p>
+        <p>Tip: [홈 화면에 추가 -> 설치]를 통해 Bitwiser 앱을 설치할 수 있어요!</p>
+        <div class="modal-buttons">
+          <button id="rotateLandscapeBtn">가로 모드로 전환하기</button>
+          <button id="closeOrientationBtn">닫기</button>
+        </div>
+      </div>
+    </div>
     <!-- 메인 화면 -->
     <div class="container" id="firstScreen">
       <div id="overallRankingArea">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -5069,3 +5069,44 @@ if (exportBtn) {
   exportBtn.addEventListener('click', handleGIFExport);
 }
 
+// --- 모바일 세로 모드 안내 모달 ---
+const orientationModal = document.getElementById('orientationModal');
+const rotateLandscapeBtn = document.getElementById('rotateLandscapeBtn');
+const closeOrientationBtn = document.getElementById('closeOrientationBtn');
+
+function isMobileDevice() {
+  return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+function checkOrientation() {
+  if (!orientationModal) return;
+  const isPortrait = window.matchMedia('(orientation: portrait)').matches;
+  if (isMobileDevice() && isPortrait) {
+    orientationModal.style.display = 'flex';
+  } else {
+    orientationModal.style.display = 'none';
+  }
+}
+
+if (rotateLandscapeBtn) {
+  rotateLandscapeBtn.addEventListener('click', () => {
+    lockOrientationLandscape();
+    if (orientationModal) orientationModal.style.display = 'none';
+  });
+}
+
+if (closeOrientationBtn) {
+  closeOrientationBtn.addEventListener('click', () => {
+    if (orientationModal) orientationModal.style.display = 'none';
+  });
+}
+
+window.addEventListener('resize', checkOrientation);
+const mqOrientation = window.matchMedia('(orientation: portrait)');
+if (mqOrientation.addEventListener) {
+  mqOrientation.addEventListener('change', checkOrientation);
+} else if (mqOrientation.addListener) {
+  mqOrientation.addListener(checkOrientation);
+}
+checkOrientation();
+


### PR DESCRIPTION
## Summary
- show a modal on mobile portrait orientation recommending landscape
- allow switching to landscape orientation via button or dismissing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68971c7ae0088332863420d9b66e0e8a