### PR TITLE
Ensure Drive OAuth flow recovers missing refresh tokens

### DIFF
--- a/oauth-callback.html
+++ b/oauth-callback.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>OAuth Callback</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f7f7f7;
+      color: #222;
+      margin: 0;
+      padding: 2rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <p>Authorization completed. You may close this window.</p>
+  <script>
+    (function () {
+      function parseParams() {
+        const query = window.location.search ? window.location.search.substring(1) : '';
+        const params = new URLSearchParams(query);
+        return {
+          code: params.get('code'),
+          state: params.get('state'),
+          error: params.get('error'),
+          error_description: params.get('error_description')
+        };
+      }
+
+      function notifyParent() {
+        const data = parseParams();
+        const message = {
+          type: 'drive_oauth_callback',
+          state: data.state || null
+        };
+        if (data.error) {
+          message.error = data.error;
+          if (data.error_description) {
+            message.error_description = data.error_description;
+          }
+        } else if (data.code) {
+          message.code = data.code;
+        }
+        const targetOrigin = window.location.origin;
+        if (window.opener && typeof window.opener.postMessage === 'function') {
+          window.opener.postMessage(message, targetOrigin);
+        } else if (window.parent && window.parent !== window && typeof window.parent.postMessage === 'function') {
+          window.parent.postMessage(message, targetOrigin);
+        }
+        setTimeout(() => window.close(), 150);
+      }
+
+      window.addEventListener('load', notifyParent);
+    })();
+  </script>
+</body>
+</html>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -14,9 +14,289 @@ let pendingClearedLevel = null;
 // Google Drive API initialization
 const GOOGLE_CLIENT_ID = '796428704868-sse38guap4kghi6ehbpv3tmh999hc9jm.apps.googleusercontent.com';
 const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.appdata';
+const DRIVE_REFRESH_COOKIE = 'drive_refresh_token';
+const DRIVE_REFRESH_COOKIE_MAX_AGE = 60 * 60 * 24 * 60; // 60 days
+const DRIVE_REFRESH_SESSION_FALLBACK = 'drive_refresh_token_fallback';
+const OAUTH_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+const OAUTH_REVOKE_ENDPOINT = 'https://oauth2.googleapis.com/revoke';
+const OAUTH_REDIRECT_URI = typeof window !== 'undefined'
+  ? new URL('oauth-callback.html', window.location.href).toString()
+  : '';
 let gapiInited = false;
 let gapiInitPromise = null;
 let tokenClient;
