### PR TITLE
Enforce recomputing outputs before publishing custom problems

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1318,6 +1318,11 @@ html, body {
   cursor: pointer;
 }
 
+.btn-back:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
   /* 사용자 문제 목록 */
   .problem-list {
   list-style: none;


### PR DESCRIPTION
## Summary
- disable the problem creation actions whenever the circuit changes until outputs are recomputed
- add translated tooltip messaging and disabled styling to guide users to run output calculation first

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e270e65dcc833289b2bc78dc2b64f6