### PR TITLE
Fix stage checkmark rendering and animation

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -562,6 +562,23 @@ function fetchOverallStats(nickname) {
   });
 }
 
+function createCheckmarkSvg(animate = false) {
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.classList.add('checkmark');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  const path = document.createElementNS(svgNS, 'path');
+  path.setAttribute('d', 'M4 12l5 5 11-11');
+  path.setAttribute('fill', 'none');
+  path.setAttribute('stroke', 'green');
+  path.setAttribute('stroke-width', '3');
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  svg.appendChild(path);
+  if (animate) svg.classList.add('animate');
+  return svg;
+}
+
 function refreshClearedUI() {
   document.querySelectorAll('.stageCard').forEach(card => {
     const level = parseInt(card.dataset.stage, 10);
@@ -570,10 +587,7 @@ function refreshClearedUI() {
     if (clearedLevelsFromDb.includes(level)) {
       card.classList.add('cleared');
       if (!check) {
-        const svg = document.createElement('svg');
-        svg.classList.add('checkmark');
-        svg.setAttribute('viewBox', '0 0 24 24');
-        svg.innerHTML = '<path d="M4 12l5 5 11-11" fill="none" stroke="green" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>';
+        const svg = createCheckmarkSvg(true);
         card.appendChild(svg);
       }
     } else if (check) {
@@ -808,10 +822,7 @@ function renderStageList(stageList) {
     } else {
       if (clearedLevelsFromDb.includes(level)) {
         card.classList.add('cleared');
-        const check = document.createElement('svg');
-        check.classList.add('checkmark');
-        check.setAttribute('viewBox', '0 0 24 24');
-        check.innerHTML = '<path d="M4 12l5 5 11-11" fill="none" stroke="green" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>';
+        const check = createCheckmarkSvg();
         card.appendChild(check);
       }
       card.onclick = () => {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -598,9 +598,20 @@ html, body {
     right: 8px;
     width: 24px;
     height: 24px;
+  }
+
+  .stageCard .checkmark path {
     stroke-dasharray: 30;
+    stroke-dashoffset: 0;
+  }
+
+  .stageCard .checkmark.animate {
+    animation: checkBounce 150ms 150ms both;
+  }
+
+  .stageCard .checkmark.animate path {
     stroke-dashoffset: 30;
-    animation: drawCheck 150ms forwards ease-out, checkBounce 150ms 150ms both;
+    animation: drawCheck 150ms forwards ease-out;
   }
 
   @keyframes drawCheck {


### PR DESCRIPTION
## Summary
- Ensure stage cards use SVG namespace when creating checkmarks
- Animate checkmark stroke on the path element and keep it visible by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a68867083328663af65857ccc76