### PR TITLE
Fix double toggle for Ctrl/Shift buttons

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -243,7 +243,9 @@ function setupKeyToggles() {
         setTimeout(() => btn.classList.remove('active'), 150);
       });
     } else {
-      btn.addEventListener('click', () => {
+      btn.addEventListener('click', e => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
         const active = !btn.classList.contains('active');
         bindings
           .filter(([, k]) => k === key)


### PR DESCRIPTION
## Summary
- Prevent Ctrl/Shift toggle buttons from firing multiple handlers by stopping event propagation and default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa901df92883329f3f1cee1c901fcc