### PR TITLE
Add CSS animations for stage selection and intro modal

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -524,6 +524,7 @@ html, body {
     border: 1px solid #666;
     border-radius: 8px;
     background: #f5f5ff;
+    will-change: transform, opacity;
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -543,12 +544,30 @@ html, body {
     border-color: green;
   }
 
+  .stageCard.card-selected {
+    animation: cardSelect 200ms cubic-bezier(.2,.8,.2,1) forwards;
+  }
+
+  .fade-blur {
+    animation: fadeOutBlur 200ms forwards;
+  }
+
   .stageCard.card-enter {
     animation: cardIn 180ms forwards ease-out;
   }
 
   @keyframes cardIn {
     to { opacity: 1; transform: scale(1); }
+  }
+
+   @keyframes cardSelect {
+    0% { transform: scale(1); }
+    60% { transform: scale(1.04); }
+    100% { transform: scale(1); }
+  }
+
+   @keyframes fadeOutBlur {
+    to { opacity: 0; filter: blur(2px); }
   }
 
   .stageCard .checkmark {
@@ -2062,3 +2081,70 @@ html, body {
   transform: translateX(3px);
 }
 
+/* Level intro modal animations */
+#levelIntroModal {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms cubic-bezier(.2,.8,.2,1);
+}
+
+#levelIntroModal.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#levelIntroModal .modal-content {
+  transform: scale(0.96);
+  opacity: 0;
+  transition: transform 200ms cubic-bezier(.2,.8,.2,1), opacity 200ms cubic-bezier(.2,.8,.2,1);
+  will-change: transform, opacity;
+}
+
+#levelIntroModal.show .modal-content {
+  transform: scale(1);
+  opacity: 1;
+}
+
+#levelIntroModal.show #introTitle {
+  animation: introTitleIn 200ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+
+#levelIntroModal.show #introDesc {
+  animation: introDescIn 180ms cubic-bezier(.2,.8,.2,1) forwards 120ms;
+}
+
+#levelIntroModal.show #truthTable tr {
+  animation: truthRowIn 180ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+
+#levelIntroModal.show #startLevelBtn {
+  animation: startBtnPop 120ms cubic-bezier(.2,.8,.2,1) forwards 300ms;
+}
+
+@keyframes introTitleIn {
+  from { transform: translateY(8px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes introDescIn {
+  from { transform: translateY(8px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes truthRowIn {
+  from { transform: translateY(6px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes startBtnPop {
+  from { transform: scale(0.98); }
+  to { transform: scale(1); }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- style stage cards with selectable and fade-blur animations
- introduce animation effects for level intro modal with reduced motion support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a7f508148332b9ad6027aa146139