### PR TITLE
Unify palette and grid into single canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,11 +161,8 @@
 
     <div id="problem-screen" class="screen" style="display:none; padding:0;">
       <div style="display:flex; gap:1rem; align-items:flex-start; justify-content:flex-start; width:fit-content;margin:auto;">
-        <div id="problemLeftPanel" style="display:flex; flex-direction:column; align-items:center;margin:auto;">
-          <div id="problemBlockPanel"></div>
-          <div id="trash" class="trash-area" style="margin-top: 20px;">🗑️ Drag here to delete</div>
-        </div>
-        <div id="problemGridContainer" style="position:relative;margin:auto;">
+        <div id="problemBlockPanel" style="display:none;"></div>
+        <div id="problemCanvasContainer" style="position:relative;margin:auto;">
           <canvas id="problemBgCanvas"></canvas>
           <canvas id="problemContentCanvas"></canvas>
           <canvas id="problemOverlayCanvas"></canvas>
@@ -301,15 +298,9 @@
         <!-- 전체 게임 영역: 좌측 메뉴 + 중앙 그리드 + 우측 안내 -->
         <div id="gameLayout">
 
-        <!-- 블록 패널 -->
-        <div id="leftPanel">
-          <div id="blockPanel" style="margin: 0; width: auto; flex-direction: row;"></div>
-          <div id="trash" class="trash-area" style="margin-top: 20px;">🗑️ Drag here to delete</div>
-        </div>
-
-        <!-- 회로 그리드 -->
-        <div id="gridContainer" style="position: relative;">
-          <canvas id="bgCanvas" style="position: relative;"></canvas>
+        <div id="blockPanel" style="display:none;"></div>
+        <div id="canvasContainer" style="position: relative;">
+          <canvas id="bgCanvas"></canvas>
           <canvas id="contentCanvas"></canvas>
           <canvas id="overlayCanvas"></canvas>
         </div>
@@ -491,9 +482,11 @@
       }, circuit, {
         wireStatusInfo: document.getElementById('wireStatusInfo'),
         wireDeleteInfo: document.getElementById('wireDeleteInfo'),
-        trash: document.querySelector('#leftPanel .trash-area'),
         usedBlocksEl: document.getElementById('usedBlocks'),
         usedWiresEl: document.getElementById('usedWires')
+      }, {
+        palette: ['INPUT','OUTPUT','AND','OR','NOT','JUNCTION'],
+        panelWidth: 120
       });
 
       const problemCircuit = makeCircuit();
@@ -504,9 +497,11 @@
       }, problemCircuit, {
         wireStatusInfo: document.getElementById('problemWireStatusInfo'),
         wireDeleteInfo: document.getElementById('problemWireDeleteInfo'),
-        trash: document.querySelector('#problemLeftPanel .trash-area'),
         usedBlocksEl: document.getElementById('problemUsedBlocks'),
         usedWiresEl: document.getElementById('problemUsedWires')
+      }, {
+        palette: ['INPUT','OUTPUT','AND','OR','NOT','JUNCTION'],
+        panelWidth: 120
       });
     </script>
 

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -13,19 +13,19 @@ export function setupCanvas(canvas, width, height) {
 }
 
 // Draw grid lines snapped to half-pixels for crisp rendering
