### PR TITLE
Enable arrow key shifting for problem modes

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2191,9 +2191,9 @@ function clearWires() {
 
 
 function moveCircuit(dx, dy) {
-  const controller = currentCustomProblem ? window.problemController : window.playController;
+  const controller = window.problemController || window.playController;
   if (!controller) return;
-  if (currentCustomProblem && currentCustomProblem.fixIO) return;
+  if (controller === window.problemController && currentCustomProblem?.fixIO) return;
   const moved = controller.moveCircuit(dx, dy);
   if (moved) {
     markCircuitModified();


### PR DESCRIPTION
## Summary
- ensure arrow keys move the circuit in problem creation and custom problem solving
- use problem controller when available and respect fixed IO restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4b132fe8833299c031f769dc4157