### PR TITLE
fix canvas grid drag & wire handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,7 +490,10 @@
         overlayCanvas: document.getElementById('overlayCanvas')
       }, circuit, {
         wireStatusInfo: document.getElementById('wireStatusInfo'),
-        wireDeleteInfo: document.getElementById('wireDeleteInfo')
+        wireDeleteInfo: document.getElementById('wireDeleteInfo'),
+        trash: document.querySelector('#leftPanel .trash-area'),
+        usedBlocksEl: document.getElementById('usedBlocks'),
+        usedWiresEl: document.getElementById('usedWires')
       });
 
       const problemCircuit = makeCircuit();
@@ -500,7 +503,10 @@
         overlayCanvas: document.getElementById('problemOverlayCanvas')
       }, problemCircuit, {
         wireStatusInfo: document.getElementById('problemWireStatusInfo'),
-        wireDeleteInfo: document.getElementById('problemWireDeleteInfo')
+        wireDeleteInfo: document.getElementById('problemWireDeleteInfo'),
+        trash: document.querySelector('#problemLeftPanel .trash-area'),
+        usedBlocksEl: document.getElementById('problemUsedBlocks'),
+        usedWiresEl: document.getElementById('problemUsedWires')
       });
     </script>
 


### PR DESCRIPTION
## Summary
- clamp mouse-to-cell conversion to grid bounds
- validate wire traces, support trash dropping, and track usage counts
- hide block preview outside canvas and expose usage counters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a301e792688332b44e830c4f7fe2f0