### PR TITLE
Align stage tutorial modal layout with login button style

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,8 +519,10 @@
     <div id="stageTutorialModal" class="modal" style="display:none;">
       <div class="modal-content">
         <img id="stageTutImg" class="tutorial-img" src="" alt="tutorial">
-        <p id="stageTutDesc"></p>
-        <button id="stageTutBtn">시작하기</button>
+        <div class="tutorial-text">
+          <p id="stageTutDesc"></p>
+          <button id="stageTutBtn" class="main-button">시작하기</button>
+        </div>
       </div>
     </div>
     <script>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1054,7 +1054,23 @@ html, body {
 #stageTutorialModal .modal-content {
   max-height: calc(100vh - 2rem);
   overflow-y: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
+
+#stageTutorialModal .tutorial-img {
+  width: 150px;
+  max-height: 150px;
+  margin: 0;
+}
+
+#stageTutorialModal .tutorial-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 
 #gifModal {
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Display stage tutorial image on the left with text and start button stacked on the right
- Style the stage tutorial start button like the main login/logout button, including hover effect

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68985b70c0348332bd1d61fb59e2ffa7