### PR TITLE
Refactor Google auth UI handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,17 +1,12 @@
 // Entry point module coordinating Bitwiser features.
 // Placeholder imports ensure upcoming modules can hook into the bootstrap flow.
 import { initializeAuth } from './modules/auth.js';
+import { initializeAuthUI } from './modules/authUI.js';
 import {
   getUsername,
-  setUsername,
   getHintProgress,
   getAutoSaveSetting,
-  setAutoSaveSetting,
-  getGoogleDisplayName,
-  setGoogleDisplayName,
-  setGoogleEmail,
-  getGoogleNickname,
-  setGoogleNickname
+  setAutoSaveSetting
 } from './modules/storage.js';
 import * as guestbookModule from './modules/guestbook.js';
 import {
@@ -108,8 +103,6 @@ const {
 } = levelsModule;
 
 initializeAuth();
-
-let loginFromMainScreen = false;  // 메인 화면에서 로그인 여부 추적
 
 onCircuitModified(() => {
   invalidateProblemOutputs();
@@ -649,134 +642,6 @@ document.getElementById("gradeButton").addEventListener("click", () => {
   }
 });
 
-const modalGoogleLoginBtn = document.getElementById('modalGoogleLoginBtn');
-const usernameSubmitBtn = document.getElementById('usernameSubmit');
-const usernameModalHeading = document.querySelector('#usernameModal h2');
-const loginInfo = document.getElementById('loginInfo');
-const defaultModalGoogleLoginDisplay = modalGoogleLoginBtn ? modalGoogleLoginBtn.style.display : '';
-const defaultUsernameSubmitText = usernameSubmitBtn ? usernameSubmitBtn.textContent : '';
-const defaultUsernameModalHeading = usernameModalHeading ? usernameModalHeading.textContent : '';
-const defaultLoginInfoHtml = loginInfo ? loginInfo.innerHTML : '';
-
-function restoreUsernameModalDefaults() {
-  if (modalGoogleLoginBtn) modalGoogleLoginBtn.style.display = defaultModalGoogleLoginDisplay;
-  if (usernameSubmitBtn) {
-    usernameSubmitBtn.textContent = defaultUsernameSubmitText;
-    usernameSubmitBtn.onclick = onInitialUsernameSubmit;
-  }
-  if (usernameModalHeading) usernameModalHeading.textContent = defaultUsernameModalHeading;
-  if (loginInfo) loginInfo.innerHTML = defaultLoginInfoHtml;
-}
-
-function promptForUsername() {
-  const input = document.getElementById("usernameInput");
-  const errorDiv = document.getElementById("usernameError");
-  input.value = "";
-  errorDiv.textContent = "";
-  document.getElementById("usernameSubmit").onclick = onInitialUsernameSubmit;
-  document.getElementById("usernameModal").style.display = "flex";
-}
-
-function onInitialUsernameSubmit() {
-  const name = document.getElementById("usernameInput").value.trim();
-  const errorDiv = document.getElementById("usernameError");
-  if (!name) {
-    errorDiv.textContent = "닉네임을 입력해주세요.";
-    return;
-  }
-  db.ref("usernames").orderByValue().equalTo(name).once("value", snapshot => {
-    if (snapshot.exists()) {
-      errorDiv.textContent = "이미 사용 중인 닉네임입니다.";
-    } else {
-      const userId = db.ref("usernames").push().key;
-      db.ref(`usernames/${userId}`).set(name);
-      setUsername(name);
-      document.getElementById("usernameModal").style.display = "none";
-      document.getElementById("guestUsername").textContent = name;
-      loadClearedLevelsFromDb().then(maybeStartTutorial);
-    }
-  });
-}
-
-function assignGuestNickname() {
-  const attempt = () => {
-    const name = `Player${Math.floor(1000 + Math.random() * 9000)}`;
-    db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
-      if (snap.exists()) {
-        attempt();
-      } else {
-        const id = db.ref('usernames').push().key;
-        db.ref(`usernames/${id}`).set(name);
-        setUsername(name);
-        document.getElementById('guestUsername').textContent = name;
-        const loginUsernameEl = document.getElementById('loginUsername');
-        if (loginUsernameEl) loginUsernameEl.textContent = name;
-        loadClearedLevelsFromDb().then(maybeStartTutorial);
-      }
-    });
-  };
-  attempt();
-}
-
-function promptForGoogleNickname(oldName, uid) {
-  const input = document.getElementById("usernameInput");
-  const errorDiv = document.getElementById("usernameError");
-  const suggested = oldName || getGoogleDisplayName(uid) || "";
-  input.value = suggested;
-  errorDiv.textContent = "";
-  if (modalGoogleLoginBtn) modalGoogleLoginBtn.style.display = 'none';
-  if (usernameSubmitBtn) usernameSubmitBtn.textContent = '닉네임 등록';
-  if (usernameModalHeading) usernameModalHeading.textContent = 'Google 닉네임 등록';
-  if (loginInfo) {
-    loginInfo.innerHTML = t('loginInfoGoogle');
-  }
-  usernameSubmitBtn.onclick = () => onGoogleUsernameSubmit(oldName, uid);
-  document.getElementById("usernameModal").style.display = "flex";
-}
-
-function onGoogleUsernameSubmit(oldName, uid) {
-  const name = document.getElementById("usernameInput").value.trim();
-  const errorDiv = document.getElementById("usernameError");
-  if (!name) {
-    errorDiv.textContent = "닉네임을 입력해주세요.";
-    return;
-  }
-  db.ref('google').orderByChild('nickname').equalTo(name).once('value', gSnap => {
-    if (gSnap.exists()) {
-      errorDiv.textContent = "이미 있는 닉네임입니다.";
-      return;
-    }
-    db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
-      if (snap.exists() && name !== oldName) {
-        document.getElementById('usernameModal').style.display = 'none';
-        restoreUsernameModalDefaults();
-        showAccountClaimModal(name, oldName, uid);
-      } else {
-        if (!snap.exists()) {
-          const id = db.ref('usernames').push().key;
-          db.ref(`usernames/${id}`).set(name);
-        }
-        setUsername(name);
-        setGoogleNickname(uid, name);
-        db.ref(`google/${uid}`).set({ uid, nickname: name });
-        document.getElementById('usernameModal').style.display = 'none';
-        restoreUsernameModalDefaults();
-        document.getElementById('guestUsername').textContent = name;
-        loadClearedLevelsFromDb().then(() => {
-          if (oldName && oldName !== name) {
-            showMergeModal(oldName, name);
-          } else {
-            registerUsernameIfNeeded(name);
-            showOverallRanking();
-          }
-          maybeStartTutorial();
-        });
-      }
-    });
-  });
-}
-
-
 initializeRankingUI({
   viewRankingButtonSelector: '#viewRankingBtn',
   rankingListSelector: '#rankingList',
@@ -787,60 +652,6 @@ initializeRankingUI({
   getLevelBlockSet,
   alert
 });
-
-function setupGoogleAuth() {
-  const buttons = ['googleLoginBtn', 'modalGoogleLoginBtn']
-    .map(id => document.getElementById(id))
-    .filter(Boolean);
-  const usernameEl = document.getElementById('loginUsername');
-  const rankSection = document.getElementById('rankSection');
-  const overallRankEl = document.getElementById('overallRank');
-  const clearedCountEl = document.getElementById('clearedCount');
-  const guestPromptEl = document.getElementById('loginGuestPrompt');
-
-  if (!buttons.length) return Promise.resolve();
-
-  return new Promise(resolve => {
-    let done = false;
-    firebase.auth().onAuthStateChanged(user => {
-      buttons.forEach(btn => btn.textContent = user ? t('logoutBtn') : t('googleLoginBtn'));
-      const nickname = getUsername() || '';
-      if (usernameEl) usernameEl.textContent = nickname;
-      if (user) {
-        handleGoogleLogin(user);
-        document.getElementById('usernameModal').style.display = 'none';
-        if (rankSection) rankSection.style.display = 'block';
-        if (guestPromptEl) guestPromptEl.style.display = 'none';
-        fetchOverallStats(nickname).then(res => {
-          if (overallRankEl) overallRankEl.textContent = `#${res.rank}`;
-          if (clearedCountEl) clearedCountEl.textContent = res.cleared;
-        });
-      } else {
-        restoreUsernameModalDefaults();
-        if (rankSection) rankSection.style.display = 'none';
-        if (guestPromptEl) guestPromptEl.style.display = 'block';
-        if (!getUsername()) {
-          assignGuestNickname();
-        }
-      }
-      if (!done) { done = true; resolve(); }
-    });
-
-    buttons.forEach(btn => btn.addEventListener('click', () => {
-      loginFromMainScreen = (btn.id === 'googleLoginBtn');
-      const user = firebase.auth().currentUser;
-      if (user) {
-        firebase.auth().signOut();
-      } else {
-        const provider = new firebase.auth.GoogleAuthProvider();
-        firebase.auth().signInWithPopup(provider).catch(err => {
-          alert(t('loginFailed').replace('{code}', err.code).replace('{message}', err.message));
-          console.error(err);
-        });
-      }
-    }));
-  });
-}
 
 configureLevelModule({
   onLevelIntroComplete: () =>
@@ -893,7 +704,37 @@ document.addEventListener("DOMContentLoaded", () => {
   if (uname) document.getElementById("guestUsername").textContent = uname;
 
   initialTasks.push(showOverallRanking());  // 전체 랭킹 표시
-  initialTasks.push(setupGoogleAuth());
+  const authInitPromise = initializeAuthUI({
+    translate,
+    loadClearedLevelsFromDb,
+    maybeStartTutorial,
+    showOverallRanking,
+    fetchOverallStats,
+    fetchProgressSummary,
+    ids: {
+      googleLoginBtnId: 'googleLoginBtn',
+      modalGoogleLoginBtnId: 'modalGoogleLoginBtn',
+      usernameModalId: 'usernameModal',
+      usernameInputId: 'usernameInput',
+      usernameErrorId: 'usernameError',
+      usernameSubmitId: 'usernameSubmit',
+      usernameModalHeadingSelector: '#usernameModal h2',
+      loginInfoId: 'loginInfo',
+      guestUsernameId: 'guestUsername',
+      loginUsernameId: 'loginUsername',
+      rankSectionId: 'rankSection',
+      overallRankId: 'overallRank',
+      clearedCountId: 'clearedCount',
+      loginGuestPromptId: 'loginGuestPrompt',
+      mergeModalId: 'mergeModal',
+      mergeDetailsId: 'mergeDetails',
+      mergeConfirmBtnId: 'mergeConfirmBtn',
+      mergeCancelBtnId: 'mergeCancelBtn'
+    }
+  });
+  if (authInitPromise) {
+    initialTasks.push(authInitPromise);
+  }
 
   setupKeyToggles();
   setupMenuToggle();
@@ -914,184 +755,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
-function handleGoogleLogin(user) {
-  const uid = user.uid;
-  // 구글 계정의 기본 정보를 로컬에 저장해 둔다
-  if (user.displayName) {
-    setGoogleDisplayName(uid, user.displayName);
-  }
-  if (user.email) {
-    setGoogleEmail(uid, user.email);
-  }
-  const oldName = getUsername();
-  db.ref(`google/${uid}`).once('value').then(snap => {
-    const dbName = snap.exists() ? snap.val().nickname : null;
-    const localGoogleName = getGoogleNickname(uid);
-    if (dbName) {
-      // 항상 DB의 최신 닉네임을 사용한다
-      setGoogleNickname(uid, dbName);
-      applyGoogleNickname(dbName, oldName);
-    } else if (localGoogleName) {
-      // DB에 없으면 로컬에 저장된 이름을 등록한다
-      db.ref(`google/${uid}`).set({ uid, nickname: localGoogleName });
-      applyGoogleNickname(localGoogleName, oldName);
-    } else if (oldName && !loginFromMainScreen) {
-      // 기존 게스트 닉네임을 구글 계정에 연결하고 병합 여부를 묻는다
-      setGoogleNickname(uid, oldName);
-      db.ref(`google/${uid}`).set({ uid, nickname: oldName });
-      document.getElementById('guestUsername').textContent = oldName;
-      loadClearedLevelsFromDb().then(() => {
-        showMergeModal(oldName, oldName);
-        maybeStartTutorial();
-      });
-    } else {
-      promptForGoogleNickname(oldName, uid);
-    }
-  });
-}
-
-function applyGoogleNickname(name, oldName) {
-  if (oldName !== name) {
-    setUsername(name);
-    document.getElementById('guestUsername').textContent = name;
-    loadClearedLevelsFromDb().then(() => {
-      if (oldName) {
-        showMergeModal(oldName, name);
-      } else {
-        registerUsernameIfNeeded(name);
-      }
-      maybeStartTutorial();
-    });
-  } else {
-    registerUsernameIfNeeded(name);
-    loadClearedLevelsFromDb().then(maybeStartTutorial);
-  }
-}
-
-function registerUsernameIfNeeded(name) {
-  db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
-    if (!snap.exists()) {
-      const id = db.ref('usernames').push().key;
-      db.ref(`usernames/${id}`).set(name);
-    }
-  });
-}
-
-function removeUsername(name) {
-  db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
-    snap.forEach(ch => ch.ref.remove());
-  });
-}
-
-function showMergeModal(oldName, newName) {
-  const modal = document.getElementById('mergeModal');
-  const details = document.getElementById('mergeDetails');
-  const confirm = document.getElementById('mergeConfirmBtn');
-  const cancel = document.getElementById('mergeCancelBtn');
-  details.innerHTML = '<p>현재 로컬 진행 상황을 Google 계정과 병합하시겠습니까?</p>';
-  confirm.textContent = '네';
-  cancel.textContent = '제 계정이 아닙니다';
-  cancel.style.display = loginFromMainScreen ? 'none' : '';
-  modal.style.display = 'flex';
-  confirm.onclick = () => {
-    modal.style.display = 'none';
-    mergeProgress(oldName, newName).then(() => {
-      loadClearedLevelsFromDb();
-      showOverallRanking();
-    });
-  };
-  cancel.onclick = () => {
-    modal.style.display = 'none';
-    if (!loginFromMainScreen && firebase.auth().currentUser) {
-      promptForGoogleNickname(oldName, firebase.auth().currentUser.uid);
-    } else {
-      registerUsernameIfNeeded(newName);
-      loadClearedLevelsFromDb();
-      showOverallRanking();
-    }
-  };
-}
-
-function showAccountClaimModal(targetName, oldName, uid) {
-  fetchProgressSummary(targetName).then(prog => {
-    const modal = document.getElementById('mergeModal');
-    const details = document.getElementById('mergeDetails');
-    const confirm = document.getElementById('mergeConfirmBtn');
-    const cancel = document.getElementById('mergeCancelBtn');
-    details.innerHTML = `
-      <p><b>${targetName}</b> 닉네임의 진행 상황</p>
-      <ul>
-        <li>클리어 레벨 수: ${prog.cleared}</li>
-        <li>사용 블록 수: ${prog.blocks}</li>
-        <li>사용 도선 수: ${prog.wires}</li>
-      </ul>
-      <p>이 계정과 진행 상황을 합치겠습니까?</p>
-    `;
-    confirm.textContent = '네';
-    cancel.textContent = '제 계정이 아닙니다';
-    cancel.style.display = loginFromMainScreen ? 'none' : '';
-    modal.style.display = 'flex';
-    confirm.onclick = () => {
-      modal.style.display = 'none';
-      setUsername(targetName);
-      setGoogleNickname(uid, targetName);
-      db.ref(`google/${uid}`).set({ uid, nickname: targetName });
-      document.getElementById('guestUsername').textContent = targetName;
-      const after = () => {
-        loadClearedLevelsFromDb().then(() => {
-          showOverallRanking();
-          maybeStartTutorial();
-        });
-      };
-      if (oldName && oldName !== targetName) {
-        mergeProgress(oldName, targetName).then(after);
-      } else {
-        registerUsernameIfNeeded(targetName);
-        after();
-      }
-    };
-    cancel.onclick = () => {
-      modal.style.display = 'none';
-      if (!loginFromMainScreen) {
-        promptForGoogleNickname(oldName, uid);
-      }
-    };
-  });
-}
-
-function isRecordBetter(a, b) {
-  if (!b) return true;
-  const sumBlocks = e => Object.values(e.blockCounts || {}).reduce((s, x) => s + x, 0);
-  const aBlocks = sumBlocks(a), bBlocks = sumBlocks(b);
-  if (aBlocks !== bBlocks) return aBlocks < bBlocks;
-  if (a.usedWires !== b.usedWires) return a.usedWires < b.usedWires;
-  return new Date(a.timestamp) < new Date(b.timestamp);
-}
-
-function mergeProgress(oldName, newName) {
-  return db.ref('rankings').once('value').then(snap => {
-    const promises = [];
-    snap.forEach(levelSnap => {
-      let best = null;
-      const removeKeys = [];
-      levelSnap.forEach(recSnap => {
-        const v = recSnap.val();
-        if (v.nickname === oldName || v.nickname === newName) {
-          if (isRecordBetter(v, best)) best = { ...v };
-          removeKeys.push(recSnap.key);
-        }
-      });
-      removeKeys.forEach(k => promises.push(levelSnap.ref.child(k).remove()));
-      if (best) {
-        best.nickname = newName;
-        promises.push(levelSnap.ref.push(best));
-      }
-    });
-    removeUsername(oldName);
-    registerUsernameIfNeeded(newName);
-    return Promise.all(promises);
-  });
-}
 
 // 1) 모달과 버튼 요소 참조
 const viewSavedBtn = document.getElementById('viewSavedBtn');

--- a/src/modules/authUI.js
+++ b/src/modules/authUI.js
@@ -1,0 +1,548 @@
+import {
+  getUsername,
+  setUsername,
+  getGoogleDisplayName,
+  setGoogleDisplayName,
+  setGoogleEmail,
+  getGoogleNickname,
+  setGoogleNickname
+} from './storage.js';
+
+let translate = key => key;
+let loadClearedLevelsFromDb = () => Promise.resolve();
+let maybeStartTutorial = () => {};
+let showOverallRanking = () => {};
+let fetchOverallStats = () => Promise.resolve({ rank: '-', cleared: 0 });
+let fetchProgressSummary = () => Promise.resolve({ cleared: 0, blocks: 0, wires: 0 });
+
+const state = {
+  loginFromMainScreen: false
+};
+
+const elements = {
+  googleLoginBtn: null,
+  modalGoogleLoginBtn: null,
+  usernameModal: null,
+  usernameInput: null,
+  usernameError: null,
+  usernameSubmitBtn: null,
+  usernameModalHeading: null,
+  loginInfo: null,
+  guestUsername: null,
+  loginUsername: null,
+  rankSection: null,
+  overallRank: null,
+  clearedCount: null,
+  loginGuestPrompt: null,
+  mergeModal: null,
+  mergeDetails: null,
+  mergeConfirmBtn: null,
+  mergeCancelBtn: null
+};
+
+const defaults = {
+  modalGoogleLoginDisplay: '',
+  usernameSubmitText: '',
+  usernameModalHeading: '',
+  loginInfoHtml: ''
+};
+
+function getElement(id) {
+  if (!id || typeof document === 'undefined') return null;
+  return document.getElementById(id);
+}
+
+function setConfigFunctions(options = {}) {
+  if (typeof options.translate === 'function') {
+    translate = options.translate;
+  }
+  if (typeof options.loadClearedLevelsFromDb === 'function') {
+    loadClearedLevelsFromDb = options.loadClearedLevelsFromDb;
+  }
+  if (typeof options.maybeStartTutorial === 'function') {
+    maybeStartTutorial = options.maybeStartTutorial;
+  }
+  if (typeof options.showOverallRanking === 'function') {
+    showOverallRanking = options.showOverallRanking;
+  }
+  if (typeof options.fetchOverallStats === 'function') {
+    fetchOverallStats = options.fetchOverallStats;
+  }
+  if (typeof options.fetchProgressSummary === 'function') {
+    fetchProgressSummary = options.fetchProgressSummary;
+  }
+}
+
+function captureElements(ids = {}) {
+  elements.googleLoginBtn = getElement(ids.googleLoginBtnId);
+  elements.modalGoogleLoginBtn = getElement(ids.modalGoogleLoginBtnId);
+  elements.usernameModal = getElement(ids.usernameModalId);
+  elements.usernameInput = getElement(ids.usernameInputId);
+  elements.usernameError = getElement(ids.usernameErrorId);
+  elements.usernameSubmitBtn = getElement(ids.usernameSubmitId);
+  elements.loginInfo = getElement(ids.loginInfoId);
+  elements.guestUsername = getElement(ids.guestUsernameId);
+  elements.loginUsername = getElement(ids.loginUsernameId);
+  elements.rankSection = getElement(ids.rankSectionId);
+  elements.overallRank = getElement(ids.overallRankId);
+  elements.clearedCount = getElement(ids.clearedCountId);
+  elements.loginGuestPrompt = getElement(ids.loginGuestPromptId);
+  elements.mergeModal = getElement(ids.mergeModalId);
+  elements.mergeDetails = getElement(ids.mergeDetailsId);
+  elements.mergeConfirmBtn = getElement(ids.mergeConfirmBtnId);
+  elements.mergeCancelBtn = getElement(ids.mergeCancelBtnId);
+  if (ids.usernameModalHeadingSelector && typeof document !== 'undefined') {
+    elements.usernameModalHeading = document.querySelector(ids.usernameModalHeadingSelector);
+  } else {
+    elements.usernameModalHeading = null;
+  }
+
+  defaults.modalGoogleLoginDisplay = elements.modalGoogleLoginBtn ? elements.modalGoogleLoginBtn.style.display : '';
+  defaults.usernameSubmitText = elements.usernameSubmitBtn ? elements.usernameSubmitBtn.textContent : '';
+  defaults.usernameModalHeading = elements.usernameModalHeading ? elements.usernameModalHeading.textContent : '';
+  defaults.loginInfoHtml = elements.loginInfo ? elements.loginInfo.innerHTML : '';
+
+  if (elements.usernameSubmitBtn) {
+    elements.usernameSubmitBtn.onclick = onInitialUsernameSubmit;
+  }
+}
+
+function updateLoginButtonLabels(buttons, user) {
+  const label = user ? translate('logoutBtn') : translate('googleLoginBtn');
+  buttons.forEach(btn => {
+    if (btn) btn.textContent = label;
+  });
+}
+
+function showUsernameModal() {
+  if (elements.usernameModal) {
+    elements.usernameModal.style.display = 'flex';
+  }
+}
+
+function hideUsernameModal() {
+  if (elements.usernameModal) {
+    elements.usernameModal.style.display = 'none';
+  }
+}
+
+function setGuestUsernameText(value) {
+  if (elements.guestUsername) {
+    elements.guestUsername.textContent = value;
+  }
+}
+
+function setLoginUsernameText(value) {
+  if (elements.loginUsername) {
+    elements.loginUsername.textContent = value;
+  }
+}
+
+function showRankSection() {
+  if (elements.rankSection) {
+    elements.rankSection.style.display = 'block';
+  }
+}
+
+function hideRankSection() {
+  if (elements.rankSection) {
+    elements.rankSection.style.display = 'none';
+  }
+}
+
+function showGuestPrompt() {
+  if (elements.loginGuestPrompt) {
+    elements.loginGuestPrompt.style.display = 'block';
+  }
+}
+
+function hideGuestPrompt() {
+  if (elements.loginGuestPrompt) {
+    elements.loginGuestPrompt.style.display = 'none';
+  }
+}
+
+export function restoreUsernameModalDefaults() {
+  if (elements.modalGoogleLoginBtn) {
+    elements.modalGoogleLoginBtn.style.display = defaults.modalGoogleLoginDisplay;
+  }
+  if (elements.usernameSubmitBtn) {
+    elements.usernameSubmitBtn.textContent = defaults.usernameSubmitText;
+    elements.usernameSubmitBtn.onclick = onInitialUsernameSubmit;
+  }
+  if (elements.usernameModalHeading) {
+    elements.usernameModalHeading.textContent = defaults.usernameModalHeading;
+  }
+  if (elements.loginInfo) {
+    elements.loginInfo.innerHTML = defaults.loginInfoHtml;
+  }
+}
+
+function onInitialUsernameSubmit() {
+  const name = elements.usernameInput ? elements.usernameInput.value.trim() : '';
+  if (!elements.usernameError) return;
+  if (!name) {
+    elements.usernameError.textContent = '닉네임을 입력해주세요.';
+    return;
+  }
+  db.ref('usernames').orderByValue().equalTo(name).once('value', snapshot => {
+    if (snapshot.exists()) {
+      elements.usernameError.textContent = '이미 사용 중인 닉네임입니다.';
+    } else {
+      const userId = db.ref('usernames').push().key;
+      db.ref(`usernames/${userId}`).set(name);
+      setUsername(name);
+      hideUsernameModal();
+      setGuestUsernameText(name);
+      loadClearedLevelsFromDb().then(maybeStartTutorial);
+    }
+  });
+}
+
+function assignGuestNickname() {
+  const attempt = () => {
+    const name = `Player${Math.floor(1000 + Math.random() * 9000)}`;
+    db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
+      if (snap.exists()) {
+        attempt();
+      } else {
+        const id = db.ref('usernames').push().key;
+        db.ref(`usernames/${id}`).set(name);
+        setUsername(name);
+        setGuestUsernameText(name);
+        setLoginUsernameText(name);
+        loadClearedLevelsFromDb().then(maybeStartTutorial);
+      }
+    });
+  };
+  attempt();
+}
+
+function promptForGoogleNickname(oldName, uid) {
+  if (elements.usernameInput) {
+    const suggested = oldName || getGoogleDisplayName(uid) || '';
+    elements.usernameInput.value = suggested;
+  }
+  if (elements.usernameError) {
+    elements.usernameError.textContent = '';
+  }
+  if (elements.modalGoogleLoginBtn) {
+    elements.modalGoogleLoginBtn.style.display = 'none';
+  }
+  if (elements.usernameSubmitBtn) {
+    elements.usernameSubmitBtn.textContent = '닉네임 등록';
+    elements.usernameSubmitBtn.onclick = () => onGoogleUsernameSubmit(oldName, uid);
+  }
+  if (elements.usernameModalHeading) {
+    elements.usernameModalHeading.textContent = 'Google 닉네임 등록';
+  }
+  if (elements.loginInfo) {
+    elements.loginInfo.innerHTML = translate('loginInfoGoogle');
+  }
+  showUsernameModal();
+}
+
+function onGoogleUsernameSubmit(oldName, uid) {
+  const name = elements.usernameInput ? elements.usernameInput.value.trim() : '';
+  if (!elements.usernameError) return;
+  if (!name) {
+    elements.usernameError.textContent = '닉네임을 입력해주세요.';
+    return;
+  }
+  db.ref('google').orderByChild('nickname').equalTo(name).once('value', gSnap => {
+    if (gSnap.exists()) {
+      elements.usernameError.textContent = '이미 있는 닉네임입니다.';
+      return;
+    }
+    db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
+      if (snap.exists() && name !== oldName) {
+        hideUsernameModal();
+        restoreUsernameModalDefaults();
+        showAccountClaimModal(name, oldName, uid);
+      } else {
+        if (!snap.exists()) {
+          const id = db.ref('usernames').push().key;
+          db.ref(`usernames/${id}`).set(name);
+        }
+        setUsername(name);
+        setGoogleNickname(uid, name);
+        db.ref(`google/${uid}`).set({ uid, nickname: name });
+        hideUsernameModal();
+        restoreUsernameModalDefaults();
+        setGuestUsernameText(name);
+        loadClearedLevelsFromDb().then(() => {
+          if (oldName && oldName !== name) {
+            showMergeModal(oldName, name);
+          } else {
+            registerUsernameIfNeeded(name);
+            showOverallRanking();
+          }
+          maybeStartTutorial();
+        });
+      }
+    });
+  });
+}
+
+function registerUsernameIfNeeded(name) {
+  db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
+    if (!snap.exists()) {
+      const id = db.ref('usernames').push().key;
+      db.ref(`usernames/${id}`).set(name);
+    }
+  });
+}
+
+function removeUsername(name) {
+  db.ref('usernames').orderByValue().equalTo(name).once('value', snap => {
+    snap.forEach(ch => ch.ref.remove());
+  });
+}
+
+function showMergeModal(oldName, newName) {
+  if (!elements.mergeModal || !elements.mergeDetails || !elements.mergeConfirmBtn || !elements.mergeCancelBtn) {
+    return;
+  }
+  elements.mergeDetails.innerHTML = '<p>현재 로컬 진행 상황을 Google 계정과 병합하시겠습니까?</p>';
+  elements.mergeConfirmBtn.textContent = '네';
+  elements.mergeCancelBtn.textContent = '제 계정이 아닙니다';
+  elements.mergeCancelBtn.style.display = state.loginFromMainScreen ? 'none' : '';
+  elements.mergeModal.style.display = 'flex';
+  elements.mergeConfirmBtn.onclick = () => {
+    elements.mergeModal.style.display = 'none';
+    mergeProgress(oldName, newName).then(() => {
+      loadClearedLevelsFromDb();
+      showOverallRanking();
+    });
+  };
+  elements.mergeCancelBtn.onclick = () => {
+    elements.mergeModal.style.display = 'none';
+    if (!state.loginFromMainScreen && firebase.auth().currentUser) {
+      promptForGoogleNickname(oldName, firebase.auth().currentUser.uid);
+    } else {
+      registerUsernameIfNeeded(newName);
+      loadClearedLevelsFromDb();
+      showOverallRanking();
+    }
+  };
+}
+
+function showAccountClaimModal(targetName, oldName, uid) {
+  fetchProgressSummary(targetName).then(prog => {
+    if (!elements.mergeModal || !elements.mergeDetails || !elements.mergeConfirmBtn || !elements.mergeCancelBtn) {
+      return;
+    }
+    elements.mergeDetails.innerHTML = `
+      <p><b>${targetName}</b> 닉네임의 진행 상황</p>
+      <ul>
+        <li>클리어 레벨 수: ${prog.cleared}</li>
+        <li>사용 블록 수: ${prog.blocks}</li>
+        <li>사용 도선 수: ${prog.wires}</li>
+      </ul>
+      <p>이 계정과 진행 상황을 합치겠습니까?</p>
+    `;
+    elements.mergeConfirmBtn.textContent = '네';
+    elements.mergeCancelBtn.textContent = '제 계정이 아닙니다';
+    elements.mergeCancelBtn.style.display = state.loginFromMainScreen ? 'none' : '';
+    elements.mergeModal.style.display = 'flex';
+    elements.mergeConfirmBtn.onclick = () => {
+      elements.mergeModal.style.display = 'none';
+      setUsername(targetName);
+      setGoogleNickname(uid, targetName);
+      db.ref(`google/${uid}`).set({ uid, nickname: targetName });
+      setGuestUsernameText(targetName);
+      const after = () => {
+        loadClearedLevelsFromDb().then(() => {
+          showOverallRanking();
+          maybeStartTutorial();
+        });
+      };
+      if (oldName && oldName !== targetName) {
+        mergeProgress(oldName, targetName).then(after);
+      } else {
+        registerUsernameIfNeeded(targetName);
+        after();
+      }
+    };
+    elements.mergeCancelBtn.onclick = () => {
+      elements.mergeModal.style.display = 'none';
+      if (!state.loginFromMainScreen) {
+        promptForGoogleNickname(oldName, uid);
+      }
+    };
+  });
+}
+
+function isRecordBetter(a, b) {
+  if (!b) return true;
+  const sumBlocks = e => Object.values(e.blockCounts || {}).reduce((s, x) => s + x, 0);
+  const aBlocks = sumBlocks(a);
+  const bBlocks = sumBlocks(b);
+  if (aBlocks !== bBlocks) return aBlocks < bBlocks;
+  if (a.usedWires !== b.usedWires) return a.usedWires < b.usedWires;
+  return new Date(a.timestamp) < new Date(b.timestamp);
+}
+
+function mergeProgress(oldName, newName) {
+  return db.ref('rankings').once('value').then(snap => {
+    const promises = [];
+    snap.forEach(levelSnap => {
+      let best = null;
+      const removeKeys = [];
+      levelSnap.forEach(recSnap => {
+        const v = recSnap.val();
+        if (v.nickname === oldName || v.nickname === newName) {
+          if (isRecordBetter(v, best)) best = { ...v };
+          removeKeys.push(recSnap.key);
+        }
+      });
+      removeKeys.forEach(k => promises.push(levelSnap.ref.child(k).remove()));
+      if (best) {
+        best.nickname = newName;
+        promises.push(levelSnap.ref.push(best));
+      }
+    });
+    removeUsername(oldName);
+    registerUsernameIfNeeded(newName);
+    return Promise.all(promises);
+  });
+}
+
+function applyGoogleNickname(name, oldName) {
+  if (oldName !== name) {
+    setUsername(name);
+    setGuestUsernameText(name);
+    loadClearedLevelsFromDb().then(() => {
+      if (oldName) {
+        showMergeModal(oldName, name);
+      } else {
+        registerUsernameIfNeeded(name);
+      }
+      maybeStartTutorial();
+    });
+  } else {
+    registerUsernameIfNeeded(name);
+    loadClearedLevelsFromDb().then(maybeStartTutorial);
+  }
+}
+
+function handleGoogleLogin(user) {
+  const uid = user.uid;
+  if (user.displayName) {
+    setGoogleDisplayName(uid, user.displayName);
+  }
+  if (user.email) {
+    setGoogleEmail(uid, user.email);
+  }
+  const oldName = getUsername();
+  db.ref(`google/${uid}`).once('value').then(snap => {
+    const dbName = snap.exists() ? snap.val().nickname : null;
+    const localGoogleName = getGoogleNickname(uid);
+    if (dbName) {
+      setGoogleNickname(uid, dbName);
+      applyGoogleNickname(dbName, oldName);
+    } else if (localGoogleName) {
+      db.ref(`google/${uid}`).set({ uid, nickname: localGoogleName });
+      applyGoogleNickname(localGoogleName, oldName);
+    } else if (oldName && !state.loginFromMainScreen) {
+      setGoogleNickname(uid, oldName);
+      db.ref(`google/${uid}`).set({ uid, nickname: oldName });
+      setGuestUsernameText(oldName);
+      loadClearedLevelsFromDb().then(() => {
+        showMergeModal(oldName, oldName);
+        maybeStartTutorial();
+      });
+    } else {
+      promptForGoogleNickname(oldName, uid);
+    }
+  });
+}
+
+function handleAuthStateChange(buttons, user) {
+  updateLoginButtonLabels(buttons, user);
+  const nickname = getUsername() || '';
+  setLoginUsernameText(nickname);
+  if (user) {
+    handleGoogleLogin(user);
+    hideUsernameModal();
+    showRankSection();
+    hideGuestPrompt();
+    fetchOverallStats(nickname).then(res => {
+      if (elements.overallRank) {
+        elements.overallRank.textContent = `#${res.rank}`;
+      }
+      if (elements.clearedCount) {
+        elements.clearedCount.textContent = res.cleared;
+      }
+    });
+  } else {
+    restoreUsernameModalDefaults();
+    hideRankSection();
+    showGuestPrompt();
+    if (!getUsername()) {
+      assignGuestNickname();
+    }
+  }
+}
+
+function setupLoginButtonHandlers(buttons, ids = {}) {
+  buttons.forEach(btn => {
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      state.loginFromMainScreen = ids.googleLoginBtnId && btn.id === ids.googleLoginBtnId;
+      if (!state.loginFromMainScreen && btn === elements.googleLoginBtn) {
+        state.loginFromMainScreen = true;
+      }
+      const user = firebase.auth().currentUser;
+      if (user) {
+        firebase.auth().signOut();
+      } else {
+        const provider = new firebase.auth.GoogleAuthProvider();
+        firebase.auth().signInWithPopup(provider).catch(err => {
+          alert(translate('loginFailed').replace('{code}', err.code).replace('{message}', err.message));
+          console.error(err);
+        });
+      }
+    });
+  });
+}
+
+export function initializeAuthUI(options = {}) {
+  setConfigFunctions(options);
+  captureElements(options.ids || {});
+
+  const buttons = [elements.googleLoginBtn, elements.modalGoogleLoginBtn].filter(Boolean);
+  if (!buttons.length || typeof firebase === 'undefined' || !firebase.auth) {
+    return Promise.resolve();
+  }
+
+  setupLoginButtonHandlers(buttons, options.ids || {});
+
+  return new Promise(resolve => {
+    let done = false;
+    firebase.auth().onAuthStateChanged(user => {
+      handleAuthStateChange(buttons, user);
+      if (!done) {
+        done = true;
+        resolve();
+      }
+    });
+  });
+}
+
+export const __testing = {
+  setConfigFunctions,
+  captureElements,
+  assignGuestNickname,
+  promptForGoogleNickname,
+  onGoogleUsernameSubmit,
+  registerUsernameIfNeeded,
+  removeUsername,
+  showMergeModal,
+  showAccountClaimModal,
+  mergeProgress,
+  applyGoogleNickname,
+  handleGoogleLogin,
+  handleAuthStateChange,
+  setupLoginButtonHandlers
+};


### PR DESCRIPTION
## Summary
- move Google authentication UI helpers, nickname prompts, and merge modals into a dedicated `authUI` module that wires required DOM nodes and callbacks
- update `main.js` to import the new initializer, remove duplicated auth UI helpers, and initialize the auth UI with explicit dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e13f9021f08332bca5ef808af86588