### PR TITLE
Switch grid and block panel to canvas drag/drop

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1,5 +1,5 @@
-import { CELL, coord, newWire } from './model.js';
-import { drawGrid, renderContent, setupCanvas } from './renderer.js';
+import { CELL, coord, newWire, newBlock } from './model.js';
+import { drawGrid, renderContent, setupCanvas, drawBlock } from './renderer.js';
 import { evaluate, startEngine } from './engine.js';
 
 // Convert pixel coordinates to cell indices
@@ -20,6 +20,8 @@ export function createController(canvasSet, circuit, ui = {}) {
     placingType: null,
     wireTrace: [],
     startBlockId: null,
+    draggingBlock: null,
+    dragCandidate: null,
   };
 
   const wireBtn = ui.wireStatusInfo;
@@ -86,45 +88,106 @@ export function createController(canvasSet, circuit, ui = {}) {
       });
       renderContent(contentCtx, circuit, 0);
     } else {
-      const blk = Object.values(circuit.blocks).find(b => b.pos.r === cell.r && b.pos.c === cell.c);
-      if (blk && blk.type === 'INPUT') {
-        blk.value = !blk.value;
-        evaluate(circuit);
+      const bid = Object.keys(circuit.blocks).find(id => {
+        const b = circuit.blocks[id];
+        return b.pos.r === cell.r && b.pos.c === cell.c;
+      });
+      if (bid) {
+        state.dragCandidate = { id: bid, start: cell };
       }
     }
   });
 
   overlayCanvas.addEventListener('mouseup', e => {
+    const { offsetX, offsetY } = e;
     if (state.mode === 'wireDrawing' && state.wireTrace.length > 1) {
       const id = 'w' + Date.now();
       circuit.wires[id] = newWire({ id, path: [...state.wireTrace] });
       renderContent(contentCtx, circuit, 0);
+    } else if (state.draggingBlock) {
+      const cell = pxToCell(offsetX, offsetY);
+      const id = state.draggingBlock.id || ('b' + Date.now());
+      circuit.blocks[id] = newBlock({
+        id,
+        type: state.draggingBlock.type,
+        name: state.draggingBlock.name,
+        pos: cell
+      });
+      renderContent(contentCtx, circuit, 0);
+      state.draggingBlock = null;
+      overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
+    } else if (state.dragCandidate) {
+      const blk = circuit.blocks[state.dragCandidate.id];
+      if (blk && blk.type === 'INPUT') {
+        blk.value = !blk.value;
+        evaluate(circuit);
+      }
+      state.dragCandidate = null;
     }
     state.wireTrace = [];
-    overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
   });
 
   overlayCanvas.addEventListener('mousemove', e => {
-    if (state.mode !== 'wireDrawing') return;
     const { offsetX, offsetY } = e;
     const cell = pxToCell(offsetX, offsetY);
-    const last = state.wireTrace[state.wireTrace.length - 1];
-    if (!last || last.r !== cell.r || last.c !== cell.c) {
-      state.wireTrace.push(coord(cell.r, cell.c));
+    if (state.mode === 'wireDrawing') {
+      const last = state.wireTrace[state.wireTrace.length - 1];
+      if (!last || last.r !== cell.r || last.c !== cell.c) {
+        state.wireTrace.push(coord(cell.r, cell.c));
+        overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
+        overlayCtx.save();
+        overlayCtx.strokeStyle = 'rgba(17,17,17,0.4)';
+        overlayCtx.lineWidth = 2;
+        overlayCtx.setLineDash([8, 8]);
+        overlayCtx.beginPath();
+        overlayCtx.moveTo(state.wireTrace[0].c * CELL + CELL / 2, state.wireTrace[0].r * CELL + CELL / 2);
+        state.wireTrace.forEach(p => {
+          overlayCtx.lineTo(p.c * CELL + CELL / 2, p.r * CELL + CELL / 2);
+        });
+        overlayCtx.stroke();
+        overlayCtx.restore();
+      }
+    } else {
+      if (state.dragCandidate && (cell.r !== state.dragCandidate.start.r || cell.c !== state.dragCandidate.start.c)) {
+        const b = circuit.blocks[state.dragCandidate.id];
+        if (b) {
+          state.draggingBlock = {
+            id: state.dragCandidate.id,
+            type: b.type,
+            name: b.name,
+            origPos: b.pos
+          };
+          delete circuit.blocks[state.dragCandidate.id];
+          renderContent(contentCtx, circuit, 0);
+        }
+        state.dragCandidate = null;
+      }
       overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
-      overlayCtx.save();
-      overlayCtx.strokeStyle = 'rgba(17,17,17,0.4)';
-      overlayCtx.lineWidth = 2;
-      overlayCtx.setLineDash([8, 8]);
-      overlayCtx.beginPath();
-      overlayCtx.moveTo(state.wireTrace[0].c * CELL + CELL / 2, state.wireTrace[0].r * CELL + CELL / 2);
-      state.wireTrace.forEach(p => {
-        overlayCtx.lineTo(p.c * CELL + CELL / 2, p.r * CELL + CELL / 2);
-      });
-      overlayCtx.stroke();
-      overlayCtx.restore();
+      if (state.draggingBlock) {
+        overlayCtx.save();
+        overlayCtx.globalAlpha = 0.5;
+        drawBlock(overlayCtx, { type: state.draggingBlock.type, name: state.draggingBlock.name, pos: cell });
+        overlayCtx.restore();
+      }
     }
   });
 
-  return { state, circuit };
+  document.addEventListener('mouseup', e => {
+    if (state.draggingBlock && e.target !== overlayCanvas) {
+      if (state.draggingBlock.origPos) {
+        const { id, type, name, origPos } = state.draggingBlock;
+        circuit.blocks[id] = newBlock({ id, type, name, pos: origPos });
+        renderContent(contentCtx, circuit, 0);
+      }
+      state.draggingBlock = null;
+      overlayCtx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
+    }
+    state.dragCandidate = null;
+  });
+
+  function startBlockDrag(type, name) {
+    state.draggingBlock = { type, name };
+  }
+
+  return { state, circuit, startBlockDrag };
 }


### PR DESCRIPTION
## Summary
- Implement canvas-based block dragging with overlay preview and placement
- Expose controller references and drag start function for block panel integration
- Hook block panel icons to new controller drag logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2fe47c0bc83329932ad5ef1a3cbf0