### PR TITLE
feat: render grid and block panels with canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,12 +184,16 @@
         style="display:flex; gap:1rem; align-items:flex-start;">
 
         <!-- 좌측: 블록 패널 -->
-        <div id="moduleBlockPanel" style="width: 120px;">
-          <!-- JS로 채워집니다 -->
+        <div id="moduleBlockWrapper" style="position:relative; width: 120px;">
+          <canvas id="moduleBlockPanelCanvas"></canvas>
+          <div id="moduleBlockPanel" style="width: 120px;">
+            <!-- JS로 채워집니다 -->
+          </div>
         </div>
 
         <!-- 중앙: 회로 그리드 -->
         <div id="moduleGridContainer" class="grid" style="position: relative;">
+          <canvas id="moduleGridCanvas"></canvas>
           <div id="moduleGrid"></div>
           <div id="moduleGridOverlay"></div>
         </div>
@@ -265,11 +269,13 @@
 
     <div id="problem-screen" class="screen" style="display:none; padding:0;">
       <div style="display:flex; gap:1rem; align-items:flex-start; justify-content:flex-start; width:fit-content;margin:auto;">
-        <div id="problemLeftPanel" style="display:flex; flex-direction:column; align-items:center;margin:auto;">
+        <div id="problemLeftPanel" style="display:flex; flex-direction:column; align-items:center;margin:auto; position:relative;">
+          <canvas id="problemBlockPanelCanvas"></canvas>
           <div id="problemBlockPanel"></div>
           <div id="trash" class="trash-area" style="margin-top: 20px;">🗑️ Drag here to delete</div>
         </div>
         <div id="problemGridContainer" class="grid" style="position:relative;margin:auto;">
+          <canvas id="problemGridCanvas"></canvas>
           <div id="problemGrid"></div>
           <div id="problemGridOverlay"></div>
         </div>
@@ -405,13 +411,15 @@
         <div id="gameLayout">
 
         <!-- 블록 패널 -->
-        <div id="leftPanel">
+        <div id="leftPanel" style="position:relative;">
+          <canvas id="blockPanelCanvas"></canvas>
           <div id="blockPanel" style="margin: 0; width: auto; flex-direction: row;"></div>
           <div id="trash" class="trash-area" style="margin-top: 20px;">🗑️ Drag here to delete</div>
         </div>
 
         <!-- 회로 그리드 -->
         <div id="gridContainer" style="position: relative;">
+          <canvas id="gridCanvas"></canvas>
           <div id="grid" class="grid"></div>
           <div id="gridOverlay"></div>
         </div>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2565,3 +2565,33 @@ html, body {
   }
 }
 
+/* Canvas 기반 그리드 및 블록 패널 */
+#gridCanvas,
+#moduleGridCanvas,
+#problemGridCanvas,
+#blockPanelCanvas,
+#moduleBlockPanelCanvas,
+#problemBlockPanelCanvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+#grid,
+#moduleGrid,
+#problemGrid,
+#blockPanel,
+#moduleBlockPanel,
+#problemBlockPanel {
+  opacity: 0;
+}
+
+#leftPanel,
+#moduleBlockWrapper,
+#problemLeftPanel,
+#gridContainer,
+#moduleGridContainer,
+#problemGridContainer {
+  position: relative;
+}
+


### PR DESCRIPTION
## Summary
- render circuit grids and block panels on canvas while keeping DOM layers for interaction
- add shared canvas styling and automatic redraw via MutationObserver

## Testing
- `node --check script.v1.4.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fec9bbd98833288a0d2fa2eedab1c