### PR TITLE
Preserve fixed blocks during reset and add reset warning

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -776,7 +776,7 @@ function setupGrid(containerId, rows, cols, paletteGroups) {
 }
 
 function resetCell(cell) {
-  if (currentCustomProblem && currentCustomProblem.fixIO && cell.dataset.fixed === '1') return;
+  if (cell.dataset.fixed === '1') return;
   cell.className = "cell";
   cell.textContent = "";
   delete cell.dataset.type;

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -221,10 +221,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       state.mode = 'deleting';
       updateButtons();
     } else if (e.key.toLowerCase() === 'r') {
-      circuit.blocks = {};
+      if (!confirm(window.t('confirmDeleteAll'))) return;
+      const fixed = {};
+      Object.entries(circuit.blocks).forEach(([id, b]) => {
+        if (b.fixed) fixed[id] = b;
+      });
+      circuit.blocks = fixed;
       circuit.wires = {};
-      paletteItems.forEach(it => it.hidden = false);
-      redrawPanel();
+      syncPaletteWithCircuit();
       renderContent(contentCtx, circuit, 0, panelTotalWidth);
       updateUsageCounts();
     }


### PR DESCRIPTION
## Summary
- Prevent `R` key reset from clearing fixed blocks
- Ask for confirmation before resetting the circuit
- Skip fixed cells when clearing DOM grid cells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4d1fe90883328dfcc6561c0546bf