### PR TITLE
feat: streamline mobile menu layout

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2891,25 +2891,6 @@ function setupGoogleAuth() {
   });
 }
 
-function formatMenuBarButtons() {
-  const isMobile = window.innerWidth <= 1024;
-  document.querySelectorAll('#menuBar button').forEach(btn => {
-    if (btn.id === 'menuToggleBtn') return;
-    if (!btn.dataset.originalText) {
-      btn.dataset.originalText = btn.textContent.trim();
-    }
-    const original = btn.dataset.originalText;
-    if (isMobile) {
-      const cleaned = original
-        .replace(/^[^\w가-힣]+\s*/, '')
-        .replace(/\s*[^\w가-힣]+$/, '');
-      btn.textContent = cleaned;
-    } else {
-      btn.textContent = original;
-    }
-  });
-}
-
 function setupMenuToggle() {
   const menuBar = document.getElementById('menuBar');
   const gameArea = document.getElementById('gameArea');
@@ -2930,8 +2911,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   setupKeyToggles();
   setupMenuToggle();
-  formatMenuBarButtons();
-  window.addEventListener('resize', formatMenuBarButtons);
   Promise.all(initialTasks).then(() => {
     hideLoadingScreen();
   });

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2298,12 +2298,9 @@ html, body {
     /* margin-right: 0.5rem; */
     /* transform: translateY(-50%); */
     width: var(--menuBarWidth);
-    height: 72vh;
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-auto-rows: 1fr;
-    row-gap: 5px;
-    column-gap: 7px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
     padding: 5px;
     /* border: 2px solid #1d4ed8; */
     /* border-radius: 10px; */
@@ -2314,14 +2311,14 @@ html, body {
     width: 100%;
     word-break: keep-all;
     font-size: 3vh;
-    height: 12vh;
+    height: 6vh;
     margin: 0;
     padding: 0;
-    /* aspect-ratio: 1 / 1; */
     box-sizing: border-box;
     background-color: #fff;
     border: 2px solid #1d4ed8;
-    border-radius: 8px;
+    border-right: none;
+    border-radius: 8px 0 0 8px;
     color: #1d4ed8;
     display: flex;
     flex-direction: column;
@@ -2334,7 +2331,6 @@ html, body {
   #menuToggleBtn {
     text-align: right;
     display: block;
-    grid-column: 1 / span 2;
     height: 6vh;
     font-size: 4vh;
     background: transparent;
@@ -2358,9 +2354,7 @@ html, body {
 
   #menuBar.collapsed {
     width: 6vh;
-    height: 6vh;
-    grid-template-columns: 1fr;
-    grid-auto-rows: 1fr;
+    height: auto;
     padding: 5px;
   }
 
@@ -2369,7 +2363,7 @@ html, body {
   }
 
   #menuBar.collapsed #menuToggleBtn {
-    grid-column: 1;
+    width: 100%;
     height: 100%;
   }
 
@@ -2378,8 +2372,7 @@ html, body {
   }
 
   #backToLevelsBtn {
-    grid-column: 1 / span 2;
-    width: calc(var(--menuBarWidth) - 2vh);
+    width: 100%;
   }
 
   #gameArea {


### PR DESCRIPTION
## Summary
- Stack mobile menu buttons vertically and style them as right-side bookmarks
- Remove emoji-stripping logic so language file text displays untouched

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899697684c883328fb25f2de6babfa4