### PR TITLE
refactor: canvas-driven palette and grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,6 @@
 
     <div id="problem-screen" class="screen" style="display:none; padding:0;">
       <div style="display:flex; gap:1rem; align-items:flex-start; justify-content:flex-start; width:fit-content;margin:auto;">
-        <div id="problemBlockPanel" style="display:none;"></div>
         <div id="problemCanvasContainer" style="position:relative;margin:auto;">
           <canvas id="problemBgCanvas"></canvas>
           <canvas id="problemContentCanvas"></canvas>
@@ -475,6 +474,10 @@
       import { makeCircuit } from './src/canvas/model.js';
       import { createController } from './src/canvas/controller.js';
       const circuit = makeCircuit();
+      const demoGroups = [
+        { label: 'IN/OUT', items: [{ type: 'INPUT', label: 'IN' }, { type: 'OUTPUT', label: 'OUT' }] },
+        { label: 'GATE', items: [{ type: 'AND' }, { type: 'OR' }, { type: 'NOT' }, { type: 'JUNCTION', label: 'JUNC' }] }
+      ];
       createController({
         bgCanvas: document.getElementById('bgCanvas'),
         contentCanvas: document.getElementById('contentCanvas'),
@@ -485,7 +488,7 @@
         usedBlocksEl: document.getElementById('usedBlocks'),
         usedWiresEl: document.getElementById('usedWires')
       }, {
-        palette: ['INPUT','OUTPUT','AND','OR','NOT','JUNCTION'],
+        paletteGroups: demoGroups,
         panelWidth: 120
       });
 
@@ -500,7 +503,7 @@
         usedBlocksEl: document.getElementById('problemUsedBlocks'),
         usedWiresEl: document.getElementById('problemUsedWires')
       }, {
-        palette: ['INPUT','OUTPUT','AND','OR','NOT','JUNCTION'],
+        paletteGroups: demoGroups,
         panelWidth: 120
       });
     </script>

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -86,18 +86,27 @@ export function drawPanel(ctx, items, panelWidth, canvasHeight, trashRect) {
   ctx.clearRect(0, 0, panelWidth, canvasHeight);
   items.forEach(item => {
     ctx.save();
-    ctx.fillStyle = '#eee';
-    ctx.strokeStyle = '#333';
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.rect(item.x, item.y, item.w, item.h);
-    ctx.fill();
-    ctx.stroke();
-    ctx.fillStyle = '#000';
-    ctx.font = '12px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(item.label || item.type, item.x + item.w / 2, item.y + item.h / 2);
+    if (item.kind === 'label') {
+      // group title
+      ctx.fillStyle = '#333';
+      ctx.font = '12px sans-serif';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      ctx.fillText(item.label, item.x, item.y);
+    } else {
+      ctx.fillStyle = '#eee';
+      ctx.strokeStyle = '#333';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.rect(item.x, item.y, item.w, item.h);
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = '#000';
+      ctx.font = '12px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(item.label || item.type, item.x + item.w / 2, item.y + item.h / 2);
+    }
     ctx.restore();
   });
   if (trashRect) {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1422,25 +1422,7 @@ html, body {
   touch-action: auto;
 }
 
-/* 공통: 게임 모드 · 모듈 모드 블록 패널 모두에 적용 */
-  #blockPanel,
-  #problemBlockPanel {
-  display: flex;               /* 세로 정렬을 위해 flex 사용 */
-  flex-direction: row;      /* 수직 방향으로 블록 나열 */
-  align-items: stretch;        /* 폭을 부모에 맞춤 */
-  gap: 1rem;                   /* 블록 간격: 원하시는 px/em 단위로 조정 가능 */
-  padding: 0.5rem 0;           /* 상하 여백(옵션) */
-  max-height: 80vh;            /* 최대 높이 제한 */
-  overflow: visible;           /* tooltip이 밖으로 보이도록 */
-}
-
-/* 블록 아이콘 크기·정렬 (필요시 조정) */
-  #blockPanel .blockIcon,
-  #problemBlockPanel .blockIcon {
-  width: 50px;
-  height: 30px;
-  text-align: center;          /* 텍스트 중앙 정렬 */
-}
+/* block panels removed in canvas-based version */
 
 /* ── 화면(.screen) 공통 ── */
 .screen {


### PR DESCRIPTION
## Summary
- render block palette and grid entirely on canvas with grouped labels
- remove DOM-based block panel usages and support palette groups in controller
- update initialization to pass palette groups and draw via canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3138c99a8833280cd5abe86dce21f