### PR TITLE
Fix duplicate stage card animations when returning to levels

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -927,7 +927,7 @@ document.getElementById("toggleChapterList").onclick = () => {
   chapterListEl.classList.toggle('hidden');
 };
 
-document.getElementById("backToLevelsBtn").onclick = () => {
+document.getElementById("backToLevelsBtn").onclick = async () => {
   window.playController?.destroy?.();
   window.playController = null;
   window.playCircuit = null;
@@ -938,13 +938,12 @@ document.getElementById("backToLevelsBtn").onclick = () => {
     userProblemsScreen.style.display = 'block';
     renderUserProblemList();
   } else {
-    chapterStageScreen.style.display = "block";
-    loadClearedLevelsFromDb();
-    renderChapterList();
+    await renderChapterList();
     const chapter = chapterData[selectedChapterIndex];
     if (chapter && chapter.id !== 'user') {
-      renderStageList(chapter.stages);
+      await renderStageList(chapter.stages);
     }
+    chapterStageScreen.style.display = "block";
   }
 };
 


### PR DESCRIPTION
## Summary
- wait for the chapter and stage lists to finish re-rendering before showing the chapter screen to prevent duplicate entry animations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df83c974b083328d2dba292bfdbd81