### PR TITLE
Add stage transition and intro animations

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -923,8 +923,19 @@ function showLevelIntro(level, callback) {
   });
 
   modal.style.display = "flex";
+  modal.classList.remove('show');
+  requestAnimationFrame(() => {
+    modal.classList.add('show');
+    // truth table row stagger animations
+    const rows = table.querySelectorAll('tr');
+    rows.forEach((r, i) => {
+      r.style.animationDelay = `${i * 60}ms`;
+    });
+  });
   modal.style.backgroundColor = "white";
-  document.getElementById("startLevelBtn").onclick = () => {
+  const startBtn = document.getElementById("startLevelBtn");
+  startBtn.onclick = () => {
+    modal.classList.remove('show');
     modal.style.display = "none";
     showStageTutorial(level, callback);  // 레벨별 튜토리얼 표시 후 시작
   };
@@ -978,6 +989,26 @@ function selectChapter(idx) {
   }
 }
 
+function handleStageSelection(card, level) {
+  const cards = stageListEl.querySelectorAll('.stageCard');
+  cards.forEach(c => {
+    if (c === card) {
+      c.classList.add('selected');
+    } else {
+      c.classList.add('fade-out');
+    }
+  });
+
+  setTimeout(() => {
+    returnToEditScreen();
+    startLevel(level);
+    chapterStageScreen.style.display = 'none';
+    gameScreen.style.display = 'flex';
+    document.body.classList.add('game-active');
+    cards.forEach(c => c.classList.remove('selected', 'fade-out'));
+  }, 200);
+}
+
 async function renderStageList(stageList) {
   await loadClearedLevelsFromDb();
   stageListEl.innerHTML = "";
@@ -1004,13 +1035,7 @@ async function renderStageList(stageList) {
         const check = createCheckmarkSvg();
         card.appendChild(check);
       }
-      card.onclick = () => {
-        returnToEditScreen();
-        startLevel(level);
-        chapterStageScreen.style.display = 'none';
-        gameScreen.style.display = 'flex';
-        document.body.classList.add('game-active');
-      };
+      card.onclick = () => handleStageSelection(card, level);
     }
     stageListEl.appendChild(card);
   });

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -551,6 +551,30 @@ html, body {
     to { opacity: 1; transform: scale(1); }
   }
 
+  /* --- Stage selection animations --- */
+  .stageCard {
+    transition: transform 200ms cubic-bezier(.2,.8,.2,1);
+    will-change: transform, opacity;
+  }
+
+  .stageCard.selected {
+    animation: cardSelect 200ms forwards;
+    z-index: 5;
+  }
+
+  @keyframes cardSelect {
+    0% { transform: scale(1); }
+    60% { transform: scale(1.04); }
+    100% { transform: scale(1); }
+  }
+
+  .stageCard.fade-out {
+    opacity: 0;
+    filter: blur(2px);
+    transition: opacity 200ms cubic-bezier(.2,.8,.2,1),
+                filter 200ms cubic-bezier(.2,.8,.2,1);
+  }
+
   .stageCard .checkmark {
     position: absolute;
     top: 8px;
@@ -2060,5 +2084,75 @@ html, body {
 
 #stageTutBtn:hover {
   transform: translateX(3px);
+}
+
+/* --- Level introduction modal animations --- */
+#levelIntroModal .modal-content {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: transform 200ms cubic-bezier(.2,.8,.2,1),
+              opacity 200ms cubic-bezier(.2,.8,.2,1);
+  will-change: transform, opacity;
+}
+
+#levelIntroModal.show .modal-content {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#levelIntroModal #introDesc {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: transform 180ms cubic-bezier(.2,.8,.2,1) 120ms,
+              opacity 180ms cubic-bezier(.2,.8,.2,1) 120ms;
+  will-change: transform, opacity;
+}
+
+#levelIntroModal.show #introDesc {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#levelIntroModal #truthTable tr {
+  opacity: 0;
+  transform: translateY(6px);
+  will-change: transform, opacity;
+}
+
+#levelIntroModal.show #truthTable tr {
+  animation: tableRowIn 180ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+
+@keyframes tableRowIn {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+#levelIntroModal #startLevelBtn {
+  transform: scale(0.98);
+  will-change: transform;
+}
+
+#levelIntroModal.show #startLevelBtn {
+  animation: startBtnPop 120ms cubic-bezier(.2,.8,.2,1) 300ms forwards;
+}
+
+@keyframes startBtnPop {
+  to { transform: scale(1); }
+}
+
+/* --- Button press feedback --- */
+button:active {
+  transform: scale(0.98);
+  filter: brightness(0.9);
+  transition: transform 80ms cubic-bezier(.4,0,.2,1),
+              filter 80ms cubic-bezier(.4,0,.2,1);
+}
+
+/* --- Reduced motion preference --- */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 


### PR DESCRIPTION
## Summary
- Animate stage card selection with scale and fade effects
- Introduce level intro modal with staggered truth table and button pop
- Add button press feedback and reduced motion fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a7f508148332b9ad6027aa146139