### PR TITLE
Use canvas resizing instead of zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,6 +506,9 @@
         paletteGroups: demoGroups,
         panelWidth: 180
       });
+
+      adjustGridZoom();
+      adjustGridZoom('problemCanvasContainer');
     </script>
 
     <div id="levelIntroModal" style="display:none" class="modal">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1797,8 +1797,6 @@ function adjustGridZoom(containerId = 'canvasContainer') {
   if (!gridContainer) return;
 
   const margin = 20;
-  gridContainer.style.zoom = 1;
-
   let availableWidth = window.innerWidth - margin * 2;
   let availableHeight = window.innerHeight - margin * 2;
 
@@ -1815,16 +1813,23 @@ function adjustGridZoom(containerId = 'canvasContainer') {
     }
   }
 
-  const gcRect = gridContainer.getBoundingClientRect();
+  const firstCanvas = gridContainer.querySelector('canvas');
+  if (!firstCanvas) return;
+  const dpr = window.devicePixelRatio || 1;
+  const baseWidth = firstCanvas.width / dpr;
+  const baseHeight = firstCanvas.height / dpr;
+
   const scale = Math.min(
-    availableWidth / gcRect.width,
-    availableHeight / gcRect.height,
+    availableWidth / baseWidth,
+    availableHeight / baseHeight,
     1
   );
 
-  if (scale < 1) {
-    gridContainer.style.zoom = scale;
-  }
+  gridContainer.querySelectorAll('canvas').forEach(c => {
+    c.style.width = baseWidth * scale + 'px';
+    c.style.height = baseHeight * scale + 'px';
+    c.dataset.scale = scale;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace zoom-based grid scaling with canvas resizing and per-canvas scale metadata
- Adjust controller event handlers to account for resized canvas coordinates
- Trigger canvas resize after controller setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a979d095cc83329aa95581f458aec3