### PR TITLE
Refactor grid helpers into grid module

### DIFF
--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -3,6 +3,13 @@ const DEFAULT_GRID_SIZE = 6;
 let gridRows = DEFAULT_GRID_SIZE;
 let gridCols = DEFAULT_GRID_SIZE;
 
+let playCircuit = null;
+let playController = null;
+let problemCircuit = null;
+let problemController = null;
+
+const circuitModifiedListeners = new Set();
+
 export function getGridRows() {
   return gridRows;
 }
@@ -18,6 +25,62 @@ export function getGridDimensions() {
 export function setGridDimensions(rows, cols) {
   gridRows = rows;
   gridCols = cols;
+}
+
+export function getPlayCircuit() {
+  return playCircuit;
+}
+
+export function getProblemCircuit() {
+  return problemCircuit;
+}
+
+export function getActiveCircuit() {
+  return problemCircuit || playCircuit;
+}
+
+export function getPlayController() {
+  return playController;
+}
+
+export function getProblemController() {
+  return problemController;
+}
+
+export function getActiveController() {
+  return problemController || playController;
+}
+
+export function destroyPlayContext() {
+  playController?.destroy?.();
+  playController = null;
+  playCircuit = null;
+}
+
+export function destroyProblemContext({ destroyController = true } = {}) {
+  if (destroyController) {
+    problemController?.destroy?.();
+  }
+  problemController = null;
+  problemCircuit = null;
+}
+
+export function onCircuitModified(listener) {
+  if (typeof listener !== 'function') return () => {};
+  circuitModifiedListeners.add(listener);
+  return () => {
+    circuitModifiedListeners.delete(listener);
+  };
+}
+
+function notifyCircuitModified() {
+  circuitModifiedListeners.forEach(listener => {
+    try {
+      listener();
+    } catch (err) {
+      console.error('Error in circuit modified listener', err);
+    }
+  });
 }
 
 export function adjustGridZoom(containerId = 'canvasContainer') {
@@ -97,14 +160,100 @@ export function setupGrid(containerId, rows, cols, paletteGroups) {
         }
       );
       if (prefix) {
-        window.problemCircuit = circuit;
-        window.problemController = controller;
+        destroyProblemContext({ destroyController: true });
+        problemCircuit = circuit;
+        problemController = controller;
       } else {
-        window.playCircuit = circuit;
-        window.playController = controller;
+        destroyPlayContext();
+        playCircuit = circuit;
+        playController = controller;
       }
       adjustGridZoom(containerId);
       return controller;
     });
   });
+}
+
+export function clearGrid() {
+  if (playCircuit) {
+    playCircuit.blocks = {};
+    playCircuit.wires = {};
+  }
+  if (problemCircuit) {
+    problemCircuit.blocks = {};
+    problemCircuit.wires = {};
+  }
+  markCircuitModified();
+  playController?.clearSelection?.();
+  problemController?.clearSelection?.();
+}
+
+export function clearWires() {
+  if (playCircuit) {
+    playCircuit.wires = {};
+  }
+  if (problemCircuit) {
+    problemCircuit.wires = {};
+  }
+  markCircuitModified();
+  playController?.clearSelection?.();
+  problemController?.clearSelection?.();
+}
+
+export function markCircuitModified() {
+  notifyCircuitModified();
+  playController?.syncPaletteWithCircuit?.();
+  problemController?.syncPaletteWithCircuit?.();
+}
+
+export function moveCircuit(dx, dy, { isProblemFixed = false } = {}) {
+  const controller = getActiveController();
+  if (!controller) return;
+  const hasSelection = controller.state?.selection;
+  let moved = false;
+  if (hasSelection) {
+    moved = controller.moveSelection?.(dy, dx);
+  } else {
+    if (controller === problemController && isProblemFixed) return;
+    moved = controller.moveCircuit(dx, dy);
+  }
+  if (moved) {
+    markCircuitModified();
+  }
+}
+
+export function setupMenuToggle() {
+  const menuBar = document.getElementById('menuBar');
+  const gameArea = document.getElementById('gameArea');
+  const toggleBtn = document.getElementById('menuToggleBtn');
+  if (!menuBar || !gameArea || !toggleBtn) return;
+
+  menuBar.addEventListener('transitionend', e => {
+    if (e.propertyName === 'width') {
+      adjustGridZoom();
+    }
+  });
+
+  toggleBtn.addEventListener('click', () => {
+    menuBar.classList.toggle('collapsed');
+    gameArea.classList.toggle('menu-collapsed');
+    adjustGridZoom();
+  });
+}
+
+export function collapseMenuBarForMobile({ onAfterCollapse } = {}) {
+  const menuBar = document.getElementById('menuBar');
+  const gameArea = document.getElementById('gameArea');
+  if (!menuBar || !gameArea) return;
+
+  if (window.matchMedia('(max-width: 1024px)').matches) {
+    menuBar.classList.add('collapsed');
+    gameArea.classList.add('menu-collapsed');
+  } else {
+    menuBar.classList.remove('collapsed');
+    gameArea.classList.remove('menu-collapsed');
+  }
+
+  adjustGridZoom();
+  onAfterCollapse?.();
 }

--- a/src/modules/levels.js
+++ b/src/modules/levels.js
@@ -1,4 +1,4 @@
-import { setupGrid, setGridDimensions } from './grid.js';
+import { setupGrid, setGridDimensions, destroyPlayContext } from './grid.js';
 import { getUsername } from './storage.js';
 
 const DEFAULT_GRID_SIZE = 6;
@@ -173,9 +173,7 @@ export async function returnToLevels({
   isCustomProblemActive = false,
   onClearCustomProblem
 } = {}) {
-  window.playController?.destroy?.();
-  window.playController = null;
-  window.playCircuit = null;
+  destroyPlayContext();
   document.body.classList.remove('game-active');
 
   const gameScreen = document.getElementById('gameScreen');


### PR DESCRIPTION
## Summary
- centralize grid state, controllers, and menu helper logic inside `src/modules/grid.js`
- update `src/main.js` to consume the new grid helpers and accessor functions without relying on window globals
- adjust `src/modules/levels.js` to tear down play contexts via the new grid utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e106ff46208332b2d465644b6b7612