### PR TITLE
Ensure pendingClearedLevel set before showing saved modal

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -3775,8 +3775,6 @@ async function gradeLevelCanvas(level) {
         }
       }
     }
-    if (saveSuccess) showCircuitSavedModal();
-
     const { blockCounts, usedWires } = getCircuitStats(circuit);
     const hintsUsed = parseInt(localStorage.getItem(`hintsUsed_${level}`) || '0');
     const nickname = localStorage.getItem('username') || '익명';
@@ -3809,6 +3807,7 @@ async function gradeLevelCanvas(level) {
           pendingClearedLevel = level;
         }
       }
+      if (saveSuccess) showCircuitSavedModal();
     });
   }
 


### PR DESCRIPTION
## Summary
- Fix timing issue in canvas grading where `pendingClearedLevel` was still null when the circuit saved modal appeared.
- Display the saved modal only after ranking lookup completes and `pendingClearedLevel` is assigned.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac215383a4833283cd15f3d5273d4c