### PR TITLE
Refine Google Drive auth handling

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -71,14 +71,23 @@ async function ensureDriveAuth() {
       };
       tokenClient.requestAccessToken(options);
     });
+    const hintOptions = user && user.email ? { hint: user.email } : {};
     try {
-      // Attempt silent access using prompt=none.
-      token = await requestToken({ prompt: 'none' });
+      // Attempt silent access with a relaxed prompt.
+      token = await requestToken({ prompt: '', ...hintOptions });
     } catch (e) {
-      try {
-        // Fallback to an interactive popup requesting consent.
-        token = await requestToken({ prompt: 'consent' });
-      } catch (e2) {
+      const err = (e.message || '').toLowerCase();
+      if (err.includes('login') || err.includes('idpiframe')) {
+        // User not logged in; do not open a popup.
+        throw new Error(t('googleLoginPrompt'));
+      } else if (err.includes('consent') || err.includes('interaction')) {
+        try {
+          // Only request an interactive popup when consent is required.
+          token = await requestToken({ prompt: 'consent', ...hintOptions });
+        } catch (e2) {
+          throw new Error(t('loginRequired'));
+        }
+      } else {
         throw new Error(t('loginRequired'));
       }
     }


### PR DESCRIPTION
## Summary
- Relax silent Drive token request and include account hint
- Branch on silent failure to avoid unwanted popups and only show consent when needed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b18ec5c2b88332b35f73deb15334d4