### PR TITLE
Fix wire preview when moving without drag in canvas grid

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -222,7 +222,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   overlayCanvas.addEventListener('mousemove', e => {
     const { offsetX, offsetY } = e;
-    if (state.mode === 'wireDrawing') {
+    if (state.mode === 'wireDrawing' && state.wireTrace.length > 0 && e.buttons === 1) {
       if (offsetX < panelWidth || offsetX >= canvasWidth || offsetY < 0 || offsetY >= circuit.rows * CELL) return;
       const cell = pxToCell(offsetX, offsetY, circuit, panelWidth);
       const last = state.wireTrace[state.wireTrace.length - 1];


### PR DESCRIPTION
## Summary
- Show wire preview only while drawing with the mouse pressed
- Prevent preview from appearing when Shift is held and the mouse moves without dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3114fa748833285817caf55aba027