### PR TITLE
Stabilize wire animation speed

### DIFF
--- a/src/canvas/engine.js
+++ b/src/canvas/engine.js
@@ -90,13 +90,20 @@ export function setWireFlows(circuit) {
 // Animation loop helper
 export function startEngine(ctx, circuit, renderer) {
   let phase = 0;
-  function tick() {
+  let lastTime = null;
+  const FLOW_SPEED = 60; // dash units per second (roughly 60fps equivalent)
+  function tick(time) {
     // Recompute circuit values every frame based solely on the
     // in-memory circuit model so block states stay in sync with
     // current connections and input values.
     evaluateCircuit(circuit);
-    // Slow wire flow animation by updating phase more gradually
-    phase = (phase + 1) % 40;
+    if (lastTime === null) {
+      lastTime = time;
+    }
+    const delta = time - lastTime;
+    lastTime = time;
+    // Advance the animation at a constant rate regardless of display refresh.
+    phase = (phase + (delta / 1000) * FLOW_SPEED) % 40;
     renderer(ctx, circuit, phase);
     requestAnimationFrame(tick);
   }


### PR DESCRIPTION
## Summary
- update the canvas engine to drive the wire dash phase using elapsed time
- keep the flow animation speed consistent across displays with different refresh rates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2049d27a483329ca5848e4f742858