### PR TITLE
Center game layout in remaining space

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2397,6 +2397,10 @@ html, body {
   #gameArea {
     /* margin-left: calc(var(--menuBarWidth) + 1rem); */
     padding-bottom: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1;
   }
 
   #gridContainer {


### PR DESCRIPTION
## Summary
- Ensure game layout fills remaining space under title and tagline
- Use flex column on game area to center game UI

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68998f4c8ddc8332b1953e544618a627