### PR TITLE
Refine Google Drive auth handling

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -69,16 +69,38 @@ async function ensureDriveAuth() {
           resolve(resp);
         }
       };
-      tokenClient.requestAccessToken(options);
-    });
-    try {
-      // Attempt silent access using prompt=none.
-      token = await requestToken({ prompt: 'none' });
-    } catch (e) {
       try {
-        // Fallback to an interactive popup requesting consent.
-        token = await requestToken({ prompt: 'consent' });
-      } catch (e2) {
+        tokenClient.requestAccessToken(options);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    const hintOptions = user && user.email ? { hint: user.email } : {};
+    try {
+      // Attempt silent access with a relaxed prompt. Fallback to 'none'
+      // if the empty prompt is not supported in this environment.
+      try {
+        token = await requestToken({ prompt: '', ...hintOptions });
+      } catch (eEmpty) {
+        if (eEmpty instanceof TypeError) {
+          token = await requestToken({ prompt: 'none', ...hintOptions });
+        } else {
+          throw eEmpty;
+        }
+      }
+    } catch (e) {
+      const err = (e.message || '').toLowerCase();
+      if (err.includes('login') || err.includes('idpiframe')) {
+        // User not logged in; do not open a popup.
+        throw new Error(t('googleLoginPrompt'));
+      } else if (err.includes('consent') || err.includes('interaction')) {
+        try {
+          // Only request an interactive popup when consent is required.
+          token = await requestToken({ prompt: 'consent', ...hintOptions });
+        } catch (e2) {
+          throw new Error(t('loginRequired'));
+        }
+      } else {
         throw new Error(t('loginRequired'));
       }
     }


### PR DESCRIPTION
## Summary
- Relax silent Drive token request and include account hint
- Branch on silent failure to avoid unwanted popups and only show consent when needed
- Fall back to `prompt: 'none'` when empty prompt is unsupported to prevent Drive load/save errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18ec5c2b88332b35f73deb15334d4