### PR TITLE
Fix right panel styling for custom stages

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1457,7 +1457,7 @@ function returnToEditScreen() {
 
   // 원래 편집 UI 복원
   document.getElementById("blockPanel").style.display = "flex";
-  document.getElementById("rightPanel").style.display = "block";
+  document.getElementById("rightPanel").style.display = "flex";
   document.getElementById("gradingArea").style.display = "none";
 }
 
@@ -5076,6 +5076,8 @@ function startCustomProblem(key, problem) {
   document.getElementById('gameTitle').textContent = problem.title || '사용자 문제';
   userProblemsScreen.style.display = 'none';
   document.getElementById('gameScreen').style.display = 'flex';
+  const rp = document.getElementById('rightPanel');
+  if (rp) rp.style.display = 'flex';
   document.body.classList.add('game-active');
   collapseMenuBarForMobile();
 }


### PR DESCRIPTION
## Summary
- Ensure right panel uses flex layout when returning from grading
- Restore right panel flex styling when starting user-created problems

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9154a7e083329d6e7e95d264a3b2