### PR TITLE
Show stage clear checkmark and animate menu transitions

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -393,8 +393,25 @@ document.getElementById("startBtn").onclick = () => {
 };
 
 document.getElementById("backToMainFromChapter").onclick = () => {
-  chapterStageScreen.style.display = "none";
-  document.getElementById("firstScreen").style.display = "";
+  const firstScreen = document.getElementById('firstScreen');
+  const leftPanel = document.getElementById('overallRankingArea');
+  const rightPanel = document.getElementById('guestbookArea');
+  const mainScreen = document.getElementById('mainScreen');
+
+  chapterStageScreen.classList.add('stage-screen-exit');
+  chapterStageScreen.addEventListener('animationend', () => {
+    chapterStageScreen.classList.remove('stage-screen-exit');
+    chapterStageScreen.style.display = 'none';
+
+    firstScreen.style.display = '';
+    leftPanel.classList.add('slide-in-left');
+    rightPanel.classList.add('slide-in-right');
+    mainScreen.classList.add('fade-scale-in');
+
+    leftPanel.addEventListener('animationend', () => leftPanel.classList.remove('slide-in-left'), { once: true });
+    rightPanel.addEventListener('animationend', () => rightPanel.classList.remove('slide-in-right'), { once: true });
+    mainScreen.addEventListener('animationend', () => mainScreen.classList.remove('fade-scale-in'), { once: true });
+  }, { once: true });
 };
 
 document.getElementById("toggleChapterList").onclick = () => {
@@ -546,8 +563,18 @@ function refreshClearedUI() {
   document.querySelectorAll('.stageCard').forEach(card => {
     const level = parseInt(card.dataset.stage, 10);
     card.classList.remove('cleared');
+    const check = card.querySelector('.checkmark');
     if (clearedLevelsFromDb.includes(level)) {
       card.classList.add('cleared');
+      if (!check) {
+        const svg = document.createElement('svg');
+        svg.classList.add('checkmark');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.innerHTML = '<path d="M4 12l5 5 11-11" fill="none" stroke="green" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>';
+        card.appendChild(svg);
+      }
+    } else if (check) {
+      check.remove();
     }
   });
 }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2078,6 +2078,23 @@ html, body {
   animation: stageScreenIn 180ms ease-out forwards;
 }
 
+/* Stage → Main transition animations */
+.slide-in-left {
+  animation: slideInLeft 200ms ease-out forwards;
+}
+
+.slide-in-right {
+  animation: slideInRight 200ms ease-out forwards;
+}
+
+.fade-scale-in {
+  animation: fadeScaleIn 180ms ease-out forwards;
+}
+
+.stage-screen-exit {
+  animation: stageScreenOut 180ms ease-out forwards;
+}
+
 @keyframes stageScreenIn {
   from {
     opacity: 0;
@@ -2087,6 +2104,26 @@ html, body {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+@keyframes slideInLeft {
+  from { transform: translateX(-25px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes slideInRight {
+  from { transform: translateX(25px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes fadeScaleIn {
+  from { transform: scale(0.98); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes stageScreenOut {
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(10px); }
 }
 
 /* Stage tutorial modal */


### PR DESCRIPTION
## Summary
- Ensure cleared stages display a checkmark
- Add animated transition when returning from stage selection to main screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6be4a1148332b3e32b4f70f27b11