### PR TITLE
Fix scrolling in user problem creation screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
     <div id="problem-screen" class="screen" style="display:none; padding:2rem;">
       <button id="backToMainFromProblem" class="btn-back">← 메인으로</button>
       <h1 id="problemCreatorTitle">📝 문제 출제</h1>
-      <div style="display:flex; gap:1rem; align-items:flex-start; justify-content:center;">
+      <div style="display:flex; gap:1rem; align-items:flex-start; justify-content:flex-start; width:fit-content;">
         <div id="problemBlockPanel" style="width:120px;"></div>
         <div id="problemGridContainer" class="grid" style="position:relative;">
           <div id="problemGrid"></div>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1831,7 +1831,7 @@ html, body {
   flex-direction: column;
   align-items: center;
   padding: 2rem;
-  overflow-y: auto;
+  overflow: auto;
   box-sizing: border-box;
   font-family: 'Noto Sans KR', sans-serif;
 }


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in screen layouts
- adjust problem creator layout to use single scroll container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea333614c8332ae1d8282a71699c2