### PR TITLE
Fix missing usage counter elements in controller setup

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2011,6 +2011,12 @@ function setupGrid(containerId, rows, cols, paletteGroups) {
           ),
           wireDeleteInfo: document.getElementById(
             prefix ? `${prefix}WireDeleteInfo` : 'wireDeleteInfo'
+          ),
+          usedBlocksEl: document.getElementById(
+            prefix ? `${prefix}UsedBlocks` : 'usedBlocks'
+          ),
+          usedWiresEl: document.getElementById(
+            prefix ? `${prefix}UsedWires` : 'usedWires'
           )
         },
         {


### PR DESCRIPTION
## Summary
- Pass usedBlocks and usedWires DOM elements to the canvas controller

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8c43a2c8833295784fb611cf6f30