### PR TITLE
Ensure canceling reset prompt preserves circuit

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -976,17 +976,17 @@ document.addEventListener("keydown", (e) => {
     if (problemScreen.style.display !== "none" && gameScreen.style.display === "none") return;
     if (gameScreen.style.display === "none" && problemScreen.style.display === "none") return;
 
-    if (confirm(t('confirmDeleteAll'))) {
-      clearGrid();
-      if (problemScreen.style.display !== "none") {
-        setupGrid('problemCanvasContainer', GRID_ROWS, GRID_COLS, createPaletteForProblem());
-        initTestcaseTable();
-      } else if (currentCustomProblem) {
-        setupGrid('canvasContainer', GRID_ROWS, GRID_COLS, createPaletteForCustom(currentCustomProblem));
-        if (currentCustomProblem.fixIO) placeFixedIO(currentCustomProblem);
-      } else {
-        setupGrid('canvasContainer', GRID_ROWS, GRID_COLS, createPaletteForLevel(currentLevel));
-      }
+    const resetConfirmed = confirm(t('confirmDeleteAll'));
+    if (!resetConfirmed) return;
+    clearGrid();
+    if (problemScreen.style.display !== "none") {
+      setupGrid('problemCanvasContainer', GRID_ROWS, GRID_COLS, createPaletteForProblem());
+      initTestcaseTable();
+    } else if (currentCustomProblem) {
+      setupGrid('canvasContainer', GRID_ROWS, GRID_COLS, createPaletteForCustom(currentCustomProblem));
+      if (currentCustomProblem.fixIO) placeFixedIO(currentCustomProblem);
+    } else {
+      setupGrid('canvasContainer', GRID_ROWS, GRID_COLS, createPaletteForLevel(currentLevel));
     }
   }
   if (e.key === "Control") {
@@ -3846,12 +3846,12 @@ function handleProblemKeyDown(e) {
         [resetToggle, problemResetToggle].forEach(btn => btn && btn.classList.remove('active'));
         return;
       }
-    if (confirm(t('confirmDeleteAll'))) {
-      clearGrid();
-      setupGrid('problemCanvasContainer', GRID_ROWS, GRID_COLS, createPaletteForProblem());
-      initTestcaseTable();
-      markCircuitModified();
-    }
+    const resetConfirmed = confirm(t('confirmDeleteAll'));
+    if (!resetConfirmed) return;
+    clearGrid();
+    setupGrid('problemCanvasContainer', GRID_ROWS, GRID_COLS, createPaletteForProblem());
+    initTestcaseTable();
+    markCircuitModified();
   }
 }
 


### PR DESCRIPTION
## Summary
- respect confirmation result before clearing the grid when pressing **R**
- handle reset confirmation in problem editor to avoid unintended resets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab1a07716c8332975adb6a14a19fae