### PR TITLE
Fix problem editor key toggles after grid reset

### DIFF
--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -138,6 +138,13 @@ export function setupGrid(
   const contentCanvas = document.getElementById(prefix ? `${prefix}ContentCanvas` : 'contentCanvas');
   const overlayCanvas = document.getElementById(prefix ? `${prefix}OverlayCanvas` : 'overlayCanvas');
 
+  if (prefix) {
+    // Clean up the existing problem controller before creating a new one.
+    destroyProblemContext({ destroyController: true });
+  } else {
+    destroyPlayContext();
+  }
+
   return import('../canvas/model.js').then(m => {
     const { makeCircuit } = m;
     return import('../canvas/controller.js').then(c => {
@@ -167,11 +174,9 @@ export function setupGrid(
         }
       );
       if (prefix) {
-        destroyProblemContext({ destroyController: true });
         problemCircuit = circuit;
         problemController = controller;
       } else {
-        destroyPlayContext();
         playCircuit = circuit;
         playController = controller;
       }


### PR DESCRIPTION
## Summary
- destroy the previous grid controller before creating a new one
- ensure keyboard listeners remain attached after applying new problem grid settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2565afc288332847068b38d0eef67