### PR TITLE
Adapt grid to viewport

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -12,6 +12,7 @@ let isMouseDown = false;
 let wireTrace = [];     // 드래그 경로
 let GRID_ROWS = 6;
 let GRID_COLS = 6;
+const DEFAULT_CELL_SIZE = 50;
 let wires = [];  // { path, start, end } 객체를 저장할 배열
 let problemOutputsValid = false;
 let problemScreenPrev = null;  // 문제 출제 화면 진입 이전 화면 기록
@@ -1853,6 +1854,31 @@ function renderStageList(stageList) {
   });
 }
 
+function updateCellSize() {
+  if (!grid) return;
+  const gap = 2;
+  const border = 4;
+  grid.style.setProperty('--cell-size', `${DEFAULT_CELL_SIZE}px`);
+
+  let rect = grid.getBoundingClientRect();
+  let availableWidth = window.innerWidth - rect.left - border;
+  let availableHeight = window.innerHeight - rect.top - border;
+  let sizeByWidth = (availableWidth - gap * (GRID_COLS - 1)) / GRID_COLS;
+  let sizeByHeight = (availableHeight - gap * (GRID_ROWS - 1)) / GRID_ROWS;
+  let newSize = Math.min(DEFAULT_CELL_SIZE, sizeByWidth, sizeByHeight);
+  grid.style.setProperty('--cell-size', `${Math.floor(newSize)}px`);
+
+  rect = grid.getBoundingClientRect();
+  if (rect.right > window.innerWidth || rect.bottom > window.innerHeight) {
+    availableWidth = window.innerWidth - rect.left - border;
+    availableHeight = window.innerHeight - rect.top - border;
+    sizeByWidth = (availableWidth - gap * (GRID_COLS - 1)) / GRID_COLS;
+    sizeByHeight = (availableHeight - gap * (GRID_ROWS - 1)) / GRID_ROWS;
+    newSize = Math.min(newSize, sizeByWidth, sizeByHeight);
+    grid.style.setProperty('--cell-size', `${Math.floor(newSize)}px`);
+  }
+}
+
 function setGridDimensions(rows, cols) {
   GRID_ROWS = rows;
   GRID_COLS = cols;
@@ -1861,12 +1887,15 @@ function setGridDimensions(rows, cols) {
     // ① CSS 변수만 업데이트
     grid.style.setProperty('--grid-rows', rows);
     grid.style.setProperty('--grid-cols', cols);
+    updateCellSize();
 
     // ② inline grid-template 은 제거하거나 주석 처리
     // grid.style.gridTemplateRows   = `repeat(${rows}, 1fr)`;
     // grid.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
   }
 }
+
+window.addEventListener('resize', updateCellSize);
 
 
 /**

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -196,9 +196,9 @@ html, body {
     display: grid;
     gap: 2px;
     border: 2px solid black;
-    grid-template-columns: repeat(var(--grid-cols, 6), 50px);
+    grid-template-columns: repeat(var(--grid-cols, 6), var(--cell-size));
     /* 기존 */
-    grid-template-rows: repeat(var(--grid-rows, 6), 50px);
+    grid-template-rows: repeat(var(--grid-rows, 6), var(--cell-size));
     touch-action: none;
     /* 추가 */
   }
