### PR TITLE
Hide used in/out blocks when loading circuits

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -3423,6 +3423,8 @@ function loadCircuit(key) {
   circuit.blocks = data.circuit.blocks || {};
   circuit.wires = data.circuit.wires || {};
   markCircuitModified();
+  const controller = window.playController || window.problemController;
+  controller?.syncPaletteWithCircuit?.();
 }
 
 function highlightOutputErrors() {

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -131,6 +131,19 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     if (usedWiresEl) usedWiresEl.textContent = wireCells.size;
   }
 
+  function syncPaletteWithCircuit() {
+    paletteItems.forEach(it => {
+      if (it.type === 'INPUT' || it.type === 'OUTPUT') {
+        const exists = Object.values(circuit.blocks).some(
+          b => b.type === it.type && b.name === it.label
+        );
+        it.hidden = exists;
+      }
+    });
+    redrawPanel();
+    updateUsageCounts();
+  }
+
   function blockAt(cell) {
     return Object.values(circuit.blocks).find(b => b.pos.r === cell.r && b.pos.c === cell.c);
   }
@@ -564,5 +577,5 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   updateUsageCounts();
-  return { state, circuit, startBlockDrag };
+  return { state, circuit, startBlockDrag, syncPaletteWithCircuit };
 }


### PR DESCRIPTION
## Summary
- sync palette with circuit to hide INPUT/OUTPUT blocks already on the board
- update loadCircuit to refresh palette after loading a saved circuit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab169d0a5c833286bb97adf7daa257