### PR TITLE
Remove trash area and align block palette with schematic

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -131,7 +131,6 @@ function enableTouchDrag() {
     // 드롭 가능 요소만 허용
     if (dropTarget) {
       const cell  = dropTarget.closest('.cell');
-      const trash = dropTarget.closest('.trash-area');
       if (cell) {
         const ctrlActive = e.ctrlKey || statusToggle.classList.contains('active');
         if (!(ctrlActive && (!cell.dataset.type || cell.dataset.type === 'WIRE'))) {
@@ -139,8 +138,6 @@ function enableTouchDrag() {
         } else {
           dropTarget = null;
         }
-      } else if (trash) {
-        dropTarget = trash;
       } else {
         dropTarget = null;
       }

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -57,14 +57,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     });
     canvasHeight = Math.max(
       canvasHeight,
-      Math.max(...colHeights) + PALETTE_ITEM_H
+      Math.max(...colHeights) + 10
     );
-    var trashRect = {
-      x: gap,
-      y: canvasHeight - PALETTE_ITEM_H,
-      w: panelTotalWidth - 2 * gap,
-      h: PALETTE_ITEM_H - 20,
-    };
   } else {
     panelTotalWidth = panelWidth;
     paletteItems = palette.map((type, i) => ({
@@ -76,8 +70,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       h: PALETTE_ITEM_H - 20,
       hidden: false,
     }));
-    canvasHeight = Math.max(canvasHeight, palette.length * PALETTE_ITEM_H + 60);
-    var trashRect = { x: gap, y: canvasHeight - PALETTE_ITEM_H, w: panelWidth - 2 * gap, h: PALETTE_ITEM_H - 20 };
+    canvasHeight = Math.max(canvasHeight, palette.length * PALETTE_ITEM_H + 20);
   }
 
   const canvasWidth = panelTotalWidth + gridWidth;
@@ -96,13 +89,13 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   };
 
   drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth);
-  drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, trashRect, groupRects);
+  drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects);
   startEngine(contentCtx, circuit, (ctx, circ, phase) =>
     renderContent(ctx, circ, phase, panelTotalWidth, state.hoverBlockId)
   );
 
   function redrawPanel() {
-    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, trashRect, groupRects);
+    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects);
   }
 
   function hidePaletteItem(type, label) {
@@ -444,12 +437,12 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       const point = e.changedTouches?.[0] || e;
       const ox = (point.clientX - rect.left) / scale;
       const oy = (point.clientY - rect.top) / scale;
-      const overTrash =
-        ox >= trashRect.x &&
-        ox <= trashRect.x + trashRect.w &&
-        oy >= trashRect.y &&
-        oy <= trashRect.y + trashRect.h;
-      if (overTrash && state.draggingBlock.id) {
+      const outsideGrid =
+        ox < panelTotalWidth ||
+        ox >= canvasWidth ||
+        oy < 0 ||
+        oy >= gridHeight;
+      if (outsideGrid && state.draggingBlock.id) {
         if (
           state.draggingBlock.type === 'INPUT' ||
           state.draggingBlock.type === 'OUTPUT'
@@ -466,13 +459,6 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
         });
         renderContent(contentCtx, circuit, 0, panelTotalWidth);
         updateUsageCounts();
-      } else if (ox < panelTotalWidth || ox >= canvasWidth || oy < 0 || oy >= gridHeight) {
-        if (state.draggingBlock.origPos) {
-          const { id, type, name, origPos } = state.draggingBlock;
-          circuit.blocks[id] = newBlock({ id, type, name, pos: origPos });
-          renderContent(contentCtx, circuit, 0, panelTotalWidth);
-          updateUsageCounts();
-        }
       }
       state.draggingBlock = null;
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -126,8 +126,8 @@ export function renderContent(ctx, circuit, phase = 0, offsetX = 0, hoverId = nu
   );
 }
 
-// Draw palette and trash area on the left panel
-export function drawPanel(ctx, items, panelWidth, canvasHeight, trashRect, groups = []) {
+// Draw palette on the left panel
+export function drawPanel(ctx, items, panelWidth, canvasHeight, groups = []) {
   ctx.clearRect(0, 0, panelWidth, canvasHeight);
   groups.forEach(g => {
     ctx.save();
@@ -148,36 +148,23 @@ export function drawPanel(ctx, items, panelWidth, canvasHeight, trashRect, group
   items.forEach(item => {
     if (item.hidden) return;
     ctx.save();
-    // palette item style matches block appearance
-    ctx.fillStyle = '#dcd8ff';
-    ctx.strokeStyle = '#a4a1de';
-    ctx.lineWidth = 2;
+    // mimic block appearance in palette items
+    ctx.shadowColor = 'rgba(0,0,0,0.25)';
+    ctx.shadowBlur = 4;
+    ctx.shadowOffsetX = 2;
+    ctx.shadowOffsetY = 2;
+    const grad = ctx.createLinearGradient(item.x, item.y, item.x, item.y + item.h);
+    grad.addColorStop(0, '#f0f0ff');
+    grad.addColorStop(1, '#d0d0ff');
+    ctx.fillStyle = grad;
     roundRect(ctx, item.x, item.y, item.w, item.h, 6);
     ctx.fill();
-    ctx.stroke();
-    ctx.fillStyle = '#3f3d96';
-    ctx.font = '14px "Noto Sans KR", sans-serif';
+    ctx.shadowColor = 'transparent';
+    ctx.fillStyle = '#000';
+    ctx.font = 'bold 14px "Noto Sans KR", sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(item.label || item.type, item.x + item.w / 2, item.y + item.h / 2);
     ctx.restore();
   });
-  if (trashRect) {
-    ctx.save();
-    ctx.fillStyle = '#fff2f2';
-    ctx.strokeStyle = '#c44';
-    ctx.lineWidth = 2;
-    roundRect(ctx, trashRect.x, trashRect.y, trashRect.w, trashRect.h, 6);
-    ctx.fill();
-    ctx.setLineDash([6,4]);
-    ctx.stroke();
-    ctx.setLineDash([]);
-    ctx.fillStyle = '#c44';
-    ctx.font = '12px "Noto Sans KR", sans-serif';
-    ctx.textAlign = 'left';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('🗑', trashRect.x + 8, trashRect.y + trashRect.h / 2);
-    ctx.fillText('Drag here to delete', trashRect.x + 28, trashRect.y + trashRect.h / 2);
-    ctx.restore();
-  }
 }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -449,20 +449,6 @@ html, body {
     cursor: grab;
   }
 
-  /* ── 휴지통 ── */
-  #trash {
-    width: 200px;
-    height: 50px;
-    margin: 20px auto;
-    border: 2px dashed #F87171;
-    background-color: #FEE2E2;
-    color: #7F1D1D;
-    font-weight: bold;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
   /* 이전: div 기반 wire/flow 및 블록 상태 스타일은 Canvas 전환으로 제거되었습니다 */
 
   #gradingTable {


### PR DESCRIPTION
## Summary
- Drop outside circuit deletes blocks without showing a trash zone
- Palette blocks now mimic the circuit block styling for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a987c412ac8332b1362ebfd6dcd978