### PR TITLE
Disallow wiring adjacent blocks

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -135,7 +135,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function isValidWire(trace) {
-    if (trace.length < 2) return false;
+    // Require at least one intermediate cell so adjacent blocks cannot be linked
+    if (trace.length < 3) return false;
     const startBlock = blockAt(trace[0]);
     const endBlock = blockAt(trace[trace.length - 1]);
     if (!startBlock || !endBlock || startBlock.id === endBlock.id) return false;


### PR DESCRIPTION
## Summary
- prevent connecting adjacent blocks by requiring wires to include at least one intermediate cell

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c5c1fb2c833286e1bc7b1a898861