### PR TITLE
Add swipe navigation for mobile tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
     </div>
     <!-- 메인 화면 -->
     <div class="container" id="firstScreen">
+      <div id="tabContainer">
       <div id="overallRankingArea">
         <h3 id="overallRankingTitle">🏆 전체 랭킹</h3>
         <div id="overallRankingList">로딩 중…</div>
@@ -142,6 +143,7 @@
             ☕ 개발자(이현준)한테 커피 사주기
           </button>
         </div>
+      </div>
       </div>
       <div id="mobileNav">
         <div class="nav-item" data-target="overallRankingArea">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -322,36 +322,56 @@ const guestbookAreaEl = document.getElementById("guestbookArea");
 const mobileNav = document.getElementById("mobileNav");
 
 if (mobileNav) {
-    function showFirstScreenSection(targetId) {
-      overallRankingAreaEl.style.display = "none";
-      mainScreenSection.style.display = "none";
-      guestbookAreaEl.style.display = "none";
-      mobileNav.querySelectorAll(".nav-item").forEach(nav => nav.classList.remove("active"));
-      const target = document.getElementById(targetId);
-      if (target) target.style.display = 'flex';
-      const activeNav = mobileNav.querySelector(`.nav-item[data-target="${targetId}"]`);
-      if (activeNav) activeNav.classList.add("active");
-      refreshUserData();
+  const tabContainer = document.getElementById("tabContainer");
+  const sections = ["overallRankingArea", "mainArea", "guestbookArea"];
+  let currentIndex = 1;
+
+  function showFirstScreenSection(targetId) {
+    const targetIndex = sections.indexOf(targetId);
+    if (targetIndex === -1) return;
+    tabContainer.style.transform = `translateX(-${targetIndex * 100}%)`;
+    mobileNav.querySelectorAll(".nav-item").forEach(nav => nav.classList.remove("active"));
+    const activeNav = mobileNav.querySelector(`.nav-item[data-target="${targetId}"]`);
+    if (activeNav) activeNav.classList.add("active");
+    currentIndex = targetIndex;
+    refreshUserData();
   }
 
-    mobileNav.querySelectorAll(".nav-item").forEach(item => {
-      item.addEventListener("click", () => {
-        const target = item.getAttribute("data-target");
-        showFirstScreenSection(target);
-      });
+  mobileNav.querySelectorAll(".nav-item").forEach(item => {
+    item.addEventListener("click", () => {
+      const target = item.getAttribute("data-target");
+      showFirstScreenSection(target);
     });
+  });
 
-    function handleFirstScreenResize() {
-      if (window.innerWidth >= 1024) {
-        overallRankingAreaEl.style.display = "";
-        mainScreenSection.style.display = "";
-        guestbookAreaEl.style.display = "";
-      } else {
-        const activeNav = mobileNav.querySelector(".nav-item.active");
-        const target = activeNav ? activeNav.getAttribute("data-target") : "mainArea";
-        showFirstScreenSection(target);
+  let startX = 0;
+  tabContainer.addEventListener("touchstart", e => {
+    startX = e.touches[0].clientX;
+  });
+  tabContainer.addEventListener("touchend", e => {
+    const diffX = e.changedTouches[0].clientX - startX;
+    if (Math.abs(diffX) > 50) {
+      if (diffX < 0 && currentIndex < sections.length - 1) {
+        showFirstScreenSection(sections[currentIndex + 1]);
+      } else if (diffX > 0 && currentIndex > 0) {
+        showFirstScreenSection(sections[currentIndex - 1]);
       }
     }
+  });
+
+  function handleFirstScreenResize() {
+    if (window.innerWidth >= 1024) {
+      tabContainer.style.transform = "";
+      overallRankingAreaEl.style.display = "";
+      mainScreenSection.style.display = "";
+      guestbookAreaEl.style.display = "";
+    } else {
+      overallRankingAreaEl.style.display = "flex";
+      mainScreenSection.style.display = "flex";
+      guestbookAreaEl.style.display = "flex";
+      showFirstScreenSection(sections[currentIndex]);
+    }
+  }
 
   window.addEventListener("resize", handleFirstScreenResize);
   handleFirstScreenResize();

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -822,6 +822,12 @@ html, body {
     gap: 5rem;
   }
 
+  #tabContainer {
+    display: flex;
+    gap: 5rem;
+    width: 100%;
+  }
+
   #mainArea {
     display: flex;
     flex-direction: column;
@@ -1645,20 +1651,24 @@ html, body {
   #firstScreen {
     display: block;
     padding-bottom: 60px;
+    overflow: hidden;
+    position: relative;
   }
 
-  #firstScreen > #overallRankingArea,
-  #firstScreen > #mainArea,
-  #firstScreen > #guestbookArea {
-    display: none;
+  #tabContainer {
+    display: flex;
+    width: 300%;
+    transition: transform 0.3s ease;
+    transform: translateX(-100%);
+  }
+
+  #tabContainer > #overallRankingArea,
+  #tabContainer > #mainArea,
+  #tabContainer > #guestbookArea {
     width: 100%;
     margin: 0;
     box-sizing: border-box;
-  }
-
-  
-  #firstScreen > #mainArea {
-    display: flex;
+    flex-shrink: 0;
   }
 
   #mainArea {
@@ -1735,20 +1745,24 @@ html, body {
   #firstScreen {
     display: block;
     padding-bottom: 60px;
+    overflow: hidden;
+    position: relative;
   }
 
-  #firstScreen > #overallRankingArea,
-  #firstScreen > #mainArea,
-  #firstScreen > #guestbookArea {
-    display: none;
+  #tabContainer {
+    display: flex;
+    width: 300%;
+    transition: transform 0.3s ease;
+    transform: translateX(-100%);
+  }
+
+  #tabContainer > #overallRankingArea,
+  #tabContainer > #mainArea,
+  #tabContainer > #guestbookArea {
     width: 100%;
     margin: 0;
     box-sizing: border-box;
-  }
-
-  
-  #firstScreen > #mainArea {
-    display: flex;
+    flex-shrink: 0;
   }
 
   #mainArea {


### PR DESCRIPTION
## Summary
- add tabContainer wrapper for mobile tab sections
- support swipe and animated navigation between ranking, home, and guestbook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9df8ca0883328ecf32efb5316dcd