### PR TITLE
Refactor circuit evaluation to use canvas model

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1,6 +1,6 @@
 import { CELL, GAP, coord, newWire, newBlock } from './model.js';
 import { drawGrid, renderContent, setupCanvas, drawBlock, drawPanel } from './renderer.js';
-import { evaluate, startEngine } from './engine.js';
+import { evaluateCircuit, startEngine } from './engine.js';
 
 // Convert pixel coordinates to cell indices (clamped to grid)
 export function pxToCell(x, y, circuit, offsetX = 0) {
@@ -357,7 +357,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       const blk = circuit.blocks[state.dragCandidate.id];
       if (blk && blk.type === 'INPUT') {
         blk.value = !blk.value;
-        evaluate(circuit);
+        evaluateCircuit(circuit);
       }
       state.dragCandidate = null;
     }


### PR DESCRIPTION
## Summary
- Replace DOM-based evaluation with canvas `circuit` data structure
- Add helper functions for block computation and wire traversal
- Update controller to invoke new evaluation routine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa691a21308332be80edc846540ef6