### PR TITLE
feat: evaluate circuit from model and highlight active blocks

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -376,19 +376,28 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       }
       state.draggingBlock = null;
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
-    } else if (state.dragCandidate) {
-      const blk = circuit.blocks[state.dragCandidate.id];
-      if (blk && blk.type === 'INPUT') {
-        blk.value = !blk.value;
-        evaluateCircuit(circuit);
-      }
-      state.dragCandidate = null;
     }
+    // Clear any pending drag candidate after pointer release
+    state.dragCandidate = null;
     state.wireTrace = [];
   }
 
   overlayCanvas.addEventListener('mouseup', handlePointerUp);
   overlayCanvas.addEventListener('touchend', handlePointerUp);
+
+  // Toggle INPUT block values on simple clicks
+  function handleCanvasClick(e) {
+    if (state.mode !== 'idle') return;
+    const { x, y } = getPointerPos(e);
+    if (x < panelTotalWidth || x >= canvasWidth || y < 0 || y >= gridHeight) return;
+    const cell = pxToCell(x, y, circuit, panelTotalWidth);
+    const blk = blockAt(cell);
+    if (blk && blk.type === 'INPUT') {
+      blk.value = !blk.value;
+      evaluateCircuit(circuit);
+    }
+  }
+  overlayCanvas.addEventListener('click', handleCanvasClick);
 
   function handlePointerMove(e) {
     const { x, y } = getPointerPos(e);

--- a/src/canvas/engine.js
+++ b/src/canvas/engine.js
@@ -91,6 +91,10 @@ export function setWireFlows(circuit) {
 export function startEngine(ctx, circuit, renderer) {
   let phase = 0;
   function tick() {
+    // Recompute circuit values every frame based solely on the
+    // in-memory circuit model so block states stay in sync with
+    // current connections and input values.
+    evaluateCircuit(circuit);
     phase = (phase + 2) % 40;
     renderer(ctx, circuit, phase);
     requestAnimationFrame(tick);

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -75,8 +75,17 @@ export function drawBlock(ctx, block, offsetX = 0, hovered = false) {
   roundRect(ctx, x, y, CELL, CELL, 6);
   ctx.fill();
 
-  // Text
+  // Highlight active INPUT/OUTPUT/JUNCTION blocks with a dashed border
   ctx.shadowColor = 'transparent';
+  if (block.value && ['INPUT', 'OUTPUT', 'JUNCTION'].includes(block.type)) {
+    ctx.strokeStyle = '#000';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([4, 4]);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  // Text
   ctx.fillStyle = '#000';
   ctx.font = 'bold 16px "Noto Sans KR", sans-serif';
   ctx.textAlign = 'center';


### PR DESCRIPTION
## Summary
- recompute circuit logic from the in-memory `circuit` model each frame
- draw black dashed borders when INPUT/OUTPUT/JUNCTION blocks are active
- allow clicking INPUT blocks to toggle between 0 and 1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9cb00f04833289515076a5675c86