### PR TITLE
Ensure single canvas block panel

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2073,13 +2073,22 @@ function setupGrid(containerId, rows, cols, paletteGroups) {
     import('./src/canvas/controller.js').then(c => {
       const { createController } = c;
       const circuit = makeCircuit(rows, cols);
-      const controller = createController({ bgCanvas, contentCanvas, overlayCanvas }, circuit, {
-        wireStatusInfo: document.getElementById(prefix ? `${prefix}WireStatusInfo` : 'wireStatusInfo'),
-        wireDeleteInfo: document.getElementById(prefix ? `${prefix}WireDeleteInfo` : 'wireDeleteInfo')
-      }, {
-        paletteGroups,
-        panelWidth: 120
-      });
+      const controller = createController(
+        { bgCanvas, contentCanvas, overlayCanvas },
+        circuit,
+        {
+          wireStatusInfo: document.getElementById(
+            prefix ? `${prefix}WireStatusInfo` : 'wireStatusInfo'
+          ),
+          wireDeleteInfo: document.getElementById(
+            prefix ? `${prefix}WireDeleteInfo` : 'wireDeleteInfo'
+          )
+        },
+        {
+          paletteGroups,
+          panelWidth: 180
+        }
+      );
       if (prefix) {
         window.problemCircuit = circuit;
         window.problemController = controller;

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -10,7 +10,7 @@ export function pxToCell(x, y, circuit, offsetX = 0) {
 }
 
 export function createController(canvasSet, circuit, ui = {}, options = {}) {
-  const { palette = [], paletteGroups = [], panelWidth = 120 } = options;
+  const { palette = [], paletteGroups = [], panelWidth = 180 } = options;
   const gap = 10;
   const PALETTE_ITEM_H = 50;
   const LABEL_H = 20;


### PR DESCRIPTION
## Summary
- default block panel width to 180px so only widest panel renders
- use same width when creating controller during grid setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9617914d08332a549ca009b88c716