### PR TITLE
style: refine mobile menu bar for mobile layout

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2177,36 +2177,40 @@ html, body {
 }
 
 @media (max-width: 1024px) {
+  :root {
+    --menu-bar-width: 12rem;
+  }
+
   #menuBar {
     position: fixed;
-    top: 0;
+    top: 50%;
     left: 0;
-    bottom: 0;
-    width: 40vh;
-    height: 95vh;
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-auto-rows: 1fr;
-    gap: 5px;
-    padding: 5px;
+    margin-left: 0.5rem;
+    transform: translateY(-50%);
+    width: var(--menu-bar-width);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background-color: #fff;
+    border: 2px solid #007bff;
+    border-radius: 0.5rem;
+    z-index: 1000;
   }
 
   #menuBar button {
-    font-size: 12pt;
-    height: 18vh;
+    background-color: #fff;
+    border: 2px solid #007bff;
+    border-radius: 0.5rem;
+    color: #007bff;
+    padding: 0.5rem;
     margin: 0;
-    padding: 0;
-    aspect-ratio: 1 / 1;
+    width: 100%;
     box-sizing: border-box;
   }
 
-  #backToLevelsBtn {
-    grid-column: 1 / span 2;
-    width: 38vh;
-  }
-
   #gameArea {
-    margin-left: 20vw;
+    margin-left: calc(var(--menu-bar-width) + 1rem);
     padding-bottom: 0;
   }
 


### PR DESCRIPTION
## Summary
- center mobile menu bar vertically with margin and rounded border
- style menu buttons with white background and blue border
- offset game area using CSS variable to avoid overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689897bcaa0c833284b1713327493617