### PR TITLE
feat: enable swipe navigation on mobile tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,11 +84,11 @@
     </div>
     <!-- 메인 화면 -->
     <div class="container" id="firstScreen">
-      <div id="overallRankingArea">
+      <div id="overallRankingArea" class="tab-section">
         <h3 id="overallRankingTitle">🏆 전체 랭킹</h3>
         <div id="overallRankingList">로딩 중…</div>
       </div>
-      <div id="mainArea">
+      <div id="mainArea" class="tab-section">
         <div id="mainScreen">
         <h1>🧠 Bitwiser</h1>
         <p class="tagline">Play bitwise. Become bit wiser.</p>
@@ -126,7 +126,7 @@
           </div>
         </div>
       </div>
-      <div id="guestbookArea">
+      <div id="guestbookArea" class="tab-section">
         <div id="guestbookForm">
           <h3 id="guestbookTitle">📝 개발자(이현준)한테 글 남기기</h3>
           <p class="info-text" id="guestNicknameLabel">닉네임: <b id="guestUsername"></b></p>
@@ -144,15 +144,15 @@
         </div>
       </div>
       <div id="mobileNav">
-        <div class="nav-item" data-target="overallRankingArea">
+        <div class="nav-item" data-target="overallRankingArea" aria-selected="false">
           <img src="assets/trophy-icon.png" alt="랭킹" class="nav-icon">
           <span class="nav-text">랭킹</span>
         </div>
-        <div class="nav-item active" data-target="mainArea">
+        <div class="nav-item active" data-target="mainArea" aria-selected="true">
           <img src="assets/home-icon.png" alt="메인" class="nav-icon">
           <span class="nav-text">메인</span>
         </div>
-        <div class="nav-item" data-target="guestbookArea">
+        <div class="nav-item" data-target="guestbookArea" aria-selected="false">
           <img src="assets/message-icon.png" alt="방명록" class="nav-icon">
           <span class="nav-text">방명록</span>
         </div>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -315,43 +315,125 @@ const gameScreen = document.getElementById("gameScreen");
 const chapterListEl = document.getElementById("chapterList");
 const stageListEl = document.getElementById("stageList");
 
-// 모바일 내비게이션을 통한 firstScreen 전환
+// 모바일 내비게이션 및 스와이프 전환
 const overallRankingAreaEl = document.getElementById("overallRankingArea");
 const mainScreenSection = document.getElementById("mainArea");
 const guestbookAreaEl = document.getElementById("guestbookArea");
 const mobileNav = document.getElementById("mobileNav");
+const firstScreenEl = document.getElementById("firstScreen");
 