-export function drawGrid(ctx, rows, cols) {
+export function drawGrid(ctx, rows, cols, offsetX = 0) {
   ctx.save();
   ctx.strokeStyle = '#ccc';
   ctx.lineWidth = 1;
   for (let r = 0; r <= rows; r++) {
     const y = r * CELL + 0.5;
     ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(cols * CELL, y);
+    ctx.moveTo(offsetX, y);
+    ctx.lineTo(offsetX + cols * CELL, y);
     ctx.stroke();
   }
   for (let c = 0; c <= cols; c++) {
-    const x = c * CELL + 0.5;
+    const x = offsetX + c * CELL + 0.5;
     ctx.beginPath();
     ctx.moveTo(x, 0);
     ctx.lineTo(x, rows * CELL);
@@ -35,9 +35,9 @@ export function drawGrid(ctx, rows, cols) {
 }
 
 // Blocks are drawn as rounded rectangles with text labels
-export function drawBlock(ctx, block) {
+export function drawBlock(ctx, block, offsetX = 0) {
   const { r, c } = block.pos;
-  const x = c * CELL;
+  const x = offsetX + c * CELL;
   const y = r * CELL;
   ctx.save();
   ctx.fillStyle = '#b3e5fc'; // light blue
@@ -56,7 +56,7 @@ export function drawBlock(ctx, block) {
 }
 
 // Draw a wire path with flowing dashed line
-export function drawWire(ctx, wire, phase = 0) {
+export function drawWire(ctx, wire, phase = 0, offsetX = 0) {
   if (!wire.path || wire.path.length < 2) return;
   ctx.save();
   ctx.strokeStyle = '#111';
@@ -65,18 +65,55 @@ export function drawWire(ctx, wire, phase = 0) {
   ctx.lineDashOffset = (-phase) % 52;
   ctx.beginPath();
   const start = wire.path[0];
-  ctx.moveTo(start.c * CELL + CELL / 2, start.r * CELL + CELL / 2);
+  ctx.moveTo(offsetX + start.c * CELL + CELL / 2, start.r * CELL + CELL / 2);
   for (let i = 1; i < wire.path.length; i++) {
     const p = wire.path[i];
-    ctx.lineTo(p.c * CELL + CELL / 2, p.r * CELL + CELL / 2);
+    ctx.lineTo(offsetX + p.c * CELL + CELL / 2, p.r * CELL + CELL / 2);
   }
   ctx.stroke();
   ctx.restore();
 }
 
 // Render the circuit: wires then blocks to keep z-order
-export function renderContent(ctx, circuit, phase = 0) {
-  ctx.clearRect(0, 0, circuit.cols * CELL, circuit.rows * CELL);
-  Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase));
-  Object.values(circuit.blocks).forEach(b => drawBlock(ctx, b));
+export function renderContent(ctx, circuit, phase = 0, offsetX = 0) {
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase, offsetX));
+  Object.values(circuit.blocks).forEach(b => drawBlock(ctx, b, offsetX));
+}
+
+// Draw palette and trash area on the left panel
+export function drawPanel(ctx, items, panelWidth, canvasHeight, trashRect) {
+  ctx.clearRect(0, 0, panelWidth, canvasHeight);
+  items.forEach(item => {
+    ctx.save();
+    ctx.fillStyle = '#eee';
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.rect(item.x, item.y, item.w, item.h);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = '#000';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(item.label || item.type, item.x + item.w / 2, item.y + item.h / 2);
+    ctx.restore();
+  });
+  if (trashRect) {
+    ctx.save();
+    ctx.fillStyle = '#ffe5e5';
+    ctx.strokeStyle = '#aa0000';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.rect(trashRect.x, trashRect.y, trashRect.w, trashRect.h);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = '#aa0000';
+    ctx.font = '14px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('🗑', trashRect.x + trashRect.w / 2, trashRect.y + trashRect.h / 2);
+    ctx.restore();
+  }
 }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -304,13 +304,16 @@ html, body {
     grid-template-rows: repeat(var(--grid-rows, 6), 50px);
     touch-action: auto;
   } */
-  #gridContainer {
+  #gridContainer,
+  #canvasContainer,
+  #problemCanvasContainer {
     flex-shrink: 0;
     display: flex;
     justify-content: center;
     align-items: center;
     /* 메뉴바 높이에 맞춰 조정 */
     box-sizing: border-box;
+    position: relative;
   }
 
 #gameArea {
@@ -1018,7 +1021,9 @@ html, body {
   } */
 
   #gridContainer canvas,
-  #problemGridContainer canvas {
+  #problemGridContainer canvas,
+  #canvasContainer canvas,
+  #problemCanvasContainer canvas {
     position: absolute;
     top: 0;
     left: 0;
@@ -2125,7 +2130,9 @@ html, body {
     padding-bottom: 0;
   }
 
-  #gridContainer {
+  #gridContainer,
+  #canvasContainer,
+  #problemCanvasContainer {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Merge block panel and grid area into a single canvas container for both play and problem screens
- Render palette and trash directly on canvas with new rendering utilities
- Rewrite controller to handle canvas-based drag, drop, and trash deletion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a30af6d8dc8332802124bcffe17835