### PR TITLE
style: refine mobile menu bar layout

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2177,18 +2177,26 @@ html, body {
 }
 
 @media (max-width: 1024px) {
+  :root {
+    --menuBarWidth: 40vh;
+  }
+
   #menuBar {
     position: fixed;
-    top: 0;
+    top: 50%;
     left: 0;
-    bottom: 0;
-    width: 40vh;
+    margin-left: 0.5rem;
+    transform: translateY(-50%);
+    width: var(--menuBarWidth);
     height: 95vh;
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     grid-auto-rows: 1fr;
     gap: 5px;
     padding: 5px;
+    border: 2px solid #1d4ed8;
+    border-radius: 10px;
+    background-color: #ddd;
   }
 
   #menuBar button {
@@ -2198,15 +2206,19 @@ html, body {
     padding: 0;
     aspect-ratio: 1 / 1;
     box-sizing: border-box;
+    background-color: #fff;
+    border: 2px solid #1d4ed8;
+    border-radius: 8px;
+    color: #1d4ed8;
   }
 
   #backToLevelsBtn {
     grid-column: 1 / span 2;
-    width: 38vh;
+    width: calc(var(--menuBarWidth) - 2vh);
   }
 
   #gameArea {
-    margin-left: 20vw;
+    margin-left: calc(var(--menuBarWidth) + 1rem);
     padding-bottom: 0;
   }
 


### PR DESCRIPTION
## Summary
- center the mobile menu bar with left margin
- add rounded blue borders to menu bar and buttons
- keep game area aligned beside menu bar using shared width variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989b0156d4833288e34e78754b908e