### PR TITLE
Restrict problem creation until outputs computed

### DIFF
--- a/src/modules/problemEditor.js
+++ b/src/modules/problemEditor.js
@@ -15,6 +15,7 @@ let startCustomProblemHandler = null;
 let paletteGroupsBuilder = blocks => blocks;
 let previousScreen = null;
 let problemOutputsValid = false;
+let saveProblemButton = null;
 let activeCustomProblem = null;
 let activeCustomProblemKey = null;
 
@@ -24,12 +25,20 @@ function clamp(value, min, max, fallback) {
   return Math.min(max, Math.max(min, num));
 }
 
+function updateProblemSaveState() {
+  if (saveProblemButton) {
+    saveProblemButton.disabled = !problemOutputsValid;
+  }
+}
+
 export function invalidateProblemOutputs() {
   problemOutputsValid = false;
+  updateProblemSaveState();
 }
 
 function markProblemOutputsValid() {
   problemOutputsValid = true;
+  updateProblemSaveState();
 }
 
 function getElement(id) {
@@ -516,6 +525,8 @@ export function initializeProblemCreationFlow({
 
   const saveProblemBtn = getElement(ids.saveProblemBtnId);
   if (saveProblemBtn) {
+    saveProblemButton = saveProblemBtn;
+    updateProblemSaveState();
     saveProblemBtn.addEventListener('click', () =>
       showProblemSaveModal(problemSaveModal, problemTitleInput, problemDescInput, fixIOCheck)
     );


### PR DESCRIPTION
## Summary
- disable the custom problem save button until outputs are recomputed after the last circuit edit
- automatically invalidate the save button whenever the circuit changes and re-enable it after computing outputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2665b1fec833295cfc7598ca20fcb