### PR TITLE
Add basic UI transition animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,6 +368,7 @@
       </div>
     </div>
     <div id="tutorialModal" class="modal tutorial-modal" style="display:none;">
+      <div class="modal-backdrop"></div>
       <div class="modal-content tutorial-content">
         <h2 id="tutTitle"></h2>
         <!-- 여기 이미지 자리 -->
@@ -487,6 +488,7 @@
       </div>
     </div>
     <div id="stageTutorialModal" class="modal" style="display:none;">
+      <div class="modal-backdrop"></div>
       <div class="modal-content">
         <img id="stageTutImg" class="tutorial-img" src="" alt="tutorial">
         <div class="tutorial-text" style="font-size: 1.1rem">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -314,6 +314,10 @@ const chapterStageScreen = document.getElementById("chapterStageScreen");
 const gameScreen = document.getElementById("gameScreen");
 const chapterListEl = document.getElementById("chapterList");
 const stageListEl = document.getElementById("stageList");
+const rankingPanel = document.getElementById("overallRankingArea");
+const guestbookPanel = document.getElementById("guestbookArea");
+const heroPanel = document.getElementById("mainScreen");
+const firstScreenEl = document.getElementById("firstScreen");
 
 // 모바일 내비게이션을 통한 firstScreen 전환
 const overallRankingAreaEl = document.getElementById("overallRankingArea");
@@ -368,13 +372,29 @@ document.getElementById("startBtn").onclick = () => {
   lockOrientationLandscape();
   renderChapterList();
   if (chapterData.length > 0) selectChapter(0);
-  document.getElementById("firstScreen").style.display = "none";
-  chapterStageScreen.style.display = "block";
+
+  rankingPanel.classList.add("panel-out-left");
+  guestbookPanel.classList.add("panel-out-right");
+  heroPanel.classList.add("hero-out");
+
+  setTimeout(() => {
+    firstScreenEl.style.display = "none";
+    chapterStageScreen.style.display = "block";
+    requestAnimationFrame(() => {
+      chapterStageScreen.classList.add("active");
+    });
+  }, 200);
 };
 
 document.getElementById("backToMainFromChapter").onclick = () => {
-  chapterStageScreen.style.display = "none";
-  document.getElementById("firstScreen").style.display = "";
+  chapterStageScreen.classList.remove("active");
+  setTimeout(() => {
+    chapterStageScreen.style.display = "none";
+    firstScreenEl.style.display = "";
+    rankingPanel.classList.remove("panel-out-left");
+    guestbookPanel.classList.remove("panel-out-right");
+    heroPanel.classList.remove("hero-out");
+  }, 180);
 };
 
 document.getElementById("toggleChapterList").onclick = () => {
@@ -720,9 +740,9 @@ function selectChapter(idx) {
 
 function renderStageList(stageList) {
   stageListEl.innerHTML = "";
-  stageList.forEach(level => {
+  stageList.forEach((level, idx) => {
     const card = document.createElement('div');
-    card.className = 'stageCard';
+    card.className = 'stageCard hidden';
     card.dataset.stage = level;
     const title = levelTitles[level] ?? `Stage ${level}`;
     let name = title;
@@ -749,6 +769,10 @@ function renderStageList(stageList) {
       };
     }
     stageListEl.appendChild(card);
+    setTimeout(() => {
+      card.classList.remove('hidden');
+      card.classList.add('appear');
+    }, idx * 40);
   });
 }
 
@@ -1039,7 +1063,7 @@ function showTutorial(idx) {
   tutPrev.disabled = (idx === 0);
   tutNext.style.display = (idx === tutorialSteps.length - 1) ? 'none' : 'inline-block';
   tutFinish.style.display = (idx === tutorialSteps.length - 1) ? 'inline-block' : 'none';
-  tutModal.style.display = "flex";
+  tutModal.classList.add("show");
 }
 
 // 4) 이벤트 연결
@@ -1048,7 +1072,7 @@ tutPrev.addEventListener("click", () => showTutorial(tutIndex - 1));
 tutNext.addEventListener("click", () => showTutorial(tutIndex + 1));
 tutFinish.addEventListener("click", finishTutorial);
 tutClose.addEventListener("click", () => {
-  tutModal.style.display = "none";
+  tutModal.classList.remove("show");
 });
 
 function getLowestUnclearedStage() {
@@ -1063,7 +1087,7 @@ function getLowestUnclearedStage() {
 
 function finishTutorial() {
   localStorage.setItem('tutorialCompleted', 'true');
-  tutModal.style.display = 'none';
+  tutModal.classList.remove('show');
   lockOrientationLandscape();
   stageDataPromise.then(() => {
     startLevel(getLowestUnclearedStage());
@@ -1113,8 +1137,8 @@ function showStageTutorial(level, done) {
 
 // 5) ESC 키로 닫기
 document.addEventListener("keydown", e => {
-  if (e.key === "Escape" && tutModal.style.display === "flex") {
-    tutModal.style.display = "none";
+  if (e.key === "Escape" && tutModal.classList.contains("show")) {
+    tutModal.classList.remove("show");
   }
 });
 

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -505,7 +505,7 @@ html, body {
     left: 0;
     width: 100%;
     height: 100%;
-    background: white;
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -570,7 +570,17 @@ html, body {
     align-items: center;
     justify-content: center;
     text-align: center;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: transform 0.18s ease-out, box-shadow 0.2s, opacity 0.18s ease-out;
+  }
+
+  .stageCard.hidden {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  .stageCard.appear {
+    opacity: 1;
+    transform: scale(1);
   }
 
   .stageCard:not(.locked):hover {
@@ -588,6 +598,7 @@ html, body {
     top: 8px;
     right: 8px;
     color: green;
+    animation: checkmarkPop 0.15s ease-out;
   }
 
   .stageCard.locked {
@@ -2030,5 +2041,76 @@ html, body {
   #problemCanvasContainer {
     margin-bottom: 0;
   }
+}
+
+/* Animations for screen transitions */
+#overallRankingArea.panel-out-left {
+  transform: translateX(-30px);
+  opacity: 0;
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+}
+
+#guestbookArea.panel-out-right {
+  transform: translateX(30px);
+  opacity: 0;
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+}
+
+#mainScreen.hero-out {
+  transform: scale(0.98);
+  opacity: 0;
+  transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+}
+
+#chapterStageScreen {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+#chapterStageScreen.active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+}
+
+@keyframes checkmarkPop {
+  0% { transform: scale(0); opacity: 0; }
+  80% { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(1); }
+}
+
+/* Modal animation */
+.modal {
+  display: none;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal .modal-content {
+  transform: scale(0.98);
+  opacity: 0;
+  transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+}
+
+.modal.show .modal-content {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.modal.show .modal-backdrop {
+  animation: modalFadeIn 0.12s ease-out forwards;
+}
+
+@keyframes modalFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Stage tutorial button hover */
+#stageTutBtn:hover {
+  transform: translateX(3px);
+  transition: transform 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
- Implement animated transition from main screen to stage selection with panel slides and screen fade.
- Add staggered appearance and checkmark pop for stage cards.
- Enhance tutorial modals with backdrop, scale/fade effect, and start button hover motion.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5a4544a08332a2ed4c261753760a