### PR TITLE
Load level config from levels file and restore panel items

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -990,7 +990,8 @@ document.getElementById("backToLevelsBtn").onclick = () => {
 
 
 
-function startLevel(level) {
+async function startLevel(level) {
+  await stageDataPromise;
   resetCaptureCanvas();
   wireTrace = [];
   wires = [];

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -271,21 +271,43 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       }
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     } else if (state.draggingBlock) {
-      if (offsetX >= panelTotalWidth && offsetX < canvasWidth && offsetY >= 0 && offsetY < circuit.rows * CELL) {
+      if (
+        offsetX >= panelTotalWidth &&
+        offsetX < canvasWidth &&
+        offsetY >= 0 &&
+        offsetY < circuit.rows * CELL
+      ) {
         const cell = pxToCell(offsetX, offsetY, circuit, panelTotalWidth);
         const id = state.draggingBlock.id || ('b' + Date.now());
         circuit.blocks[id] = newBlock({
           id,
           type: state.draggingBlock.type,
           name: state.draggingBlock.name,
-          pos: cell
+          pos: cell,
         });
-        if (state.draggingBlock.type === 'INPUT' || state.draggingBlock.type === 'OUTPUT') {
-          hidePaletteItem(state.draggingBlock.type, state.draggingBlock.name);
+        if (
+          state.draggingBlock.type === 'INPUT' ||
+          state.draggingBlock.type === 'OUTPUT'
+        ) {
+          hidePaletteItem(
+            state.draggingBlock.type,
+            state.draggingBlock.name
+          );
         }
-        renderContent(contentCtx, circuit, 0, panelTotalWidth);
-        updateUsageCounts();
+      } else {
+        if (
+          state.draggingBlock.id &&
+          (state.draggingBlock.type === 'INPUT' ||
+            state.draggingBlock.type === 'OUTPUT')
+        ) {
+          showPaletteItem(
+            state.draggingBlock.type,
+            state.draggingBlock.name
+          );
+        }
       }
+      renderContent(contentCtx, circuit, 0, panelTotalWidth);
+      updateUsageCounts();
       state.draggingBlock = null;
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     } else if (state.dragCandidate) {


### PR DESCRIPTION
## Summary
- Wait for level metadata before starting a stage and configure canvas grid and palette from levels.json
- Ensure IN/OUT block icons reappear when blocks are dragged back to the panel for deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a95951ccf8833293382d0d6170a74d