### PR TITLE
Adjust guestbook layout for mobile and desktop

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -795,7 +795,7 @@ html, body {
     border-radius: 12px;
     max-width: 600px;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     align-items: flex-start;
   }
 
@@ -808,15 +808,15 @@ html, body {
   }
 
   #guestbookForm {
-    flex: 1 1 50%;
-    padding-right: 0.5rem;
+    width: 100%;
+    padding-right: 0;
   }
 
   #guestbookListArea {
-    flex: 1 1 50%;
+    width: 100%;
     margin-top: 0;
-    border-left: 1px solid #ddd;
-    padding-left: 0.5rem;
+    border-top: 1px solid #ddd;
+    padding-top: 0.5rem;
     display: flex;
     flex-direction: column;
   }
@@ -2098,6 +2098,27 @@ html, body {
   #mainArea > #mainScreen,
   #mainArea > #loginArea {
     flex: 1;
+  }
+
+  #guestbookArea {
+    flex-direction: row;
+  }
+
+  #guestbookForm,
+  #guestbookListArea {
+    flex: 1 1 50%;
+    width: 50%;
+  }
+
+  #guestbookForm {
+    padding-right: 0.5rem;
+  }
+
+  #guestbookListArea {
+    border-left: 1px solid #ddd;
+    border-top: 0;
+    padding-left: 0.5rem;
+    padding-top: 0;
   }
 
   #mobileNav {


### PR DESCRIPTION
## Summary
- Stack guestbook form and list vertically by default
- Display guestbook sections side-by-side on screens up to 1024px

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973304ba5c8332b2db0895d652410a