### PR TITLE
Adjust game area padding for bottom menu

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2937,6 +2937,23 @@ function setupSettings() {
   });
 }
 
+function setupGameAreaPadding() {
+  const menuBar = document.getElementById('menuBar');
+  const gameArea = document.getElementById('gameArea');
+  if (!menuBar || !gameArea) return;
+
+  function updatePadding() {
+    if (window.matchMedia('(max-width: 1024px)').matches) {
+      gameArea.style.paddingBottom = '';
+    } else {
+      gameArea.style.paddingBottom = menuBar.offsetHeight + 'px';
+    }
+  }
+
+  updatePadding();
+  window.addEventListener('resize', updatePadding);
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const uname = localStorage.getItem("username");
   if (uname) document.getElementById("guestUsername").textContent = uname;
@@ -2947,6 +2964,7 @@ document.addEventListener("DOMContentLoaded", () => {
   setupKeyToggles();
   setupMenuToggle();
   setupSettings();
+  setupGameAreaPadding();
   Promise.all(initialTasks).then(() => {
     hideLoadingScreen();
   });


### PR DESCRIPTION
## Summary
- Dynamically set the game area’s bottom padding to match the menu bar height on desktop screens
- Adjust padding on window resize to prevent the bottom menu from covering content

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6899be15327c833282e3d2bf3320611a