### PR TITLE
Stop replaying stage card entry animation

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1328,6 +1328,9 @@ async function renderStageList(stageList) {
     const card = document.createElement('div');
     card.className = 'stageCard card-enter';
     card.style.animationDelay = `${idx * 40}ms`;
+    card.addEventListener('animationend', () => {
+      card.classList.remove('card-enter');
+    }, { once: true });
     card.dataset.stage = level;
     const title = levelTitles[level] ?? `Stage ${level}`;
     let name = title;


### PR DESCRIPTION
## Summary
- remove the stage card entry class after the animation completes so it doesn't trigger again when returning from the game screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df7c9c75e48332978e1a4b1d4dd7f1