### PR TITLE
fix: stop R key from affecting app after leaving game

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -562,6 +562,9 @@ document.getElementById("toggleChapterList").onclick = () => {
 };
 
 document.getElementById("backToLevelsBtn").onclick = () => {
+  window.playController?.destroy?.();
+  window.playController = null;
+  window.playCircuit = null;
   document.body.classList.remove('game-active');
   gameScreen.style.display = "none";
   if (currentCustomProblem) {
@@ -2763,6 +2766,9 @@ if (createProblemBtn) {
 
 //— ⑤ 문제 출제 화면 → 메인
 backToMainFromProblem.addEventListener('click', () => {
+  window.problemController?.destroy?.();
+  window.problemController = null;
+  window.problemCircuit = null;
   problemScreen.style.display = 'none';
   if (problemScreenPrev === 'userProblems') {
     userProblemsScreen.style.display = 'block';

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -403,6 +403,17 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   };
   document.addEventListener('keyup', keyupHandler);
 
+  function destroy() {
+    if (keydownHandler) {
+      document.removeEventListener('keydown', keydownHandler);
+      keydownHandler = null;
+    }
+    if (keyupHandler) {
+      document.removeEventListener('keyup', keyupHandler);
+      keyupHandler = null;
+    }
+  }
+
   wireBtn?.addEventListener('click', () => {
     state.mode = state.mode === 'wireDrawing' ? 'idle' : 'wireDrawing';
     updateButtons();
@@ -922,5 +933,6 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     clearSelection,
     undo,
     redo,
+    destroy,
   };
 }


### PR DESCRIPTION
## Summary
- add destroy method in canvas controller to unbind key handlers
- clear controllers on exit so R key does not trigger outside game or editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff4ee35708332a4d30d45777e4fec