### PR TITLE
Add smooth mobile menu toggle animation

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2306,6 +2306,8 @@ html, body {
     /* border: 2px solid #1d4ed8; */
     /* border-radius: 10px; */
     background-color: transparent;
+    overflow: hidden;
+    transition: width 0.3s ease;
   }
 
   #menuBar button:not(#menuToggleBtn) {
@@ -2327,6 +2329,9 @@ html, body {
     justify-content: center;
     gap: 4px;
     text-align: center;
+    transition: height 0.3s ease, opacity 0.3s ease;
+    overflow: hidden;
+    opacity: 1;
   }
 
   #menuToggleBtn {
@@ -2360,7 +2365,12 @@ html, body {
   }
 
   #menuBar.collapsed button:not(#menuToggleBtn) {
-    display: none;
+    height: 0;
+    opacity: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    pointer-events: none;
   }
 
   #menuBar.collapsed #menuToggleBtn {


### PR DESCRIPTION
## Summary
- animate menu bar width change on mobile toggle
- fade and collapse menu items during transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68996fdd26388332a57d95ec3f34f0e7