### PR TITLE
Fix duplicate stage card animation when returning to level select

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -927,7 +927,7 @@ document.getElementById("toggleChapterList").onclick = () => {
   chapterListEl.classList.toggle('hidden');
 };
 
-document.getElementById("backToLevelsBtn").onclick = () => {
+document.getElementById("backToLevelsBtn").onclick = async () => {
   window.playController?.destroy?.();
   window.playController = null;
   window.playCircuit = null;
@@ -939,11 +939,10 @@ document.getElementById("backToLevelsBtn").onclick = () => {
     renderUserProblemList();
   } else {
     chapterStageScreen.style.display = "block";
-    loadClearedLevelsFromDb();
-    renderChapterList();
+    await renderChapterList();
     const chapter = chapterData[selectedChapterIndex];
     if (chapter && chapter.id !== 'user') {
-      renderStageList(chapter.stages);
+      await renderStageList(chapter.stages);
     }
   }
 };


### PR DESCRIPTION
## Summary
- make returning to the chapter screen await the chapter and stage list rendering
- prevent redundant animation triggers by avoiding overlapping renders when leaving the game screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7c9c75e48332978e1a4b1d4dd7f1