### PR TITLE
Fix missing grid containers causing setupGrid errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
           <canvas id="problemBgCanvas"></canvas>
           <canvas id="problemContentCanvas"></canvas>
           <canvas id="problemOverlayCanvas"></canvas>
+  <div id="problemGrid"></div>
         </div>
         <div class="rightPanel" id="problemRightPanel" style="display:flex; flex-direction:column; gap:0.5rem; margin: auto 0;">
           <h1 id="problemCreatorTitle">📝 문제 출제</h1>
@@ -312,6 +313,7 @@
           <canvas id="bgCanvas" style="position: relative;"></canvas>
           <canvas id="contentCanvas"></canvas>
           <canvas id="overlayCanvas"></canvas>
+  <div id="grid"></div>
         </div>
 
         <!-- 우측: 시뮬레이트 + 안내 + 삭제 -->

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -295,15 +295,17 @@ html, body {
   }
 
 
-  /* 이전: #grid div 기반 레이아웃 */
-  /* #grid {
-    display: grid;
-    gap: 2px;
-    border: 2px solid black;
-    grid-template-columns: repeat(var(--grid-cols, 6), 50px);
-    grid-template-rows: repeat(var(--grid-rows, 6), 50px);
-    touch-action: auto;
-  } */
+  /* 회로 그리드 */
+#grid, #problemGrid {
+  display: grid;
+  gap: 2px;
+  border: 2px solid black;
+  grid-template-columns: repeat(var(--grid-cols, 6), 50px);
+  grid-template-rows: repeat(var(--grid-rows, 6), 50px);
+  touch-action: auto;
+  position: relative;
+  z-index: 1;
+}
   #gridContainer {
     flex-shrink: 0;
     display: flex;
@@ -1776,16 +1778,6 @@ html, body {
     outline: none;
     /* 포커스 아웃라인 제거 */
   }
-
-  #problemGrid {
-  display: grid;
-  gap: 2px;
-  border: 2px solid black;
-  grid-template-columns: repeat(var(--grid-cols, 6), 50px);
-  grid-template-rows: repeat(var(--grid-rows, 6), 50px);
-  touch-action: auto;
-}
-
 /* 공통: 게임 모드 · 모듈 모드 블록 패널 모두에 적용 */
   #blockPanel,
   #problemBlockPanel {


### PR DESCRIPTION
## Summary
- Add `#grid` and `#problemGrid` containers so `setupGrid` can mount cells
- Restore grid CSS and apply to both game and problem grids

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2e767d5288332a6fd603f028b2e24