### PR TITLE
Change undo shortcut to Z

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -359,13 +359,13 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   if (keydownHandler) document.removeEventListener('keydown', keydownHandler);
   keydownHandler = e => {
     if (window.isScoring) {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') e.preventDefault();
+      if (e.key.toLowerCase() === 'z') e.preventDefault();
       else if (e.key.toLowerCase() === 'r') e.preventDefault();
       return;
     }
     const active = document.activeElement;
     if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) return;
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+    if (e.key.toLowerCase() === 'z') {
       e.preventDefault();
       if (e.shiftKey) redo();
       else undo();


### PR DESCRIPTION
## Summary
- update the undo keyboard shortcut to trigger on the Z key instead of Ctrl+Z
- keep Shift+Z mapped to redo to maintain existing functionality

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8be4fd74833287addb30e9d94543