### PR TITLE
Add canvas-based rendering structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,9 +165,10 @@
           <div id="problemBlockPanel"></div>
           <div id="trash" class="trash-area" style="margin-top: 20px;">🗑️ Drag here to delete</div>
         </div>
-        <div id="problemGridContainer" class="grid" style="position:relative;margin:auto;">
-          <div id="problemGrid"></div>
-          <div id="problemGridOverlay"></div>
+        <div id="problemGridContainer" style="position:relative;margin:auto;">
+          <canvas id="problemBgCanvas"></canvas>
+          <canvas id="problemContentCanvas"></canvas>
+          <canvas id="problemOverlayCanvas"></canvas>
         </div>
         <div class="rightPanel" id="problemRightPanel" style="display:flex; flex-direction:column; gap:0.5rem; margin: auto 0;">
           <h1 id="problemCreatorTitle">📝 문제 출제</h1>
@@ -308,8 +309,9 @@
 
         <!-- 회로 그리드 -->
         <div id="gridContainer" style="position: relative;">
-          <div id="grid" class="grid"></div>
-          <div id="gridOverlay"></div>
+          <canvas id="bgCanvas"></canvas>
+          <canvas id="contentCanvas"></canvas>
+          <canvas id="overlayCanvas"></canvas>
         </div>
 
         <!-- 우측: 시뮬레이트 + 안내 + 삭제 -->
@@ -478,6 +480,23 @@
     <script src="https://cdn.jsdelivr.net/npm/gif.js@0.2.0/dist/gif.js"></script>
     <script src="background.js"></script>
     <script src="script.v1.4.js"></script>
+    <script type="module">
+      import { makeCircuit } from './src/canvas/model.js';
+      import { createController } from './src/canvas/controller.js';
+      const circuit = makeCircuit();
+      createController({
+        bgCanvas: document.getElementById('bgCanvas'),
+        contentCanvas: document.getElementById('contentCanvas'),
+        overlayCanvas: document.getElementById('overlayCanvas')
+      }, circuit);
+
+      const problemCircuit = makeCircuit();
+      createController({
+        bgCanvas: document.getElementById('problemBgCanvas'),
+        contentCanvas: document.getElementById('problemContentCanvas'),
+        overlayCanvas: document.getElementById('problemOverlayCanvas')
+      }, problemCircuit);
+    </script>
 
     <div id="levelIntroModal" style="display:none" class="modal">
       <div class="modal-content">

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1,0 +1,60 @@
+import { CELL, coord } from './model.js';
+import { drawGrid, renderContent, setupCanvas } from './renderer.js';
+import { evaluate, startEngine } from './engine.js';
+
+// Convert pixel coordinates to cell indices
+export function pxToCell(x, y) {
+  return { r: Math.floor(y / CELL), c: Math.floor(x / CELL) };
+}
+
+export function createController(canvasSet, circuit) {
+  const { bgCanvas, contentCanvas, overlayCanvas } = canvasSet;
+  const bgCtx = setupCanvas(bgCanvas, circuit.cols * CELL, circuit.rows * CELL);
+  const contentCtx = setupCanvas(contentCanvas, circuit.cols * CELL, circuit.rows * CELL);
+  const overlayCtx = setupCanvas(overlayCanvas, circuit.cols * CELL, circuit.rows * CELL);
+  drawGrid(bgCtx, circuit.rows, circuit.cols);
+  startEngine(contentCtx, circuit, renderContent);
+
+  const state = {
+    mode: 'idle',
+    placingType: null,
+    wireTrace: [],
+    startBlockId: null,
+  };
+
+  overlayCanvas.addEventListener('mousedown', e => {
+    const { offsetX, offsetY } = e;
+    const cell = pxToCell(offsetX, offsetY);
+    state.mode = 'placingBlock';
+    state.lastCell = cell;
+  });
+  overlayCanvas.addEventListener('mouseup', () => {
+    state.mode = 'idle';
+    state.wireTrace = [];
+    overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
+  });
+
+  overlayCanvas.addEventListener('mousemove', e => {
+    if (state.mode !== 'wireDrawing') return;
+    const { offsetX, offsetY } = e;
+    const cell = pxToCell(offsetX, offsetY);
+    const last = state.wireTrace[state.wireTrace.length - 1];
+    if (!last || last.r !== cell.r || last.c !== cell.c) {
+      state.wireTrace.push(coord(cell.r, cell.c));
+      overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
+      overlayCtx.save();
+      overlayCtx.strokeStyle = 'rgba(17,17,17,0.4)';
+      overlayCtx.lineWidth = 2;
+      overlayCtx.setLineDash([8, 8]);
+      overlayCtx.beginPath();
+      overlayCtx.moveTo(state.wireTrace[0].c * CELL + CELL / 2, state.wireTrace[0].r * CELL + CELL / 2);
+      state.wireTrace.forEach(p => {
+        overlayCtx.lineTo(p.c * CELL + CELL / 2, p.r * CELL + CELL / 2);
+      });
+      overlayCtx.stroke();
+      overlayCtx.restore();
+    }
+  });
+
+  return { state, circuit };
+}