+let driveTokenExpiry = 0;
+
+function getCookieValue(name) {
+  if (typeof document === 'undefined' || !document.cookie) return null;
+  const prefix = `${name}=`;
+  const parts = document.cookie.split(';');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) {
+      try {
+        return decodeURIComponent(trimmed.substring(prefix.length));
+      } catch (err) {
+        console.warn('Failed to decode cookie value', err);
+        return trimmed.substring(prefix.length);
+      }
+    }
+  }
+  if (window.location && window.location.protocol !== 'https:' && typeof sessionStorage !== 'undefined') {
+    return sessionStorage.getItem(`${DRIVE_REFRESH_SESSION_FALLBACK}_${name}`);
+  }
+  return null;
+}
+
+function setSecureCookie(name, value, maxAgeSeconds) {
+  if (typeof document === 'undefined') return;
+  let cookie = `${name}=${encodeURIComponent(value)}; Path=/; SameSite=Strict`;
+  if (typeof maxAgeSeconds === 'number') {
+    cookie += `; Max-Age=${Math.max(0, Math.floor(maxAgeSeconds))}`;
+  }
+  const isHttps = window.location && window.location.protocol === 'https:';
+  if (isHttps) {
+    cookie += '; Secure';
+  }
+  document.cookie = cookie;
+  if (!isHttps && typeof sessionStorage !== 'undefined') {
+    try {
+      sessionStorage.setItem(`${DRIVE_REFRESH_SESSION_FALLBACK}_${name}`, value);
+    } catch (err) {
+      console.warn('Failed to persist refresh token fallback in sessionStorage', err);
+    }
+  }
+}
+
+function deleteCookie(name) {
+  if (typeof document === 'undefined') return;
+  const base = `${name}=; Path=/; Max-Age=0; SameSite=Strict`;
+  document.cookie = `${base}; Secure`;
+  document.cookie = base;
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.removeItem(`${DRIVE_REFRESH_SESSION_FALLBACK}_${name}`);
+  }
+}
+
+function applyDriveAccessToken(tokenData) {
+  if (!tokenData || !tokenData.access_token) {
+    throw new Error('Invalid token data');
+  }
+  const token = {
+    access_token: tokenData.access_token,
+    token_type: tokenData.token_type || 'Bearer',
+    scope: tokenData.scope || DRIVE_SCOPE
+  };
+  if (tokenData.expires_in) {
+    token.expires_in = tokenData.expires_in;
+  }
+  if (tokenData.expires_in) {
+    driveTokenExpiry = Date.now() + Math.max(0, (tokenData.expires_in - 60)) * 1000;
+  } else {
+    driveTokenExpiry = Date.now() + 5 * 60 * 1000; // default to 5 minutes
+  }
+  gapi.client.setToken(token);
+}
+
+async function exchangeCodeForTokens(code, codeVerifier) {
+  const body = new URLSearchParams({
+    client_id: GOOGLE_CLIENT_ID,
+    code,
+    code_verifier: codeVerifier,
+    grant_type: 'authorization_code',
+    redirect_uri: OAUTH_REDIRECT_URI
+  });
+  const res = await fetch(OAUTH_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString()
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = data && (data.error_description || data.error) ? data : null;
+    const message = err ? `${err.error || 'token_error'}: ${err.error_description || ''}` : 'token_exchange_failed';
+    throw new Error(message);
+  }
+  return data;
+}
+
+async function refreshAccessToken(refreshToken) {
+  const body = new URLSearchParams({
+    client_id: GOOGLE_CLIENT_ID,
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken
+  });
+  const res = await fetch(OAUTH_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString()
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = data && (data.error_description || data.error) ? data : null;
+    const message = err ? `${err.error || 'token_error'}: ${err.error_description || ''}` : 'refresh_failed';
+    throw new Error(message);
+  }
+  if (data.refresh_token) {
+    setSecureCookie(DRIVE_REFRESH_COOKIE, data.refresh_token, DRIVE_REFRESH_COOKIE_MAX_AGE);
+  } else {
+    console.warn('Drive refresh response did not include a refresh_token; future silent refreshes may fail.');
+  }
+  applyDriveAccessToken(data);
+  return data;
+}
+
+async function revokeDriveAccess(token) {
+  if (!token) return false;
+  try {
+    const response = await fetch(OAUTH_REVOKE_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ token }).toString()
+    });
+    if (!response.ok) {
+      console.warn('Failed to revoke Drive access token', await response.text().catch(() => ''));
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn('Error while revoking Drive access token', err);
+    return false;
+  }
+}
+
+function createRandomString(length) {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+  const array = new Uint8Array(length);
+  if (window.crypto && window.crypto.getRandomValues) {
+    window.crypto.getRandomValues(array);
+  } else {
+    for (let i = 0; i < length; i++) {
+      array[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  let result = '';
+  for (let i = 0; i < array.length; i++) {
+    result += charset.charAt(array[i] % charset.length);
+  }
+  return result;
+}
+
+async function pkceChallengeFromVerifier(verifier) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await window.crypto.subtle.digest('SHA-256', data);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return base64;
+}
+
+async function generatePkcePair() {
+  const codeVerifier = createRandomString(64);
+  const codeChallenge = await pkceChallengeFromVerifier(codeVerifier);
+  return { codeVerifier, codeChallenge };
+}
+
+function waitForOAuthCode(popup, state) {
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    const timeout = setTimeout(() => {
+      if (!resolved) {
+        cleanup();
+        reject(new Error('oauth_timeout'));
+      }
+    }, 120000);
+    const closeCheck = setInterval(() => {
+      if (!resolved && popup && popup.closed) {
+        cleanup();
+        reject(new Error('oauth_window_closed'));
+      }
+    }, 500);
+
+    function cleanup() {
+      resolved = true;
+      clearTimeout(timeout);
+      clearInterval(closeCheck);
+      window.removeEventListener('message', onMessage);
+      if (popup && !popup.closed) {
+        popup.close();
+      }
+    }
+
+    function onMessage(event) {
+      if (event.origin !== window.location.origin) return;
+      const data = event.data || {};
+      if (data.type !== 'drive_oauth_callback') return;
+      if (data.state !== state) return;
+      if (data.error) {
+        cleanup();
+        const errMsg = data.error_description || data.error;
+        reject(new Error(errMsg || 'oauth_error'));
+        return;
+      }
+      if (data.code) {
+        cleanup();
+        resolve(data.code);
+      }
+    }
+
+    window.addEventListener('message', onMessage);
+  });
+}
+
+async function obtainDriveTokensViaOAuth(options = {}) {
+  if (!window.crypto || !window.crypto.subtle) {
+    throw new Error('crypto_unsupported');
+  }
+  const { codeVerifier, codeChallenge } = await generatePkcePair();
+  const state = createRandomString(32);
+  sessionStorage.setItem(`drive_pkce_${state}`, codeVerifier);
+
+  const params = new URLSearchParams({
+    client_id: GOOGLE_CLIENT_ID,
+    redirect_uri: OAUTH_REDIRECT_URI,
+    response_type: 'code',
+    scope: DRIVE_SCOPE,
+    access_type: 'offline',
+    include_granted_scopes: 'true',
+    prompt: options.prompt || 'consent',
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256'
+  });
+  if (options && options.hint) {
+    params.set('login_hint', options.hint);
+  }
+
+  const popup = window.open(
+    `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`,
+    'drive_oauth',
+    'width=480,height=640'
+  );
+  if (!popup) {
+    sessionStorage.removeItem(`drive_pkce_${state}`);
+    throw new Error(t('loginRequired'));
+  }
+
+  try {
+    const code = await waitForOAuthCode(popup, state);
+    const storedVerifier = sessionStorage.getItem(`drive_pkce_${state}`) || codeVerifier;
+    sessionStorage.removeItem(`drive_pkce_${state}`);
+    const tokens = await exchangeCodeForTokens(code, storedVerifier);
+    if (tokens.refresh_token) {
+      setSecureCookie(DRIVE_REFRESH_COOKIE, tokens.refresh_token, DRIVE_REFRESH_COOKIE_MAX_AGE);
+    } else {
+      console.warn('Drive OAuth response did not include a refresh_token; revoking consent may be required to obtain one.');
+    }
+    applyDriveAccessToken(tokens);
+    return tokens;
+  } catch (err) {
+    sessionStorage.removeItem(`drive_pkce_${state}`);
+    throw err;
+  }
+}
 
 window.addEventListener('load', () => {
   if (window.gapi) {
@@ -37,6 +317,12 @@ window.addEventListener('load', () => {
       scope: DRIVE_SCOPE,
       callback: (tokenResponse) => {
         gapi.client.setToken(tokenResponse);
+        if (tokenResponse && tokenResponse.expires_in) {
+          driveTokenExpiry = Date.now() + Math.max(0, (tokenResponse.expires_in - 60)) * 1000;
+        }
+        if (tokenResponse && tokenResponse.refresh_token) {
+          setSecureCookie(DRIVE_REFRESH_COOKIE, tokenResponse.refresh_token, DRIVE_REFRESH_COOKIE_MAX_AGE);
+        }
         if (tokenClient.onResolve) {
           const cb = tokenClient.onResolve;
           tokenClient.onResolve = null;
@@ -59,9 +345,44 @@ async function ensureDriveAuth() {
       throw new Error(t('loginRequired'));
     }
   }
+  const now = Date.now();
   let token = gapi.client.getToken();
-  if (!token || !token.scope || !token.scope.includes(DRIVE_SCOPE)) {
-    if (!tokenClient) throw new Error(t('loginRequired'));
+  if (token && token.access_token && driveTokenExpiry - now > 5000 && token.scope && token.scope.includes(DRIVE_SCOPE)) {
+    return token;
+  }
+
+  const storedRefreshToken = getCookieValue(DRIVE_REFRESH_COOKIE);
+  if (storedRefreshToken) {
+    try {
+      await refreshAccessToken(storedRefreshToken);
+      return gapi.client.getToken();
+    } catch (refreshError) {
+      console.warn('Failed to refresh Drive access token', refreshError);
+      deleteCookie(DRIVE_REFRESH_COOKIE);
+    }
+  }
+
+  try {
+    const hintOptions = user && user.email ? { hint: user.email } : {};
+    let tokens = await obtainDriveTokensViaOAuth(hintOptions);
+    if (!tokens.refresh_token) {
+      console.warn('Re-attempting Drive OAuth after revoking previous grant to acquire a refresh_token.');
+      await revokeDriveAccess(tokens.access_token);
+      deleteCookie(DRIVE_REFRESH_COOKIE);
+      tokens = await obtainDriveTokensViaOAuth({ ...hintOptions, prompt: 'consent select_account' });
+      if (!tokens.refresh_token) {
+        console.warn('Drive OAuth still did not provide a refresh_token. Please revoke the app\'s Drive access from your Google Account settings and try again.');
+      }
+    }
+    if (tokens && tokens.refresh_token) {
+      setSecureCookie(DRIVE_REFRESH_COOKIE, tokens.refresh_token, DRIVE_REFRESH_COOKIE_MAX_AGE);
+    }
+    return gapi.client.getToken();
+  } catch (oauthError) {
+    console.error('Failed to obtain Drive refresh token via OAuth', oauthError);
+    if (!tokenClient) {
+      throw new Error(t('loginRequired'));
+    }
     const requestToken = (options) => new Promise((resolve, reject) => {
       tokenClient.onResolve = (resp) => {
         if (resp.error) {
@@ -78,8 +399,6 @@ async function ensureDriveAuth() {
     });
     const hintOptions = user && user.email ? { hint: user.email } : {};
     try {
-      // Attempt silent access with a relaxed prompt. Fallback to 'none'
-      // if the empty prompt is not supported in this environment.
       try {
         token = await requestToken({ prompt: 'none', ...hintOptions });
       } catch (eEmpty) {
@@ -92,11 +411,9 @@ async function ensureDriveAuth() {
     } catch (e) {
       const err = (e.message || '').toLowerCase();
       if (err.includes('login') || err.includes('idpiframe')) {
-        // User not logged in; do not open a popup.
         throw new Error(t('googleLoginPrompt'));
       } else if (err.includes('consent') || err.includes('interaction')) {
         try {
-          // Only request an interactive popup when consent is required.
           token = await requestToken({ prompt: 'consent', ...hintOptions });
         } catch (e2) {
           throw new Error(t('loginRequired'));
@@ -105,8 +422,8 @@ async function ensureDriveAuth() {
         throw new Error(t('loginRequired'));
       }
     }
+    return token;
   }
-  return token;
 }
 
 // Preload heavy canvas modules so they are ready when a stage begins.


### PR DESCRIPTION
## Summary
- add a Google OAuth revoke helper so the Drive PKCE flow can retry with forced consent when no refresh token is returned
- log clear warnings whenever Google omits a refresh token and allow the PKCE request to customize its prompt for the retry path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dddda109008332b4e822e8fc038534