### PR TITLE
Refactor mobile menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,15 +393,15 @@
       </div>
       <!-- 메뉴바 -->
       <div id="menuBar">
-        <button id="prevStageBtnMenu">← 이전 스테이지</button>
         <button id="saveCircuitBtn">💾 회로 저장</button>
         <button id="viewSavedBtn">💾 저장된 회로 보기</button>
         <button id="viewRankingBtn">🏆 랭킹 보기</button>
         <button id="showIntroBtn">ℹ️ 스테이지 안내</button>
         <button id="hintBtn">💡 힌트</button>
         <button id="exportGifBtn">📷 GIF 내보내기</button>
-        <button id="backToLevelsBtn">← 레벨 선택으로</button>
+        <button id="prevStageBtnMenu">← 이전 스테이지</button>
         <button id="nextStageBtnMenu">다음 스테이지 →</button>
+        <button id="backToLevelsBtn">← 레벨 선택으로</button>
       </div>
     </div>
     <div id="tutorialModal" class="modal tutorial-modal" style="display:none;">

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2175,3 +2175,41 @@ html, body {
     height: 24px;
   }
 }
+
+@media (max-width: 600px) {
+  #menuBar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 40vw;
+    height: 100vh;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: 1fr;
+    gap: 5px;
+    padding: 5px;
+  }
+
+  #menuBar button {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    aspect-ratio: 1 / 1;
+    box-sizing: border-box;
+  }
+
+  #backToLevelsBtn {
+    grid-column: 1 / span 2;
+  }
+
+  #gameLayout {
+    margin-left: 40vw;
+    padding-bottom: 0;
+  }
+
+  #gridContainer {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Reorder menu bar buttons to group save/view/ranking options and move stage navigation near bottom
- Introduce mobile-specific menu layout: left-side 2x5 grid with square buttons and double-width level select
- Adjust game layout spacing to accommodate new mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898896b1bf483329ba5d66a21cdaa22