### PR TITLE
Add glass panel styling to user problem screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,8 +159,8 @@
       </div>
     </div>
 
-    <div id="problem-screen" class="screen" style="display:none; padding:0;">
-      <div style="display:flex; gap:1rem; align-items:flex-start; justify-content:flex-start; width:fit-content;margin:auto;">
+    <div id="problem-screen" class="screen" style="display:none;">
+      <div class="panel-overlay problem-screen-panel">
         <div id="problemCanvasContainer" style="position:relative;margin:auto;">
           <canvas id="problemBgCanvas" style="position:relative;"></canvas>
           <canvas id="problemContentCanvas"></canvas>
@@ -258,10 +258,12 @@
       <button id="toggleChapterList" class="btn-toggle" style='display: none'>☰</button>
     </div>
     <div id="user-problems-screen" class="screen" style="display:none;">
-      <button id="backToChapterFromUserProblems" class="btn-back">← 챕터로</button>
-      <h1 id="userProblemsTitle">📝 사용자 문제</h1>
-      <ul id="userProblemList" class="problem-list" style="margin:0 auto;"></ul>
-      <button id="openProblemCreatorBtn" class="btn-primary">문제 만들기</button>
+      <div class="panel-overlay user-problems-panel">
+        <button id="backToChapterFromUserProblems" class="btn-back">← 챕터로</button>
+        <h1 id="userProblemsTitle">📝 사용자 문제</h1>
+        <ul id="userProblemList" class="problem-list" style="margin:0 auto;"></ul>
+        <button id="openProblemCreatorBtn" class="btn-primary">문제 만들기</button>
+      </div>
     </div>
     <div id="rankingModal" class="modal" style="display:none;">
       <div class="modal-content">

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -801,6 +801,46 @@ html, body {
     box-sizing: border-box;
   }
 
+  #problem-screen,
+  #user-problems-screen {
+    background: transparent;
+    padding: 2rem;
+  }
+
+  .panel-overlay {
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(10px);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+    padding: 2rem 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    width: min(100%, 1200px);
+    margin: 0 auto;
+    box-sizing: border-box;
+  }
+
+  .problem-screen-panel {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+  }
+
+  .problem-screen-panel #problemCanvasContainer {
+    margin: 0 auto;
+  }
+
+  .user-problems-panel {
+    align-items: center;
+  }
+
+  .user-problems-panel .btn-back {
+    align-self: flex-start;
+  }
+
 #mainScreen,
 #loginArea{
   width: 320px;


### PR DESCRIPTION
## Summary
- wrap the user problem list and creation views with a translucent panel container
- add shared glassmorphism-inspired panel styling for the custom problem interfaces

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e328999724833281ae184ddf71df46