### PR TITLE
Show first screen sections on resize

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -936,23 +936,38 @@ const guestbookAreaEl = document.getElementById("guestbookArea");
 const mobileNav = document.getElementById("mobileNav");
 
 if (mobileNav) {
-  function showFirstScreenSection(targetId) {
-    overallRankingAreaEl.style.display = "none";
-    mainScreenSection.style.display = "none";
-    guestbookAreaEl.style.display = "none";
-    mobileNav.querySelectorAll(".nav-item").forEach(nav => nav.classList.remove("active"));
-    const target = document.getElementById(targetId);
-    if (target) target.style.display = 'flex';
-    const activeNav = mobileNav.querySelector(`.nav-item[data-target="${targetId}"]`);
-    if (activeNav) activeNav.classList.add("active");
+    function showFirstScreenSection(targetId) {
+      overallRankingAreaEl.style.display = "none";
+      mainScreenSection.style.display = "none";
+      guestbookAreaEl.style.display = "none";
+      mobileNav.querySelectorAll(".nav-item").forEach(nav => nav.classList.remove("active"));
+      const target = document.getElementById(targetId);
+      if (target) target.style.display = 'flex';
+      const activeNav = mobileNav.querySelector(`.nav-item[data-target="${targetId}"]`);
+      if (activeNav) activeNav.classList.add("active");
   }
 
-  mobileNav.querySelectorAll(".nav-item").forEach(item => {
-    item.addEventListener("click", () => {
-      const target = item.getAttribute("data-target");
-      showFirstScreenSection(target);
+    mobileNav.querySelectorAll(".nav-item").forEach(item => {
+      item.addEventListener("click", () => {
+        const target = item.getAttribute("data-target");
+        showFirstScreenSection(target);
+      });
     });
-  });
+
+    function handleFirstScreenResize() {
+      if (window.innerWidth >= 1024) {
+        overallRankingAreaEl.style.display = "";
+        mainScreenSection.style.display = "";
+        guestbookAreaEl.style.display = "";
+      } else {
+        const activeNav = mobileNav.querySelector(".nav-item.active");
+        const target = activeNav ? activeNav.getAttribute("data-target") : "mainArea";
+        showFirstScreenSection(target);
+      }
+    }
+
+  window.addEventListener("resize", handleFirstScreenResize);
+  handleFirstScreenResize();
 }
 
 function lockOrientationLandscape() {


### PR DESCRIPTION
## Summary
- restore first screen areas when window width is at least 1024px
- listen for resize events and clear inline styles to show all sections

## Testing
- `node --check script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_68973ec13bf08332a13df54ce5ed3267