### PR TITLE
feat: add emoji font support

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -6,7 +6,8 @@
     display: flex;
     /* 기존 space-between 제거 */
     align-items: center;
-    font-family: 'Noto Sans KR', sans-serif;
+    font-family: 'Noto Sans KR', 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
     background-color: #f0f0f0;
     color: #0F172A;
     text-align: center;
@@ -173,6 +174,8 @@ html, body {
     padding: 6px 10px;
     cursor: pointer;
     transition: background-color 0.2s, color 0.2s;
+    font-family: system-ui, 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
   }
 
   #menuBar button:hover:not(:disabled) {
@@ -749,7 +752,8 @@ html, body {
     border-top: 2px solid #ccc;
     margin-top: 20px;
     padding: 1.5rem;
-    font-family: 'Noto Sans KR', sans-serif;
+    font-family: 'Noto Sans KR', 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
     font-size: 1rem;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     border-radius: 12px;
@@ -1100,7 +1104,8 @@ html, body {
 
   body {
     /* assets/background.png 파일을 프로젝트 루트 기준으로 불러옵니다 */
-    font-family: 'Noto Sans KR', sans-serif;
+    font-family: 'Noto Sans KR', 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
     text-align: center;
   }
 
@@ -1659,7 +1664,8 @@ html, body {
   padding: 2rem;
   overflow-y: auto;
   box-sizing: border-box;
-  font-family: 'Noto Sans KR', sans-serif;
+  font-family: 'Noto Sans KR', 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
 }
 
 /* 뒤로가기 버튼 */


### PR DESCRIPTION
## Summary
- allow emoji-capable fonts by expanding body font stack
- ensure menu bar buttons use system font stack for emoji rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a4bba75883329f5ccfa3b2a720ce