### PR TITLE
fix: update Google Drive auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,6 +467,7 @@
     const db = firebase.database();
   </script>
     <script src="https://apis.google.com/js/api.js" async defer></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
     <script src="lang.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/gif.js@0.2.0/dist/gif.js"></script>
     <script src="background.js"></script>


### PR DESCRIPTION
## Summary
- replace deprecated gapi.auth2-based sign-in with Google Identity Services token client
- include Google Identity script in index.html

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adb01418048332bc3b1d91be0d51a5