### PR TITLE
fix: load block panel after tutorial

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -85,6 +85,7 @@ function resetCaptureCanvas() {
 
 // 초기 로딩 관련
 const initialTasks = [];
+let stageDataPromise = Promise.resolve();
 function hideLoadingScreen() {
   const el = document.getElementById('loadingScreen');
   if (el) el.style.display = 'none';
@@ -1581,7 +1582,7 @@ function loadClearedLevelsFromDb() {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
-  const p = loadStageData().then(() => {
+  stageDataPromise = loadStageData().then(() => {
     const prevMenuBtn = document.getElementById('prevStageBtnMenu');
     const nextMenuBtn = document.getElementById('nextStageBtnMenu');
 
@@ -1597,7 +1598,7 @@ window.addEventListener("DOMContentLoaded", () => {
     enableTouchDrag();
     return loadClearedLevelsFromDb();
   });
-  initialTasks.push(p);
+  initialTasks.push(stageDataPromise);
 });
 
 function markLevelCleared(level) {
@@ -2432,7 +2433,9 @@ function finishTutorial() {
   localStorage.setItem('tutorialCompleted', 'true');
   tutModal.style.display = 'none';
   lockOrientationLandscape();
-  startLevel(getLowestUnclearedStage());
+  stageDataPromise.then(() => {
+    startLevel(getLowestUnclearedStage());
+  });
   document.body.classList.add('game-active');
   document.getElementById('firstScreen').style.display = 'none';
   document.getElementById('chapterStageScreen').style.display = 'none';


### PR DESCRIPTION
## Summary
- ensure level data finishes loading before starting first stage
- initialize block panel only after stage data promise resolves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2e5d65e608332b3f5ffee036f9c21