### PR TITLE
Mark cleared levels after ranking save

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -3297,6 +3297,7 @@ async function gradeLevelCanvas(level) {
       if (!snapshot.exists()) {
         saveRanking(level, blockCounts, usedWires, hintsUsed);
         pendingClearedLevel = level;
+        markLevelCleared(level);
       } else {
         let best = null;
         snapshot.forEach(child => {
@@ -3318,6 +3319,7 @@ async function gradeLevelCanvas(level) {
             timestamp: new Date().toISOString()
           });
           pendingClearedLevel = level;
+          markLevelCleared(level);
         }
       }
       if (saveSuccess) showCircuitSavedModal();


### PR DESCRIPTION
## Summary
- Ensure level UI is refreshed when a stage is cleared by calling `markLevelCleared` after ranking save.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae78eb3a088332a9562a3d767b64e7