--- a/src/canvas/engine.js
+++ b/src/canvas/engine.js
@@ -1,0 +1,61 @@
+import { newBlock } from './model.js';
+
+// Basic evaluation of the circuit without DOM traversal
+export function evaluate(circuit) {
+  const blocks = circuit.blocks;
+  const getValue = id => blocks[id]?.value || false;
+  let changed = true;
+  let guard = 0;
+  while (changed && guard++ < 1000) {
+    changed = false;
+    Object.values(blocks).forEach(b => {
+      const old = b.value;
+      switch (b.type) {
+        case 'INPUT':
+          break; // value already set
+        case 'NOT':
+          b.value = !getValue(b.inputs?.[0]);
+          break;
+        case 'AND':
+          b.value = (b.inputs || []).every(id => getValue(id));
+          break;
+        case 'OR':
+          b.value = (b.inputs || []).some(id => getValue(id));
+          break;
+        case 'JUNCTION':
+          // pass-through
+          b.value = getValue(b.inputs?.[0]);
+          break;
+      }
+      if (old !== b.value) changed = true;
+    });
+  }
+  return blocks;
+}
+
+// Compute directional flow for each wire based on path
+export function setWireFlows(circuit) {
+  Object.values(circuit.wires).forEach(w => {
+    const flow = [];
+    for (let i = 0; i < w.path.length - 1; i++) {
+      const a = w.path[i];
+      const b = w.path[i + 1];
+      if (b.r > a.r) flow.push('D');
+      else if (b.r < a.r) flow.push('U');
+      else if (b.c > a.c) flow.push('R');
+      else if (b.c < a.c) flow.push('L');
+    }
+    w.flow = flow;
+  });
+}
+
+// Animation loop helper
+export function startEngine(ctx, circuit, renderer) {
+  let phase = 0;
+  function tick() {
+    phase = (phase + 2) % 52;
+    renderer(ctx, circuit, phase);
+    requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+}

--- a/src/canvas/model.js
+++ b/src/canvas/model.js
@@ -1,0 +1,17 @@
+export const CELL = 50; // px — existing CSS cell size
+
+export function makeCircuit(rows = 6, cols = 6) {
+  return { rows, cols, blocks: {}, wires: {} };
+}
+
+export function coord(r, c) {
+  return { r, c };
+}
+
+export function newBlock({ id, type, name, pos }) {
+  return { id, type, name, pos, value: false };
+}
+
+export function newWire({ id, path, startBlockId, endBlockId }) {
+  return { id, path, startBlockId, endBlockId, flow: [] };
+}

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -1,0 +1,82 @@
+import { CELL } from './model.js';
+
+// Utility to prepare canvas for HiDPI displays
+export function setupCanvas(canvas, width, height) {
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = width + 'px';
+  canvas.style.height = height + 'px';
+  const ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+  return ctx;
+}
+
+// Draw grid lines snapped to half-pixels for crisp rendering
+export function drawGrid(ctx, rows, cols) {
+  ctx.save();
+  ctx.strokeStyle = '#ccc';
+  ctx.lineWidth = 1;
+  for (let r = 0; r <= rows; r++) {
+    const y = r * CELL + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(cols * CELL, y);
+    ctx.stroke();
+  }
+  for (let c = 0; c <= cols; c++) {
+    const x = c * CELL + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, rows * CELL);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+// Blocks are drawn as rounded rectangles with text labels
+export function drawBlock(ctx, block) {
+  const { r, c } = block.pos;
+  const x = c * CELL;
+  const y = r * CELL;
+  ctx.save();
+  ctx.fillStyle = '#b3e5fc'; // light blue
+  ctx.strokeStyle = '#1565c0'; // dark blue
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.rect(x + 4, y + 4, CELL - 8, CELL - 8);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#0d47a1';
+  ctx.font = '12px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(block.name || block.type, x + CELL / 2, y + CELL / 2);
+  ctx.restore();
+}
+
+// Draw a wire path with flowing dashed line
+export function drawWire(ctx, wire, phase = 0) {
+  if (!wire.path || wire.path.length < 2) return;
+  ctx.save();
+  ctx.strokeStyle = '#111';
+  ctx.lineWidth = 2;
+  ctx.setLineDash([26, 26]);
+  ctx.lineDashOffset = (-phase) % 52;
+  ctx.beginPath();
+  const start = wire.path[0];
+  ctx.moveTo(start.c * CELL + CELL / 2, start.r * CELL + CELL / 2);
+  for (let i = 1; i < wire.path.length; i++) {
+    const p = wire.path[i];
+    ctx.lineTo(p.c * CELL + CELL / 2, p.r * CELL + CELL / 2);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+// Render the circuit: wires then blocks to keep z-order
+export function renderContent(ctx, circuit, phase = 0) {
+  ctx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
+  Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase));
+  Object.values(circuit.blocks).forEach(b => drawBlock(ctx, b));
+}

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -295,16 +295,15 @@ html, body {
   }
 
 
-  #grid {
+  /* 이전: #grid div 기반 레이아웃 */
+  /* #grid {
     display: grid;
     gap: 2px;
     border: 2px solid black;
     grid-template-columns: repeat(var(--grid-cols, 6), 50px);
-    /* 기존 */
     grid-template-rows: repeat(var(--grid-rows, 6), 50px);
     touch-action: auto;
-    /* 추가 */
-  }
+  } */
   #gridContainer {
     flex-shrink: 0;
     display: flex;
