### PR TITLE
Handle missing overlay to prevent grading crash

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1243,7 +1243,7 @@ async function gradeLevelAnimated(level) {
 
   if (junctionError) {
     alert("❌ JUNCTION 블록에 여러 입력이 연결되어 있습니다. 회로를 수정해주세요.");
-    overlay.style.display = "none";
+    overlay?.style.display = "none";
     isScoring = false;
     return;
   }
@@ -1260,7 +1260,7 @@ async function gradeLevelAnimated(level) {
     });
   if (outputError) {
     alert("❌ OUTPUT 블록에 여러 입력이 연결되어 있습니다. 회로를 수정해주세요.");
-    overlay.style.display = "none";
+    overlay?.style.display = "none";
     isScoring = false;
     return;
   }
@@ -1277,7 +1277,7 @@ async function gradeLevelAnimated(level) {
   const missingOutputs = requiredOutputs.filter(name => !actualOutputNames.includes(name));
   if (missingOutputs.length > 0) {
     alert(t('outputMissingAlert').replace('{list}', missingOutputs.join(', ')));
-    overlay.style.display = "none";
+    overlay?.style.display = "none";
     isScoring = false;
     return;
   }
@@ -1469,12 +1469,15 @@ async function gradeLevelAnimated(level) {
 function returnToEditScreen() {
   // 채점 모드 해제
   isScoring = false;
-  overlay.style.display = "none";
+  overlay?.style.display = "none";
 
   // 원래 편집 UI 복원
-  document.getElementById("blockPanel").style.display = "flex";
-  document.getElementById("rightPanel").style.display = "block";
-  document.getElementById("gradingArea").style.display = "none";
+  const blockPanel = document.getElementById("blockPanel");
+  const rightPanel = document.getElementById("rightPanel");
+  const gradingArea = document.getElementById("gradingArea");
+  if (blockPanel) blockPanel.style.display = "flex";
+  if (rightPanel) rightPanel.style.display = "block";
+  if (gradingArea) gradingArea.style.display = "none";
 }
 
 let clearedLevelsFromDb = [];
@@ -2637,7 +2640,7 @@ document.getElementById("gradeButton").addEventListener("click", () => {
   if (isScoring) return;
   if (currentCustomProblem == null && currentLevel == null) return;
   isScoring = true;
-  overlay.style.display = "block";
+  overlay?.style.display = "block";
   if (currentCustomProblem) {
     gradeProblemAnimated(currentCustomProblemKey, currentCustomProblem);
   } else {
@@ -4834,7 +4837,7 @@ async function gradeProblemAnimated(key, problem) {
   });
   if (junctionError){
     alert('❌ JUNCTION 블록에 여러 입력이 연결되어 있습니다. 회로를 수정해주세요.');
-    overlay.style.display='none';
+    overlay?.style.display='none';
     isScoring=false; return; }
   let outputError=false;
   Array.from(grid.querySelectorAll('.cell.block[data-type="OUTPUT"]'))
@@ -4844,7 +4847,7 @@ async function gradeProblemAnimated(key, problem) {
     });
   if(outputError){
     alert('❌ OUTPUT 블록에 여러 입력이 연결되어 있습니다. 회로를 수정해주세요.');
-    overlay.style.display='none';
+    overlay?.style.display='none';
     isScoring=false;return;
   }
 
@@ -4854,7 +4857,7 @@ async function gradeProblemAnimated(key, problem) {
   const missingOutputs = requiredOutputs.filter(n=>!actualOutputNames.includes(n));
   if(missingOutputs.length>0){
     alert(t('outputMissingAlert').replace('{list}', missingOutputs.join(', ')));
-    overlay.style.display='none';
+    overlay?.style.display='none';
     isScoring=false;return;
   }
 


### PR DESCRIPTION
## Summary
- Guard scoring overlay DOM calls to avoid null reference crashes
- Restore edit UI safely when exiting grading mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2dff815208332ac1011f8c7a9702f