### PR TITLE
feat: force Drive scope reauthorization

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -33,13 +33,13 @@ async function ensureDriveAuth() {
   if (!gapiInited) throw new Error(t('loginRequired'));
   const auth = gapi.auth2.getAuthInstance();
   let user = auth.currentUser.get();
-  if (!auth.isSignedIn.get()) {
+  if (!auth.isSignedIn.get() || !user.hasGrantedScopes(DRIVE_SCOPE)) {
+    // Force the consent screen even for users who are already signed in so that
+    // newly required scopes (e.g. Drive read/write) can be granted without
+    // requiring a separate logout/login cycle.
     await auth.signIn({ scope: DRIVE_SCOPE, prompt: 'consent' });
     user = auth.currentUser.get();
-  } else if (!user.hasGrantedScopes(DRIVE_SCOPE)) {
-    await user.grant({ scope: DRIVE_SCOPE });
   }
-  user = auth.currentUser.get();
   if (!user.hasGrantedScopes(DRIVE_SCOPE)) throw new Error(t('loginRequired'));
   return user;
 }


### PR DESCRIPTION
## Summary
- ensure Google Drive auth prompts for new permissions even for existing sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9affb5348332bee6611876f5ba0e