### PR TITLE
Disallow starting wires on empty cells

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -280,8 +280,10 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     } else if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
       const cell = pxToCell(x, y, circuit, panelTotalWidth);
       if (state.mode === 'wireDrawing') {
-        state.wireTrace = [coord(cell.r, cell.c)];
-        handled = true;
+        if (blockAt(cell)) {
+          state.wireTrace = [coord(cell.r, cell.c)];
+          handled = true;
+        }
       } else if (state.mode === 'deleting') {
         let deleted = false;
         const bid = Object.keys(circuit.blocks).find(id => {


### PR DESCRIPTION
## Summary
- prevent starting wires from cells that lack blocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6334fa688332b4836e1517cb45a4