@@ -261,8 +261,8 @@ html, body {
     box-sizing: border-box;
     position: relative;
     background-color: white;
-    width: 50px;
-    height: 50px;
+    width: var(--cell-size);
+    height: var(--cell-size);
   }
 
   .cell.block {
@@ -272,6 +272,7 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: calc(var(--cell-size) * 0.4);
   }
 
   .cell.wire {
@@ -287,6 +288,7 @@ html, body {
     left: 50%;
     background-color: black;
     transform: translateX(-50%);
+    width: calc(var(--cell-size) / 25);
   }
 
   .cell.wire.wire-up::before {
@@ -307,6 +309,7 @@ html, body {
     top: 50%;
     background-color: black;
     transform: translateY(-50%);
+    height: calc(var(--cell-size) / 25);
   }
 
   .cell.wire.wire-left::after {
@@ -369,7 +372,7 @@ html, body {
   /* 세로선(│) – 굵기만 2 px */
   .cell.wire.wire-up::before,
   .cell.wire.wire-down::before {
-    width: 2px;
+    width: calc(var(--cell-size) / 25);
     /* ▽ 세로 점선 + 애니메이션 */
     background-image: repeating-linear-gradient(0deg, #000 0 26px, transparent 26px var(--unit));
     background-size: 100% var(--unit);
@@ -379,7 +382,7 @@ html, body {
   /* 가로선(─) – 굵기를 height 로만 통일 */
   .cell.wire.wire-left::after,
   .cell.wire.wire-right::after {
-    height: 2px;
+    height: calc(var(--cell-size) / 25);
     /* ▽ 가로 점선 + 애니메이션 */
     background-image: repeating-linear-gradient(90deg, #000 0 26px, transparent 26px var(--unit));
     background-size: var(--unit) 100%;
@@ -390,28 +393,29 @@ html, body {
 
   /* 셀 크기 변수(선택) */
   :root {
-    --unit: 52px;
+    --cell-size: 50px;
+    --unit: calc(var(--cell-size) + 2px);
     /* 셀 한 칸 간격 */
-    /* 아래 네 값만 바꿔가며 테스트하세요 */
-    --phase-right: 26px;
+    --half-unit: calc(var(--unit) / 2);
+    --phase-right: var(--half-unit);
     /* →  흐름 */
     --phase-left: 0px;
     /* ←  흐름 (반 주기 만큼 밀어 예시) */
     --phase-down: 0px;
     /* ↓  흐름 */
-    --phase-up: 26px;
+    --phase-up: var(--half-unit);
     /* ↑  흐름 */
     /* shape: down+right (┌) */
     --corner-offset-dr-right: 0px;
     --corner-offset-dr-down: 0px;
 
     /* shape: down+left  (┐) */
-    --corner-offset-dl-left: 26px;
-    --corner-offset-dl-down: 26px;
+    --corner-offset-dl-left: var(--half-unit);
+    --corner-offset-dl-down: var(--half-unit);
 
     /* shape: up+right   (└) */
-    --corner-offset-ur-right: 26px;
-    --corner-offset-ur-up: 26px;
+    --corner-offset-ur-right: var(--half-unit);
+    --corner-offset-ur-up: var(--half-unit);
 
     /* shape: up+left    (┘) */
     --corner-offset-ul-left: 0px;
@@ -419,7 +423,6 @@ html, body {
 
     /* fallback */
     --corner-offset: 0px;
-    --half-unit: calc(var(--unit) / 2);
   }
 
   /* ── 가로 기본선(h) ───────────────────────── */
@@ -430,7 +433,7 @@ html, body {
     top: 50%;
     transform: translateY(-50%);
     width: 100%;
-    height: 2px;
+    height: calc(var(--cell-size) / 25);
 
     /* 검정 26px → 투명 26px = 총 52px */
     background-image: repeating-linear-gradient(90deg, #000 0 26px, transparent 26px var(--unit));
@@ -447,7 +450,7 @@ html, body {
     top: 0;
     left: 50%;
     transform: translateX(-50%);
-    width: 2px;
+    width: calc(var(--cell-size) / 25);
     height: 100%;
 
     background-image: repeating-linear-gradient(0deg, #000 0 26px, transparent 26px var(--unit));
@@ -1639,8 +1642,8 @@ html, body {
   display: grid;
   gap: 2px;
   border: 2px solid black;
-  grid-template-columns: repeat(var(--grid-cols, 6), 50px);
-  grid-template-rows: repeat(var(--grid-rows, 6), 50px);
+  grid-template-columns: repeat(var(--grid-cols, 6), var(--cell-size));
+  grid-template-rows: repeat(var(--grid-rows, 6), var(--cell-size));
   touch-action: none;
 }
 
@@ -1899,8 +1902,8 @@ html, body {
 
 /* ── 1) 기본 셀 ── */
 .cell {
-  width: 50px;
-  height: 50px;
+  width: var(--cell-size);
+  height: var(--cell-size);
   background-color: #ffffff;
   border-radius: 3px;             /* 🎯 핵심 – 4~6px 권장 */
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
## Summary
- shrink grid cell size when the board would overflow the screen
- drive grid, wire, and block styling from new CSS cell-size variable

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689991d0687c833291bcef19bdc3a107