### PR TITLE
feat: restyle directional buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,11 +402,13 @@
               R - 회로 초기화
             </button>
           </div>
-          <div id="moveButtons" style="display:flex; flex-wrap:wrap; gap:0.5rem; justify-content:center;">
-            <button id="moveUpBtn">↑</button>
-            <button id="moveLeftBtn">←</button>
-            <button id="moveDownBtn">↓</button>
-            <button id="moveRightBtn">→</button>
+          <div id="moveButtonWrapper">
+            <div id="moveButtons">
+              <button id="moveUpBtn">↑</button>
+              <button id="moveLeftBtn">←</button>
+              <button id="moveDownBtn">↓</button>
+              <button id="moveRightBtn">→</button>
+            </div>
           </div>
           <div id="usageSection" style="width:100%;">
             <table id="usageTable">

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -91,11 +91,53 @@ html, body {
     align-items: center;
   }
 
+  #moveButtonWrapper {
+    border: 2px solid #444;
+    padding: 0.5rem;
+    border-radius: 8px;
+    display: inline-block;
+  }
+
   #moveButtons {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-areas:
+      '. up .'
+      'left down right';
+    grid-template-columns: repeat(3, 60px);
+    grid-template-rows: repeat(2, 60px);
     gap: 0.5rem;
     justify-content: center;
+  }
+
+  #moveUpBtn {
+    grid-area: up;
+  }
+
+  #moveLeftBtn {
+    grid-area: left;
+  }
+
+  #moveDownBtn {
+    grid-area: down;
+  }
+
+  #moveRightBtn {
+    grid-area: right;
+  }
+
+  #moveButtons button {
+    width: 60px;
+    height: 60px;
+    font-size: 1.5rem;
+    border: 1px solid #999;
+    border-radius: 6px;
+    background: #f7f7f7;
+    box-shadow: 0 2px 0 #ccc;
+  }
+
+  #moveButtons button:active {
+    box-shadow: none;
+    transform: translateY(2px);
   }
 
   #mainScreen {


### PR DESCRIPTION
## Summary
- Arrange directional controls in a keyboard-like layout with dedicated container
- Enlarge and style arrow buttons for clearer interaction
- Add bordered wrapper around movement controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1777c6d0833290cacbac5e7fbc96