### PR TITLE
Fix Control toggle on Apple platforms

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -225,7 +225,25 @@ const problemMoveRightBtn = document.getElementById('problemMoveRightBtn');
 let grid;
 
 function simulateKey(key, type = 'keydown') {
-  const ev = new KeyboardEvent(type, { key, bubbles: true });
+  const actualKey =
+    key === 'Control' && isApplePlatform
+      ? 'Meta'
+      : key;
+  const eventInit = {
+    key: actualKey,
+    bubbles: true,
+    cancelable: true
+  };
+
+  if (actualKey === 'Meta') {
+    eventInit.metaKey = true;
+  } else if (actualKey === 'Control') {
+    eventInit.ctrlKey = true;
+  } else if (actualKey === 'Shift') {
+    eventInit.shiftKey = true;
+  }
+
+  const ev = new KeyboardEvent(type, eventInit);
   document.dispatchEvent(ev);
 }
 


### PR DESCRIPTION
## Summary
- send the Meta key when the Control toggle button is used on Apple devices
- include modifier flags when synthesising keyboard events to match native behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e27e22fcf48332bc115d8763de87b9