-if (mobileNav) {
-    function showFirstScreenSection(targetId) {
-      overallRankingAreaEl.style.display = "none";
-      mainScreenSection.style.display = "none";
-      guestbookAreaEl.style.display = "none";
-      mobileNav.querySelectorAll(".nav-item").forEach(nav => nav.classList.remove("active"));
-      const target = document.getElementById(targetId);
-      if (target) target.style.display = 'flex';
-      const activeNav = mobileNav.querySelector(`.nav-item[data-target="${targetId}"]`);
-      if (activeNav) activeNav.classList.add("active");
-      refreshUserData();
-  }
+const firstScreenTabs = [overallRankingAreaEl, mainScreenSection, guestbookAreaEl];
+let activeTabIndex = 1; // 메인 탭
+let isTransitioning = false;
+let startX = 0, startY = 0, deltaX = 0, deltaY = 0, isSwiping = false;
 
-    mobileNav.querySelectorAll(".nav-item").forEach(item => {
-      item.addEventListener("click", () => {
-        const target = item.getAttribute("data-target");
-        showFirstScreenSection(target);
-      });
+function updateNavActive() {
+  if (!mobileNav) return;
+  mobileNav.querySelectorAll(".nav-item").forEach((nav, idx) => {
+    nav.classList.toggle("active", idx === activeTabIndex);
+    nav.setAttribute("aria-selected", idx === activeTabIndex ? "true" : "false");
+  });
+}
+
+function focusFirstInActiveTab() {
+  const activeEl = firstScreenTabs[activeTabIndex];
+  if (!activeEl) return;
+  const focusable = activeEl.querySelector(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  if (focusable) focusable.focus();
+}
+
+function goToFirstScreenTab(newIndex, direction) {
+  if (isTransitioning || newIndex === activeTabIndex) return;
+  const current = firstScreenTabs[activeTabIndex];
+  const next = firstScreenTabs[newIndex];
+  if (!current || !next) return;
+  isTransitioning = true;
+
+  next.style.display = "flex";
+  next.style.transform = `translateX(${direction * 100}%)`;
+  next.style.opacity = "0";
+
+  requestAnimationFrame(() => {
+    current.style.transform = `translateX(${direction * -100}%)`;
+    current.style.opacity = "0";
+    next.style.transform = "translateX(0)";
+    next.style.opacity = "1";
+  });
+
+  const onEnd = () => {
+    current.style.display = "none";
+    current.style.transform = "";
+    current.style.opacity = "";
+    next.style.transform = "";
+    next.style.opacity = "";
+    next.removeEventListener("transitionend", onEnd);
+    activeTabIndex = newIndex;
+    updateNavActive();
+    focusFirstInActiveTab();
+    refreshUserData();
+    isTransitioning = false;
+  };
+  next.addEventListener("transitionend", onEnd);
+}
+
+if (mobileNav && firstScreenEl) {
+  mobileNav.querySelectorAll(".nav-item").forEach((item, idx) => {
+    item.addEventListener("click", () => {
+      const direction = idx > activeTabIndex ? 1 : -1;
+      goToFirstScreenTab(idx, direction);
     });
+  });
 
-    function handleFirstScreenResize() {
-      if (window.innerWidth >= 1024) {
-        overallRankingAreaEl.style.display = "";
-        mainScreenSection.style.display = "";
-        guestbookAreaEl.style.display = "";
-      } else {
-        const activeNav = mobileNav.querySelector(".nav-item.active");
-        const target = activeNav ? activeNav.getAttribute("data-target") : "mainArea";
-        showFirstScreenSection(target);
+  firstScreenEl.addEventListener("touchstart", e => {
+    if (window.innerWidth >= 1024 || isTransitioning) return;
+    const t = e.touches[0];
+    startX = t.clientX;
+    startY = t.clientY;
+    deltaX = 0;
+    deltaY = 0;
+    isSwiping = true;
+  });
+
+  firstScreenEl.addEventListener("touchmove", e => {
+    if (!isSwiping) return;
+    const t = e.touches[0];
+    deltaX = t.clientX - startX;
+    deltaY = t.clientY - startY;
+    if (Math.abs(deltaY) > Math.abs(deltaX)) {
+      isSwiping = false; // 수직 이동이 더 크면 스와이프 취소
+    }
+  });
+
+  firstScreenEl.addEventListener("touchend", () => {
+    if (!isSwiping) return;
+    const threshold = window.innerWidth * 0.25;
+    if (Math.abs(deltaX) > threshold) {
+      if (deltaX < 0 && activeTabIndex < firstScreenTabs.length - 1) {
+        goToFirstScreenTab(activeTabIndex + 1, 1);
+      } else if (deltaX > 0 && activeTabIndex > 0) {
+        goToFirstScreenTab(activeTabIndex - 1, -1);
       }
     }
+    isSwiping = false;
+  });
+
+  function handleFirstScreenResize() {
+    if (window.innerWidth >= 1024) {
+      firstScreenTabs.forEach(tab => {
+        tab.style.display = "";
+        tab.style.transform = "";
+        tab.style.opacity = "";
+      });
+    } else {
+      firstScreenTabs.forEach((tab, idx) => {
+        tab.style.display = idx === activeTabIndex ? "flex" : "none";
+        tab.style.transform = "";
+        tab.style.opacity = "";
+      });
+    }
+  }
 
   window.addEventListener("resize", handleFirstScreenResize);
   handleFirstScreenResize();

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1645,15 +1645,20 @@ html, body {
   #firstScreen {
     display: block;
     padding-bottom: 60px;
+    position: relative;
+    overflow: hidden;
   }
 
-  #firstScreen > #overallRankingArea,
-  #firstScreen > #mainArea,
-  #firstScreen > #guestbookArea {
+  #firstScreen > .tab-section {
     display: none;
     width: 100%;
     margin: 0;
     box-sizing: border-box;
+    position: absolute;
+    top: 0;
+    left: 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    will-change: transform, opacity;
   }
 
   


### PR DESCRIPTION
## Summary
- add swipe-driven tab transitions for ranking, home, and guestbook
- animate tab changes with sliding/opacity effects and sync bottom nav

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb4c9164c833289fd66338b571106