### PR TITLE
feat: improve mobile menu bar buttons

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2891,6 +2891,24 @@ function setupGoogleAuth() {
   });
 }
 
+function formatMenuBarButtons() {
+  const isMobile = window.innerWidth <= 1024;
+  document.querySelectorAll('#menuBar button').forEach(btn => {
+    if (!btn.dataset.originalText) {
+      btn.dataset.originalText = btn.textContent.trim();
+    }
+    const original = btn.dataset.originalText;
+    const firstSpace = original.indexOf(' ');
+    const firstChar = original.charAt(0);
+    if (isMobile && firstSpace !== -1 && !/[A-Za-z0-9가-힣]/.test(firstChar)) {
+      const rest = original.slice(firstSpace + 1);
+      btn.innerHTML = `<span class="emoji">${firstChar}</span><span class="btn-text">${rest}</span>`;
+    } else {
+      btn.textContent = original;
+    }
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const uname = localStorage.getItem("username");
   if (uname) document.getElementById("guestUsername").textContent = uname;
@@ -2899,6 +2917,8 @@ document.addEventListener("DOMContentLoaded", () => {
   initialTasks.push(setupGoogleAuth());
 
   setupKeyToggles();
+  formatMenuBarButtons();
+  window.addEventListener('resize', formatMenuBarButtons);
   Promise.all(initialTasks).then(() => {
     hideLoadingScreen();
   });

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -171,6 +171,17 @@ html, body {
   #menuBar button {
     margin: 0 5px;
     padding: 6px 10px;
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+  }
+
+  #menuBar button:hover:not(:disabled) {
+    background-color: #eee;
+  }
+
+  #menuBar button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
 
@@ -2210,6 +2221,25 @@ html, body {
     border: 2px solid #1d4ed8;
     border-radius: 8px;
     color: #1d4ed8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    text-align: center;
+  }
+
+  #menuBar button:hover:not(:disabled) {
+    background-color: #1d4ed8;
+    color: #fff;
+  }
+
+  #menuBar button:disabled {
+    background-color: #ccc;
+    border-color: #aaa;
+    color: #666;
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 
   #backToLevelsBtn {


### PR DESCRIPTION
## Summary
- Stack menu bar button icons above labels on small screens
- Add hover and disabled styles for menu bar buttons
- Auto-format buttons when screen size changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989f7301fc83328033732827907c95