### PR TITLE
Capture GIF directly from main canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,8 +431,6 @@
         </div>
       </div>
     </div>
-    <!-- 캡처용 캔버스 (화면에 표시되지 않음) -->
-    <canvas id="captureCanvas" style="display:none;"></canvas>
     <div id="clearedModal" class="modal" style="display: none;">
       <div class="modal-content">
         <h2 id="clearedTitle">스테이지 <span id="clearedStageNumber"></span> 클리어!</h2>


### PR DESCRIPTION
## Summary
- Remove hidden capture canvas element
- Capture GIF frames from the main content canvas and restore original drawing afterward
- Allow drawCaptureFrame to render at arbitrary scales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aad2e4076c8332a24e01dae344b9da