### PR TITLE
Add transition and tutorial animations

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -368,8 +368,28 @@ document.getElementById("startBtn").onclick = () => {
   lockOrientationLandscape();
   renderChapterList();
   if (chapterData.length > 0) selectChapter(0);
-  document.getElementById("firstScreen").style.display = "none";
-  chapterStageScreen.style.display = "block";
+
+  const leftPanel = document.getElementById('overallRankingArea');
+  const rightPanel = document.getElementById('guestbookArea');
+  const mainScreen = document.getElementById('mainScreen');
+  const firstScreen = document.getElementById('firstScreen');
+
+  leftPanel.classList.add('slide-out-left');
+  rightPanel.classList.add('slide-out-right');
+  mainScreen.classList.add('fade-scale-out');
+
+  setTimeout(() => {
+    firstScreen.style.display = 'none';
+    leftPanel.classList.remove('slide-out-left');
+    rightPanel.classList.remove('slide-out-right');
+    mainScreen.classList.remove('fade-scale-out');
+
+    chapterStageScreen.style.display = 'block';
+    chapterStageScreen.classList.add('stage-screen-enter');
+    chapterStageScreen.addEventListener('animationend', () => {
+      chapterStageScreen.classList.remove('stage-screen-enter');
+    }, { once: true });
+  }, 200);
 };
 
 document.getElementById("backToMainFromChapter").onclick = () => {
@@ -720,9 +740,10 @@ function selectChapter(idx) {
 
 function renderStageList(stageList) {
   stageListEl.innerHTML = "";
-  stageList.forEach(level => {
+  stageList.forEach((level, idx) => {
     const card = document.createElement('div');
-    card.className = 'stageCard';
+    card.className = 'stageCard card-enter';
+    card.style.animationDelay = `${idx * 40}ms`;
     card.dataset.stage = level;
     const title = levelTitles[level] ?? `Stage ${level}`;
     let name = title;
@@ -739,6 +760,11 @@ function renderStageList(stageList) {
     } else {
       if (clearedLevelsFromDb.includes(level)) {
         card.classList.add('cleared');
+        const check = document.createElement('svg');
+        check.classList.add('checkmark');
+        check.setAttribute('viewBox', '0 0 24 24');
+        check.innerHTML = '<path d="M4 12l5 5 11-11" fill="none" stroke="green" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>';
+        card.appendChild(check);
       }
       card.onclick = () => {
         returnToEditScreen();
@@ -1103,12 +1129,16 @@ function showStageTutorial(level, done) {
       idx++;
       render();
     } else {
-      modal.style.display = 'none';
-      done();
+      modal.classList.remove('show');
+      setTimeout(() => {
+        modal.style.display = 'none';
+        done();
+      }, 180);
     }
   };
   render();
   modal.style.display = 'flex';
+  requestAnimationFrame(() => modal.classList.add('show'));
 }
 
 // 5) ESC 키로 닫기

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -571,6 +571,8 @@ html, body {
     justify-content: center;
     text-align: center;
     transition: transform 0.2s, box-shadow 0.2s;
+    opacity: 0;
+    transform: scale(0.96);
   }
 
   .stageCard:not(.locked):hover {
@@ -582,12 +584,33 @@ html, body {
     border-color: green;
   }
 
-  .stageCard.cleared::after {
-    content: '✓';
+  .stageCard.card-enter {
+    animation: cardIn 180ms forwards ease-out;
+  }
+
+  @keyframes cardIn {
+    to { opacity: 1; transform: scale(1); }
+  }
+
+  .stageCard .checkmark {
     position: absolute;
     top: 8px;
     right: 8px;
-    color: green;
+    width: 24px;
+    height: 24px;
+    stroke-dasharray: 30;
+    stroke-dashoffset: 30;
+    animation: drawCheck 150ms forwards ease-out, checkBounce 150ms 150ms both;
+  }
+
+  @keyframes drawCheck {
+    to { stroke-dashoffset: 0; }
+  }
+
+  @keyframes checkBounce {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
   }
 
   .stageCard.locked {
@@ -2030,5 +2053,68 @@ html, body {
   #problemCanvasContainer {
     margin-bottom: 0;
   }
+}
+
+/* Main → Stage transition animations */
+.slide-out-left {
+  transform: translateX(-25px);
+  opacity: 0;
+  transition: transform 200ms ease-out, opacity 200ms ease-out;
+}
+
+.slide-out-right {
+  transform: translateX(25px);
+  opacity: 0;
+  transition: transform 200ms ease-out, opacity 200ms ease-out;
+}
+
+.fade-scale-out {
+  transform: scale(0.98);
+  opacity: 0;
+  transition: transform 180ms ease-out, opacity 180ms ease-out;
+}
+
+.stage-screen-enter {
+  animation: stageScreenIn 180ms ease-out forwards;
+}
+
+@keyframes stageScreenIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Stage tutorial modal */
+#stageTutorialModal {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+#stageTutorialModal.show {
+  opacity: 1;
+}
+
+#stageTutorialModal .modal-content {
+  transform: scale(0.98);
+  opacity: 0;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+#stageTutorialModal.show .modal-content {
+  transform: scale(1);
+  opacity: 1;
+}
+
+#stageTutBtn {
+  transition: transform 300ms ease-in-out;
+}
+
+#stageTutBtn:hover {
+  transform: translateX(3px);
 }
 


### PR DESCRIPTION
## Summary
- animate main panels and stage screen when starting the game
- stagger stage card entrance and add drawing checkmarks for cleared stages
- add fade/scale animation to stage tutorial modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5a4544a08332a2ed4c261753760a