### PR TITLE
feat: enable swipe navigation on mobile

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1936,6 +1936,61 @@ html, body {
   }
 }
 
+@media (max-width: 1024px) {
+  #firstScreen {
+    position: relative;
+    overflow: hidden;
+    min-height: calc(100vh - 60px);
+  }
+
+  #firstScreen > #overallRankingArea,
+  #firstScreen > #mainArea,
+  #firstScreen > #guestbookArea {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: calc(100% - 60px);
+  }
+}
+
+/* firstScreen slide animations */
+@keyframes firstScreenSlideInFromRight {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes firstScreenSlideOutToLeft {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+
+@keyframes firstScreenSlideInFromLeft {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes firstScreenSlideOutToRight {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+
+.first-screen-slide-in-right {
+  animation: firstScreenSlideInFromRight 0.3s ease-out forwards;
+}
+
+.first-screen-slide-out-left {
+  animation: firstScreenSlideOutToLeft 0.3s ease-out forwards;
+}
+
+.first-screen-slide-in-left {
+  animation: firstScreenSlideInFromLeft 0.3s ease-out forwards;
+}
+
+.first-screen-slide-out-right {
+  animation: firstScreenSlideOutToRight 0.3s ease-out forwards;
+}
+
 /* Main → Stage transition animations */
 .slide-out-left {
   transform: translateX(-25px);


### PR DESCRIPTION
## Summary
- allow left/right swipes to move between ranking, home, and guestbook tabs
- animate tab changes from both swipe gestures and nav bar taps
- add CSS keyframes and layout rules for horizontal sliding on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9df8ca0883328ecf32efb5316dcd