### PR TITLE
Ensure problem creation requires fresh output computation

### DIFF
--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -164,6 +164,17 @@ export function setupGrid(
     const { makeCircuit } = m;
     return import('../canvas/controller.js').then(c => {
       const { createController } = c;
+      const { onCircuitModified: customCircuitModified, ...restOptions } = options;
+      const handleCircuitModified = () => {
+        markCircuitModified();
+        if (typeof customCircuitModified === 'function') {
+          try {
+            customCircuitModified();
+          } catch (err) {
+            console.error('Error in custom onCircuitModified callback', err);
+          }
+        }
+      };
       const circuit = makeCircuit(rows, cols);
       const controller = createController(
         { bgCanvas, contentCanvas, overlayCanvas },
@@ -185,7 +196,8 @@ export function setupGrid(
         {
           paletteGroups,
           panelWidth: 180,
-          ...options,
+          ...restOptions,
+          onCircuitModified: handleCircuitModified,
         }
       );
       if (prefix) {


### PR DESCRIPTION
## Summary
- notify problem output validation logic whenever the canvas controller records a structural change
- route circuit modification callbacks through the grid setup so custom handlers run alongside the built-in invalidation

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e2746d43508332808fd03211046cf2