### PR TITLE
feat: add stage transition animations

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -10,6 +10,7 @@ let loginFromMainScreen = false;  // 메인 화면에서 로그인 여부 추적
 
 let lastSavedKey = null;
 let pendingClearedLevel = null;
+let lastSelectedStageCard = null;
 
 // Google Drive API initialization
 const GOOGLE_CLIENT_ID = '796428704868-sse38guap4kghi6ehbpv3tmh999hc9jm.apps.googleusercontent.com';
@@ -615,7 +616,7 @@ document.getElementById("backToLevelsBtn").onclick = () => {
 
 
 
-async function startLevel(level) {
+async function startLevel(level, card) {
   await stageDataPromise;
   await loadClearedLevelsFromDb();
   const [rows, cols] = levelGridSizes[level] || [6, 6];
@@ -635,7 +636,7 @@ async function startLevel(level) {
     nextMenuBtn.disabled = !(levelTitles[level + 1] && isLevelUnlocked(level + 1));
 
     collapseMenuBarForMobile();
-  });
+  }, card);
 }
 
 
@@ -883,7 +884,7 @@ firebase.database().ref("guestbook").on("value", (snapshot) => {
   }
 });
 */
-function showLevelIntro(level, callback) {
+function showLevelIntro(level, callback, card) {
   const modal = document.getElementById("levelIntroModal");
   const title = document.getElementById("introTitle");
   const desc = document.getElementById("introDesc");
@@ -922,9 +923,50 @@ function showLevelIntro(level, callback) {
     table.appendChild(tr);
   });
 
+  // reset animations
+  title.classList.remove('intro-title');
+  desc.classList.remove('intro-desc');
+  table.querySelectorAll('tr').forEach(tr => tr.classList.remove('intro-row'));
+
   modal.style.display = "flex";
   modal.style.backgroundColor = "white";
-  document.getElementById("startLevelBtn").onclick = () => {
+
+  if (card) {
+    const h3 = card.querySelector('h3');
+    const clone = h3.cloneNode(true);
+    const rect = h3.getBoundingClientRect();
+    clone.classList.add('flying-title');
+    clone.style.left = `${rect.left}px`;
+    clone.style.top = `${rect.top}px`;
+    document.body.appendChild(clone);
+    const destRect = title.getBoundingClientRect();
+    const dx = destRect.left - rect.left;
+    const dy = destRect.top - rect.top;
+    title.style.visibility = 'hidden';
+    requestAnimationFrame(() => {
+      clone.style.transform = `translate(${dx}px, ${dy}px)`;
+    });
+    clone.addEventListener('transitionend', () => {
+      clone.remove();
+      title.style.visibility = '';
+      title.classList.add('intro-title');
+    }, { once: true });
+  } else {
+    title.classList.add('intro-title');
+  }
+
+  desc.classList.add('intro-desc');
+  const rows = table.querySelectorAll('tr');
+  rows.forEach((tr, idx) => {
+    tr.style.setProperty('--row', idx);
+    tr.classList.add('intro-row');
+  });
+
+  const startBtn = document.getElementById("startLevelBtn");
+  startBtn.classList.remove('appear');
+  void startBtn.offsetWidth; // reflow
+  startBtn.classList.add('appear');
+  startBtn.onclick = () => {
     modal.style.display = "none";
     showStageTutorial(level, callback);  // 레벨별 튜토리얼 표시 후 시작
   };
@@ -978,6 +1020,28 @@ function selectChapter(idx) {
   }
 }
 
+function animateStageSelection(card) {
+  return new Promise(resolve => {
+    lastSelectedStageCard = card;
+    const cards = document.querySelectorAll('.stageCard');
+    cards.forEach(c => {
+      if (c === card) {
+        c.classList.add('selected');
+        setTimeout(() => c.classList.add('stabilize'), 120);
+      } else {
+        c.classList.add('fade-out');
+      }
+    });
+    const chapterList = document.getElementById('chapterList');
+    if (chapterList) chapterList.classList.add('fade-out');
+    setTimeout(() => {
+      cards.forEach(c => c.classList.remove('selected','stabilize','fade-out'));
+      if (chapterList) chapterList.classList.remove('fade-out');
+      resolve();
+    }, 200);
+  });
+}
+
 async function renderStageList(stageList) {
   await loadClearedLevelsFromDb();
   stageListEl.innerHTML = "";
@@ -1005,11 +1069,13 @@ async function renderStageList(stageList) {
         card.appendChild(check);
       }
       card.onclick = () => {
-        returnToEditScreen();
-        startLevel(level);
-        chapterStageScreen.style.display = 'none';
-        gameScreen.style.display = 'flex';
-        document.body.classList.add('game-active');
+        animateStageSelection(card).then(() => {
+          returnToEditScreen();
+          startLevel(level, card);
+          chapterStageScreen.style.display = 'none';
+          gameScreen.style.display = 'flex';
+          document.body.classList.add('game-active');
+        });
       };
     }
     stageListEl.appendChild(card);

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2062,3 +2062,66 @@ html, body {
   transform: translateX(3px);
 }
 
+.stageCard.selected {
+  z-index: 1;
+  transform: scale(1.04);
+  transition: transform 120ms cubic-bezier(.2,.8,.2,1);
+}
+.stageCard.selected.stabilize {
+  transform: scale(1);
+  transition: transform 80ms cubic-bezier(.2,.8,.2,1);
+}
+.stageCard.fade-out,
+#chapterList.fade-out {
+  opacity: 0;
+  filter: blur(2px);
+  transition: opacity 200ms cubic-bezier(.2,.8,.2,1), filter 200ms cubic-bezier(.2,.8,.2,1);
+}
+
+.flying-title {
+  position: absolute;
+  pointer-events: none;
+  z-index: 1000;
+  transition: transform 280ms cubic-bezier(.2,.8,.2,1);
+}
+
+.intro-title {
+  animation: introTitleIn 200ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+.intro-desc {
+  animation: introDescIn 180ms cubic-bezier(.2,.8,.2,1) 120ms forwards;
+}
+#truthTable tr.intro-row {
+  animation: introRowIn 180ms cubic-bezier(.2,.8,.2,1) forwards;
+  animation-delay: calc(var(--row) * 60ms);
+}
+#startLevelBtn.appear {
+  animation: startBtnIn 150ms cubic-bezier(.2,.8,.2,1) 300ms forwards;
+}
+#startLevelBtn:active {
+  transform: scale(0.98);
+  filter: brightness(0.9);
+  transition: transform 80ms cubic-bezier(.4,0,.2,1), filter 80ms cubic-bezier(.4,0,.2,1);
+}
+
+@keyframes introTitleIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes introDescIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes introRowIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes startBtnIn {
+  from { transform: scale(0.98); }
+  to { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+


### PR DESCRIPTION
## Summary
- animate stage card selection with scale and fade effects
- introduce level intro animations with shared element title transition
- support reduced-motion preferences for new transitions

## Testing
- `node --check script.v1.4.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a7f508148332b9ad6027aa146139