### PR TITLE
Ensure LevelIntroModal start button remains visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -553,7 +553,9 @@
       <div class="modal-content">
         <h2 id="introTitle"></h2>
         <p id="introDesc"></p>
-        <table id="truthTable" border="1" style="margin: 10px auto;"></table>
+        <div id="truthTableContainer">
+          <table id="truthTable" border="1"></table>
+        </div>
         <button id="startLevelBtn">시작하기</button>
       </div>
     </div>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1182,7 +1182,16 @@ html, body {
   flex-direction: column;
   gap: 1rem;
 }
+#truthTableContainer {
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+  margin: 10px auto;
+}
 
+#truthTable {
+  width: 100%;
+  border-collapse: collapse;
+}
 
 #gifModal {
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Wrap the truth table in a scrollable container within the level intro modal.
- Add styles to limit table height and enable vertical scrolling while keeping the start button accessible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8481c0948332bebbce0326ae4e33