### PR TITLE
Remove menu bar emojis on mobile

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2898,11 +2898,11 @@ function formatMenuBarButtons() {
       btn.dataset.originalText = btn.textContent.trim();
     }
     const original = btn.dataset.originalText;
-    const firstSpace = original.indexOf(' ');
-    const firstChar = original.charAt(0);
-    if (isMobile && firstSpace !== -1 && !/[A-Za-z0-9가-힣]/.test(firstChar)) {
-      const rest = original.slice(firstSpace + 1);
-      btn.innerHTML = `<span class="emoji">${firstChar}</span><span class="btn-text">${rest}</span>`;
+    if (isMobile) {
+      const cleaned = original
+        .replace(/^[^\w가-힣]+\s*/, '')
+        .replace(/\s*[^\w가-힣]+$/, '');
+      btn.textContent = cleaned;
     } else {
       btn.textContent = original;
     }


### PR DESCRIPTION
## Summary
- Strip emoji characters from menu bar buttons on small screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898aba9db8883328d210205ad39e25c