### PR TITLE
Organize block panel into IN/OUT and GATE

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1052,6 +1052,30 @@ function setupBlockPanel(level) {
   const panel = getBlockPanel();
   panel.innerHTML = "";
 
+  // 두 줄(IN/OUT, GATE) 컨테이너 생성
+  const inoutRow = document.createElement('div');
+  inoutRow.className = 'blockRow';
+  const inoutTitle = document.createElement('div');
+  inoutTitle.className = 'blockRowTitle';
+  inoutTitle.textContent = 'IN/OUT';
+  const inoutContainer = document.createElement('div');
+  inoutContainer.className = 'blockRowContent';
+  inoutRow.appendChild(inoutTitle);
+  inoutRow.appendChild(inoutContainer);
+
+  const gateRow = document.createElement('div');
+  gateRow.className = 'blockRow';
+  const gateTitle = document.createElement('div');
+  gateTitle.className = 'blockRowTitle';
+  gateTitle.textContent = 'GATE';
+  const gateContainer = document.createElement('div');
+  gateContainer.className = 'blockRowContent';
+  gateRow.appendChild(gateTitle);
+  gateRow.appendChild(gateContainer);
+
+  panel.appendChild(inoutRow);
+  panel.appendChild(gateRow);
+
   const blocks = levelBlockSets[level];
   if (!blocks) return;
 
@@ -1061,7 +1085,7 @@ function setupBlockPanel(level) {
     div.draggable = true;
     div.dataset.type = block.type;
     if (block.name) div.dataset.name = block.name;
-    div.textContent = block.name || block.type;
+    div.textContent = block.type === 'JUNCTION' ? 'junc' : (block.name || block.type);
 
     // ↓ 여기에 설명 추가
     div.dataset.tooltip = (() => {
@@ -1076,9 +1100,12 @@ function setupBlockPanel(level) {
       }
     })();
 
-    panel.appendChild(div);
+    if (block.type === 'INPUT' || block.type === 'OUTPUT') {
+      inoutContainer.appendChild(div);
+    } else {
+      gateContainer.appendChild(div);
+    }
   });
-
 
   // WIRE는 블록이 아니므로 패널에 추가하지 않음
 

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -39,6 +39,25 @@ html, body {
     overflow: visible;
   }
 
+  .blockRow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+  }
+
+  .blockRowTitle {
+    font-weight: bold;
+  }
+
+  .blockRowContent {
+    display: flex;
+    gap: 0.5rem;
+  }
+
   #gameScreen {
     display: flex;
     flex-direction: column;
@@ -347,8 +366,8 @@ html, body {
 
   /* ── 블록 아이콘 스타일 ── */
   .blockIcon {
-    width: 60px;
-    height: 30px;
+    width: 40px;
+    height: 40px;
     background-color: #e0e0ff;
     border: 1px solid #666;
     display: inline-flex;
@@ -1669,7 +1688,8 @@ html, body {
 #blockPanel .blockIcon,
 #moduleBlockPanel .blockIcon,
 #problemBlockPanel .blockIcon {
-  width: 100%;                 /* 패널 폭에 꽉 차도록 */
+  width: 40px;
+  height: 40px;
   text-align: center;          /* 텍스트 중앙 정렬 */
 }
 


### PR DESCRIPTION
## Summary
- Split block panel into two labeled rows, IN/OUT and GATE, automatically sorting blocks accordingly and abbreviating junction icons as "junc".
- Introduce square block icons and white, rounded containers for each row.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ccba411c8332b4c27a84c43e58cf