### PR TITLE
Reset selection when circuit changes

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2221,6 +2221,7 @@ function applyCircuitData(data, key) {
   markCircuitModified();
   const controller = window.playController || window.problemController;
   controller?.syncPaletteWithCircuit?.();
+  controller?.clearSelection?.();
   if (key) lastSavedKey = key;
 }
 
@@ -2283,6 +2284,8 @@ function clearGrid() {
   }
   wires = [];
   markCircuitModified();
+  window.playController?.clearSelection?.();
+  window.problemController?.clearSelection?.();
 }
 
 function clearWires() {
@@ -2293,6 +2296,8 @@ function clearWires() {
     window.problemCircuit.wires = {};
   }
   markCircuitModified();
+  window.playController?.clearSelection?.();
+  window.problemController?.clearSelection?.();
 }
 
   function markCircuitModified() {

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -333,6 +333,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       syncPaletteWithCircuit();
       renderContent(contentCtx, circuit, 0, panelTotalWidth);
       updateUsageCounts();
+      clearSelection();
     }
   };
   document.addEventListener('keydown', keydownHandler);
@@ -446,6 +447,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
           }
           renderContent(contentCtx, circuit, 0, panelTotalWidth);
           updateUsageCounts();
+          if (deleted) clearSelection();
           handled = deleted;
         } else {
           const bid = Object.keys(circuit.blocks).find(id => {
@@ -530,6 +532,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
         endBlock.inputs = [...(endBlock.inputs || []), startBlock.id];
         renderContent(contentCtx, circuit, 0, panelTotalWidth);
         updateUsageCounts();
+        clearSelection();
       }
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     } else if (state.draggingBlock) {
@@ -591,6 +594,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
         renderContent(contentCtx, circuit, 0, panelTotalWidth);
         updateUsageCounts();
       }
+      if (placed || state.draggingBlock.id) clearSelection();
       state.draggingBlock = null;
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
       if (state.selection) drawSelection();
@@ -702,6 +706,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
             delete circuit.blocks[state.dragCandidate.id];
             renderContent(contentCtx, circuit, 0, panelTotalWidth);
             updateUsageCounts();
+            clearSelection();
           }
           state.dragCandidate = null;
         }
@@ -845,5 +850,5 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   updateUsageCounts();
-  return { state, circuit, startBlockDrag, syncPaletteWithCircuit, moveCircuit, placeFixedIO, moveSelection };
+  return { state, circuit, startBlockDrag, syncPaletteWithCircuit, moveCircuit, placeFixedIO, moveSelection, clearSelection };
 }


### PR DESCRIPTION
## Summary
- Clear selection whenever blocks or wires are added, removed, or circuit is reset
- Expose `clearSelection` and invoke from helpers like applyCircuitData, clearGrid, and clearWires

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae56381ce083328f2624f8a2a1ed7d