### PR TITLE
Reuse cached circuit data to speed up loading

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2135,8 +2135,8 @@ async function renderSavedList() {
     cap.textContent = `${label} — ${new Date(data.timestamp).toLocaleString()}`;
     item.appendChild(cap);
 
-    item.addEventListener('click', async () => {
-      await loadCircuit(key);
+    item.addEventListener('click', () => {
+      applyCircuitData(data, key);
       document.getElementById('savedModal').style.display = 'none';
     });
 
@@ -2181,6 +2181,10 @@ async function loadCircuit(key) {
   if (!blob) return alert(t('loadFailedNoData'));
   const text = await blob.text();
   const data = JSON.parse(text);
+  applyCircuitData(data, key);
+}
+
+function applyCircuitData(data, key) {
   if (data.version !== CURRENT_CIRCUIT_VERSION || !data.circuit) {
     alert(t('incompatibleCircuit'));
     return;
@@ -2194,6 +2198,7 @@ async function loadCircuit(key) {
   markCircuitModified();
   const controller = window.playController || window.problemController;
   controller?.syncPaletteWithCircuit?.();
+  if (key) lastSavedKey = key;
 }
 
 


### PR DESCRIPTION
## Summary
- Avoid redundant Google Drive fetch when choosing a saved circuit
- Add helper to apply preloaded circuit data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc009c32c8332acc6a82c770e173a