### PR TITLE
Ensure circuit move buttons shift block labels and handlers

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -3680,6 +3680,7 @@ function moveCircuit(dx, dy) {
       classes: Array.from(cell.classList).filter(c => c !== 'cell'),
       data,
       draggable: cell.draggable,
+      text: cell.textContent,
     };
   });
 
@@ -3695,6 +3696,8 @@ function moveCircuit(dx, dy) {
     for (const k in s.cell.dataset) {
       if (k !== 'index') delete s.cell.dataset[k];
     }
+    s.cell.textContent = '';
+    s.cell.onclick = null;
   });
 
   states.forEach(s => {
@@ -3704,6 +3707,10 @@ function moveCircuit(dx, dy) {
       target.dataset[k] = v;
     }
     target.draggable = s.draggable;
+    target.textContent = s.text;
+    if (target.dataset.type === 'INPUT' || target.dataset.type === 'OUTPUT') {
+      attachInputClickHandlers(target);
+    }
   });
 
   wires.forEach(w => {


### PR DESCRIPTION
## Summary
- Preserve text and dataset when shifting blocks with move buttons
- Reattach input/output click handlers after moving blocks

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.v1.4.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_689c146e70f08332ad13599a4f702620