### PR TITLE
Move game title to right panel and link stage intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,8 +362,6 @@
     <!-- 게임 화면 -->
     <div id="gameScreen" style="display:none">
       <div id="gameArea">
-        <h1 id="gameTitle">🧠 Bitwiser</h1>
-        <p class="tagline">Play bitwise. Become bit wiser.</p>
 
         <!-- 전체 게임 영역: 좌측 메뉴 + 중앙 그리드 + 우측 안내 -->
         <div id="gameLayout">
@@ -381,6 +379,7 @@
         <!-- 우측: 시뮬레이트 + 안내 + 삭제 -->
         <div class="rightPanel" id="rightPanel"
           style="display: flex; flex-direction: column; align-items: center; gap: 1rem;">
+          <h1 id="gameTitle" title="ℹ️ 스테이지 안내">🧠 Bitwiser</h1>
           <button id="gradeButton" class="main-button">채점하기</button>
           <div style="text-align: center; line-height: 1.6;">
             <button id="wireStatusInfo" class="toggle-key"

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2120,6 +2120,14 @@ document.getElementById("showIntroBtn").addEventListener("click", () => {
   }
 });
 
+document.getElementById("gameTitle").addEventListener("click", () => {
+  if (currentLevel != null) {
+    showIntroModal(currentLevel);
+  } else if (currentCustomProblem) {
+    showProblemIntro(currentCustomProblem);
+  }
+});
+
 document.getElementById('hintBtn').addEventListener('click', () => {
   if (currentLevel == null) {
     if (currentCustomProblem) {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -77,6 +77,15 @@ html, body {
     flex-shrink: 0;
   }
 
+  #gameTitle {
+    cursor: pointer;
+    margin: 0;
+  }
+
+  #gameTitle:hover {
+    text-decoration: underline;
+  }
+
   #problem-screen .rightPanel {
     overflow-x: auto;
   }


### PR DESCRIPTION
## Summary
- Remove tagline from game area and show game title inside the right panel above the grading button.
- Style game title with hover effect and wire it to open the stage intro when clicked.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68999a4e16988332bf3a44e8caccb80a