### PR TITLE
Slow canvas wire animation

### DIFF
--- a/src/canvas/engine.js
+++ b/src/canvas/engine.js
@@ -95,7 +95,8 @@ export function startEngine(ctx, circuit, renderer) {
     // in-memory circuit model so block states stay in sync with
     // current connections and input values.
     evaluateCircuit(circuit);
-    phase = (phase + 2) % 40;
+    // Slow wire flow animation by updating phase more gradually
+    phase = (phase + 1) % 40;
     renderer(ctx, circuit, phase);
     requestAnimationFrame(tick);
   }


### PR DESCRIPTION
## Summary
- Slow down canvas wire dash animation by incrementing phase more gradually

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabe2c19a08332a4f09b88cdbbe20c