### PR TITLE
feat: update mobile navigation bar with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,9 +127,18 @@
         </div>
       </div>
       <div id="mobileNav">
-        <div class="nav-item" data-target="overallRankingArea">랭킹</div>
-        <div class="nav-item" data-target="mainArea">메인</div>
-        <div class="nav-item" data-target="guestbookArea">방명록</div>
+        <div class="nav-item" data-target="overallRankingArea">
+          <img src="assets/trophy-icon.png" alt="랭킹" class="nav-icon">
+          <span class="nav-text">랭킹</span>
+        </div>
+        <div class="nav-item active" data-target="mainArea">
+          <img src="assets/home-icon.png" alt="메인" class="nav-icon">
+          <span class="nav-text">메인</span>
+        </div>
+        <div class="nav-item" data-target="guestbookArea">
+          <img src="assets/message-icon.png" alt="방명록" class="nav-icon">
+          <span class="nav-text">방명록</span>
+        </div>
       </div>
     </div>
     <div id="module-management-screen" class="screen module-management-screen"

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -940,8 +940,11 @@ if (mobileNav) {
     overallRankingAreaEl.style.display = "none";
     mainScreenSection.style.display = "none";
     guestbookAreaEl.style.display = "none";
+    mobileNav.querySelectorAll(".nav-item").forEach(nav => nav.classList.remove("active"));
     const target = document.getElementById(targetId);
     if (target) target.style.display = 'flex';
+    const activeNav = mobileNav.querySelector(`.nav-item[data-target="${targetId}"]`);
+    if (activeNav) activeNav.classList.add("active");
   }
 
   mobileNav.querySelectorAll(".nav-item").forEach(item => {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2127,7 +2127,7 @@ html, body {
     bottom: 0;
     left: 0;
     width: 100%;
-    background-color: #ddd;
+    background-color: #fff;
   }
 
   #mobileNav .nav-item {
@@ -2135,9 +2135,27 @@ html, body {
     padding: 10px;
     text-align: center;
     cursor: pointer;
+    background-color: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+
+  #mobileNav .nav-item .nav-text {
+    display: none;
+  }
+
+  #mobileNav .nav-item.active .nav-text {
+    display: inline;
   }
 
   #mobileNav .nav-item:hover {
-    background-color: #ccc;
+    background-color: #e0e0e0;
+  }
+
+  #mobileNav .nav-icon {
+    width: 24px;
+    height: 24px;
   }
 }


### PR DESCRIPTION
## Summary
- Show trophy, home, and message icons in the mobile nav bar with text only for the active section.
- Style the nav bar with a white background and light grey button areas.
- Toggle active state in JavaScript so the correct label appears.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973bbc50448332909ec5b564f16377