### PR TITLE
Render flows within grid cells and update background color

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,7 +4,7 @@
   const ctx = canvas.getContext('2d');
 
   const cellSize = 50;
-  const baseColor = '#FFFFFB';
+  const baseColor = '#FFFDF0';
   const gridColor = '#f0f0e8';
   const flowColors = ['#FFF7B0', '#FFE7A0', '#FFD8A8'];
 
@@ -17,9 +17,12 @@
   window.addEventListener('resize', resize);
   resize();
 
-  function drawGrid() {
+  function drawBackground() {
     ctx.fillStyle = baseColor;
     ctx.fillRect(0, 0, width, height);
+  }
+
+  function drawGridLines() {
     ctx.strokeStyle = gridColor;
     ctx.lineWidth = 1;
     for (let x = 0; x <= width; x += cellSize) {
@@ -41,17 +44,30 @@
   }
 
   function createFlow() {
-    const dirs = [
-      [ {x:1,y:0}, {x:0,y:1} ],  // right/down
-      [ {x:1,y:0}, {x:0,y:-1} ], // right/up
-      [ {x:-1,y:0}, {x:0,y:1} ], // left/down
-      [ {x:-1,y:0}, {x:0,y:-1} ] // left/up
-    ];
-    const dirPair = dirs[Math.floor(Math.random() * dirs.length)];
-    const start = {
-      x: Math.floor(Math.random() * (width / cellSize)) * cellSize,
-      y: Math.floor(Math.random() * (height / cellSize)) * cellSize
-    };
+    const start = {};
+    let dirPair;
+    const side = Math.floor(Math.random() * 4); // 0: left, 1: right, 2: top, 3: bottom
+    if (side === 0) {
+      start.x = 0;
+      start.y = Math.floor(Math.random() * (height / cellSize)) * cellSize;
+      const v = start.y === 0 ? 1 : (start.y === height - cellSize ? -1 : (Math.random() < 0.5 ? 1 : -1));
+      dirPair = [{x:1,y:0}, {x:0,y:v}];
+    } else if (side === 1) {
+      start.x = width - cellSize;
+      start.y = Math.floor(Math.random() * (height / cellSize)) * cellSize;
+      const v = start.y === 0 ? 1 : (start.y === height - cellSize ? -1 : (Math.random() < 0.5 ? 1 : -1));
+      dirPair = [{x:-1,y:0}, {x:0,y:v}];
+    } else if (side === 2) {
+      start.y = 0;
+      start.x = Math.floor(Math.random() * (width / cellSize)) * cellSize;
+      const h = start.x === 0 ? 1 : (start.x === width - cellSize ? -1 : (Math.random() < 0.5 ? 1 : -1));
+      dirPair = [{x:0,y:1}, {x:h,y:0}];
+    } else {
+      start.y = height - cellSize;
+      start.x = Math.floor(Math.random() * (width / cellSize)) * cellSize;
+      const h = start.x === 0 ? 1 : (start.x === width - cellSize ? -1 : (Math.random() < 0.5 ? 1 : -1));
+      dirPair = [{x:0,y:-1}, {x:h,y:0}];
+    }
     return {
       dirPair,
       path: [start],
@@ -65,32 +81,28 @@
   let flows = [createFlow()];
 
   function update(time) {
-    drawGrid();
+    drawBackground();
     flows.forEach(flow => {
       if (!flow.fading && time - flow.lastStep > 120) {
         flow.lastStep = time;
         const last = flow.path[flow.path.length - 1];
         const dir = flow.dirPair[Math.random() < 0.5 ? 0 : 1];
         const next = {x: last.x + dir.x * cellSize, y: last.y + dir.y * cellSize};
-        flow.path.push(next);
-        if (next.x < 0 || next.x > width || next.y < 0 || next.y > height) {
+        if (next.x < 0 || next.x >= width || next.y < 0 || next.y >= height) {
           flow.fading = true;
+        } else {
+          flow.path.push(next);
         }
       }
       if (flow.fading) {
         flow.alpha -= 0.01;
       }
       ctx.globalAlpha = Math.max(flow.alpha, 0);
-      ctx.strokeStyle = flow.color;
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      ctx.moveTo(flow.path[0].x + 0.5, flow.path[0].y + 0.5);
-      for (let i = 1; i < flow.path.length; i++) {
-        ctx.lineTo(flow.path[i].x + 0.5, flow.path[i].y + 0.5);
-      }
-      ctx.stroke();
+      ctx.fillStyle = flow.color;
+      flow.path.forEach(p => ctx.fillRect(p.x, p.y, cellSize, cellSize));
     });
     ctx.globalAlpha = 1;
+    drawGridLines();
     flows = flows.filter(f => f.alpha > 0);
     if (flows.length < 3) {
       flows.push(createFlow());

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1151,7 +1151,7 @@ html, body {
   }
 
   body:not(.game-active) {
-    background-color: #FFFFFB;
+    background-color: #FFFDF0;
   }
 
   #backgroundCanvas {


### PR DESCRIPTION
## Summary
- Recolor background to a softer #FFFDF0 shade.
- Render animated flows inside grid cells and redraw grid lines above them.
- Ensure each flow begins and ends along screen borders for better composition.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acba6fc1883328e6e569c6a88e31b