### PR TITLE
Count wire cells instead of wire objects

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -121,9 +121,12 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   function updateUsageCounts() {
     const blockCount = Object.keys(circuit.blocks).length;
-    const wireCount = Object.keys(circuit.wires).length;
+    const wireCells = new Set();
+    Object.values(circuit.wires).forEach(w => {
+      w.path.slice(1, -1).forEach(p => wireCells.add(`${p.r},${p.c}`));
+    });
     if (usedBlocksEl) usedBlocksEl.textContent = blockCount;
-    if (usedWiresEl) usedWiresEl.textContent = wireCount;
+    if (usedWiresEl) usedWiresEl.textContent = wireCells.size;
   }
 
   function blockAt(cell) {


### PR DESCRIPTION
## Summary
- count wires by total cells occupied rather than wire objects in canvas controller

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa93a64e508332975a90305eea0a57