### PR TITLE
feat: support fixed io blocks in canvas

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -3039,24 +3039,7 @@ function showHint(index) {
 }
 
 function placeFixedIO(problem) {
-  if (!problem.fixIO || !problem.grid || !window.playController) return;
-  const circuit = window.playController.circuit;
-  problem.grid.forEach(state => {
-    if (state.type === 'INPUT' || state.type === 'OUTPUT') {
-      const r = Math.floor(state.index / GRID_COLS);
-      const c = state.index % GRID_COLS;
-      const id = 'fixed_' + state.name + '_' + state.index;
-      circuit.blocks[id] = {
-        id,
-        type: state.type,
-        name: state.name,
-        pos: { r, c },
-        value: state.type === 'INPUT' ? (state.value === '1') : false,
-        fixed: true
-      };
-    }
-  });
-  window.playController?.syncPaletteWithCircuit?.();
+  window.playController?.placeFixedIO?.(problem);
 }
 
 function startCustomProblem(key, problem) {

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -611,6 +611,27 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     return true;
   }
 
+  function placeFixedIO(problem) {
+    if (!problem?.fixIO || !problem.grid) return;
+    problem.grid.forEach(state => {
+      if (state.type === 'INPUT' || state.type === 'OUTPUT') {
+        const r = Math.floor(state.index / circuit.cols);
+        const c = state.index % circuit.cols;
+        const id = 'fixed_' + state.name + '_' + state.index;
+        circuit.blocks[id] = newBlock({
+          id,
+          type: state.type,
+          name: state.name,
+          pos: { r, c },
+          value: state.type === 'INPUT' ? state.value === '1' : false,
+          fixed: true,
+        });
+      }
+    });
+    syncPaletteWithCircuit();
+    renderContent(contentCtx, circuit, 0, panelTotalWidth);
+  }
+
   updateUsageCounts();
-  return { state, circuit, startBlockDrag, syncPaletteWithCircuit, moveCircuit };
+  return { state, circuit, startBlockDrag, syncPaletteWithCircuit, moveCircuit, placeFixedIO };
 }

--- a/src/canvas/model.js
+++ b/src/canvas/model.js
@@ -9,8 +9,8 @@ export function coord(r, c) {
   return { r, c };
 }
 
-export function newBlock({ id, type, name, pos }) {
-  return { id, type, name, pos, value: false };
+export function newBlock({ id, type, name, pos, value = false, fixed = false }) {
+  return { id, type, name, pos, value, fixed };
 }
 
 export function newWire({ id, path, startBlockId, endBlockId }) {


### PR DESCRIPTION
## Summary
- allow blocks to carry a fixed flag
- add controller helper to place fixed IN/OUT blocks and sync palette
- delegate script `placeFixedIO` to new controller method

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac47632a848332842dd9428d610eb7