### PR TITLE
feat: add mobile menu toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,7 @@
       </div>
       <!-- 메뉴바 -->
       <div id="menuBar">
+        <button id="menuToggleBtn">☰</button>
         <button id="saveCircuitBtn">💾 회로 저장</button>
         <button id="viewSavedBtn">💾 저장된 회로</button>
         <button id="viewRankingBtn">🏆 랭킹</button>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2894,6 +2894,7 @@ function setupGoogleAuth() {
 function formatMenuBarButtons() {
   const isMobile = window.innerWidth <= 1024;
   document.querySelectorAll('#menuBar button').forEach(btn => {
+    if (btn.id === 'menuToggleBtn') return;
     if (!btn.dataset.originalText) {
       btn.dataset.originalText = btn.textContent.trim();
     }
@@ -2909,6 +2910,17 @@ function formatMenuBarButtons() {
   });
 }
 
+function setupMenuToggle() {
+  const menuBar = document.getElementById('menuBar');
+  const gameArea = document.getElementById('gameArea');
+  const toggleBtn = document.getElementById('menuToggleBtn');
+  if (!menuBar || !gameArea || !toggleBtn) return;
+  toggleBtn.addEventListener('click', () => {
+    menuBar.classList.toggle('collapsed');
+    gameArea.classList.toggle('menu-collapsed');
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const uname = localStorage.getItem("username");
   if (uname) document.getElementById("guestUsername").textContent = uname;
@@ -2917,6 +2929,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initialTasks.push(setupGoogleAuth());
 
   setupKeyToggles();
+  setupMenuToggle();
   formatMenuBarButtons();
   window.addEventListener('resize', formatMenuBarButtons);
   Promise.all(initialTasks).then(() => {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -176,6 +176,10 @@ html, body {
     transition: background-color 0.2s, color 0.2s;
   }
 
+  #menuToggleBtn {
+    display: none;
+  }
+
   #menuBar button:hover:not(:disabled) {
     background-color: #eee;
   }
@@ -2233,6 +2237,13 @@ html, body {
     text-align: center;
   }
 
+  #menuToggleBtn {
+    display: block;
+    grid-column: 1 / span 2;
+    height: 6vh;
+    font-size: 4vh;
+  }
+
   #menuBar button:hover:not(:disabled) {
     background-color: #1d4ed8;
     color: #fff;
@@ -2244,6 +2255,27 @@ html, body {
     color: #666;
     cursor: not-allowed;
     opacity: 0.6;
+  }
+
+  #menuBar.collapsed {
+    width: 6vh;
+    height: 6vh;
+    grid-template-columns: 1fr;
+    grid-auto-rows: 1fr;
+    padding: 5px;
+  }
+
+  #menuBar.collapsed button:not(#menuToggleBtn) {
+    display: none;
+  }
+
+  #menuBar.collapsed #menuToggleBtn {
+    grid-column: 1;
+    height: 100%;
+  }
+
+  #gameArea.menu-collapsed {
+    margin-left: 1rem;
   }
 
   #backToLevelsBtn {


### PR DESCRIPTION
## Summary
- add hamburger toggle button to the mobile menu bar
- collapse/expand menu bar and adjust game area spacing via CSS
- wire up JavaScript to toggle menu visibility

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_6898b2b83dec833290722f1691924cb4