@@ -358,7 +357,8 @@ html, body {
     padding: 5px 20px;
     width: 100%;
   }
-  .cell {
+  /* 이전: div 기반 셀/배선 스타일 */
+  /* .cell {
     border: 1px solid #ccc;
     box-sizing: border-box;
     position: relative;
@@ -381,7 +381,6 @@ html, body {
     background-color: #ffe;
   }
 
-  /* ── 수직선 (│) 은 ::before 에만 그리기 ── */
   .cell.wire.wire-up::before,
   .cell.wire.wire-down::before {
     content: '';
@@ -401,7 +400,6 @@ html, body {
     height: 50%;
   }
 
-  /* ── 수평선 (─) 은 ::after 에만 그리기 ── */
   .cell.wire.wire-left::after,
   .cell.wire.wire-right::after {
     content: '';
@@ -421,23 +419,19 @@ html, body {
     width: 50%;
   }
 
-  /* ── 두 방향이 동시에 있을 땐 전체 길이로 ── */
-  /* 세로 전체 (│) */
   .cell.wire.wire-up.wire-down::before {
     top: 0;
     height: 100%;
   }
 
-  /* 가로 전체 (─) */
   .cell.wire.wire-left.wire-right::after {
     left: 0;
     width: 100%;
   }
 
-  /* ── 배선 미리보기 강조 ── */
   .cell.wire-preview {
     background: #ffeca0;
-  }
+  } */
 
   /* ── 블록 아이콘 스타일 ── */
   .blockIcon {
@@ -1367,7 +1361,8 @@ html, body {
     /* 중복되어도 무방 */
   }
 
-  #gridOverlay {
+  /* 이전: #gridOverlay, #problemGridOverlay 사용 */
+  /* #gridOverlay {
     display: none;
     position: absolute;
     top: 0;
@@ -1389,6 +1384,13 @@ html, body {
     background: rgba(255, 255, 255, 0.6);
     z-index: 1000;
     cursor: not-allowed;
+  } */
+
+  #gridContainer canvas,
+  #problemGridContainer canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
   }
 
   .blockIcon {


### PR DESCRIPTION
## Summary
- add modular canvas model, renderer, controller and engine
- replace grid DOM with layered canvases and initialize controllers
- start migrating CSS away from legacy `.cell` and wire classes

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a2b4dff82083329714b0e8084d3307