### PR TITLE
Ensure custom problems require recent output computation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,6 @@ import {
   setupGrid,
   setGridDimensions,
   clearGrid,
-  markCircuitModified,
   moveCircuit,
   setupMenuToggle,
   collapseMenuBarForMobile,
@@ -103,8 +102,10 @@ const {
 
 initializeAuth();
 
-onCircuitModified(() => {
-  invalidateProblemOutputs();
+onCircuitModified(context => {
+  if (context === 'problem' || context === 'unknown') {
+    invalidateProblemOutputs();
+  }
 });
 
 const translate = typeof t === 'function' ? t : key => key;

--- a/src/modules/circuitShare.js
+++ b/src/modules/circuitShare.js
@@ -424,7 +424,7 @@ function applyCircuitData(data, key) {
   circuit.cols = data.circuit.cols;
   circuit.blocks = data.circuit.blocks || {};
   circuit.wires = data.circuit.wires || {};
-  markCircuitModified();
+  markCircuitModified(circuit);
   const controller = getActiveController();
   controller?.syncPaletteWithCircuit?.();
   controller?.clearSelection?.();

--- a/src/modules/problemEditor.js
+++ b/src/modules/problemEditor.js
@@ -156,7 +156,7 @@ export function initializeProblemEditorUI() {
   clearWires();
   setGridDimensions(rows, cols);
   initTestcaseTable();
-  markCircuitModified();
+  markCircuitModified('problem');
   adjustGridZoom('problemCanvasContainer');
   invalidateProblemOutputs();
 }


### PR DESCRIPTION
## Summary
- add circuit context tracking so modification listeners can differentiate between play and problem grids
- invalidate custom problem output calculations only when the problem circuit changes
- tag problem-editor initialization and imported circuits with the appropriate context for consistent button state handling

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e27aad2824833283d998976da73f88