### PR TITLE
Persist canvas logical dimensions for zoom handling

### DIFF
--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -21,6 +21,11 @@ export function setupCanvas(canvas, width, height) {
   canvas.height = height * dpr;
   canvas.style.width = width + 'px';
   canvas.style.height = height + 'px';
+  if (canvas.dataset) {
+    canvas.dataset.baseWidth = String(width);
+    canvas.dataset.baseHeight = String(height);
+    canvas.dataset.dpr = String(dpr);
+  }
   const ctx = canvas.getContext('2d');
   ctx.scale(dpr, dpr);
   return ctx;

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -106,9 +106,24 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
 
   const firstCanvas = gridContainer.querySelector('canvas');
   if (!firstCanvas) return;
-  const dpr = window.devicePixelRatio || 1;
-  const baseWidth = firstCanvas.width / dpr;
-  const baseHeight = firstCanvas.height / dpr;
+
+  const datasetWidth = parseFloat(firstCanvas.dataset?.baseWidth);
+  const datasetHeight = parseFloat(firstCanvas.dataset?.baseHeight);
+  const datasetDpr = parseFloat(firstCanvas.dataset?.dpr);
+  let baseWidth;
+  let baseHeight;
+
+  if (Number.isFinite(datasetWidth) && Number.isFinite(datasetHeight)) {
+    baseWidth = datasetWidth;
+    baseHeight = datasetHeight;
+  } else if (Number.isFinite(datasetDpr) && datasetDpr > 0) {
+    baseWidth = firstCanvas.width / datasetDpr;
+    baseHeight = firstCanvas.height / datasetDpr;
+  } else {
+    const dpr = window.devicePixelRatio || 1;
+    baseWidth = firstCanvas.width / dpr;
+    baseHeight = firstCanvas.height / dpr;
+  }
 
   const scale = Math.min(
     availableWidth / baseWidth,


### PR DESCRIPTION
## Summary
- store the logical width, height, and DPR on canvases during setup
- reuse the stored logical dimensions when computing grid zoom so scaling remains stable across DPR changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25e4e0a288332b7706a52fa39f74e