### PR TITLE
Fix selection shift handling for circuit movement

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2305,8 +2305,14 @@ function clearWires() {
 function moveCircuit(dx, dy) {
   const controller = window.problemController || window.playController;
   if (!controller) return;
-  if (controller === window.problemController && currentCustomProblem?.fixIO) return;
-  const moved = controller.moveCircuit(dx, dy);
+  const hasSelection = controller.state?.selection;
+  let moved = false;
+  if (hasSelection) {
+    moved = controller.moveSelection?.(dy, dx);
+  } else {
+    if (controller === window.problemController && currentCustomProblem?.fixIO) return;
+    moved = controller.moveCircuit(dx, dy);
+  }
   if (moved) {
     markCircuitModified();
   }

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -197,11 +197,11 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   function moveSelection(dr, dc) {
     const sel = state.selection;
-    if (!sel || sel.cross) return;
+    if (!sel || sel.cross) return false;
 
     for (const id of sel.blocks) {
       const b = circuit.blocks[id];
-      if (!b || b.fixed) return;
+      if (!b || b.fixed) return false;
     }
 
     const occupiedBlocks = new Set();
@@ -219,8 +219,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       const b = circuit.blocks[id];
       const nr = b.pos.r + dr;
       const nc = b.pos.c + dc;
-      if (nr < 0 || nr >= circuit.rows || nc < 0 || nc >= circuit.cols) return;
-      if (occupiedBlocks.has(`${nr},${nc}`) || occupiedWires.has(`${nr},${nc}`)) return;
+      if (nr < 0 || nr >= circuit.rows || nc < 0 || nc >= circuit.cols) return false;
+      if (occupiedBlocks.has(`${nr},${nc}`) || occupiedWires.has(`${nr},${nc}`)) return false;
     }
 
     for (const id of sel.wires) {
@@ -228,8 +228,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       for (const p of w.path) {
         const nr = p.r + dr;
         const nc = p.c + dc;
-        if (nr < 0 || nr >= circuit.rows || nc < 0 || nc >= circuit.cols) return;
-        if (occupiedBlocks.has(`${nr},${nc}`) || occupiedWires.has(`${nr},${nc}`)) return;
+        if (nr < 0 || nr >= circuit.rows || nc < 0 || nc >= circuit.cols) return false;
+        if (occupiedBlocks.has(`${nr},${nc}`) || occupiedWires.has(`${nr},${nc}`)) return false;
       }
     }
 
@@ -250,6 +250,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     renderContent(contentCtx, circuit, 0, panelTotalWidth);
     overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     drawSelection();
+    return true;
   }
 
   function isValidWireTrace(trace) {
@@ -332,15 +333,6 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       syncPaletteWithCircuit();
       renderContent(contentCtx, circuit, 0, panelTotalWidth);
       updateUsageCounts();
-    } else if (e.key.startsWith('Arrow') && state.mode === 'idle') {
-      e.preventDefault();
-      const dir = {
-        ArrowUp: [-1, 0],
-        ArrowDown: [1, 0],
-        ArrowLeft: [0, -1],
-        ArrowRight: [0, 1],
-      }[e.key];
-      moveSelection(dir[0], dir[1]);
     }
   };
   document.addEventListener('keydown', keydownHandler);
@@ -853,5 +845,5 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   updateUsageCounts();
-  return { state, circuit, startBlockDrag, syncPaletteWithCircuit, moveCircuit, placeFixedIO };
+  return { state, circuit, startBlockDrag, syncPaletteWithCircuit, moveCircuit, placeFixedIO, moveSelection };
 }


### PR DESCRIPTION
## Summary
- Only shift selected blocks/wires when a selection exists; otherwise move entire circuit
- Expose `moveSelection` and remove duplicate arrow-key handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae540649b88332ac1324727220bd32