### PR TITLE
Ensure problem screen layout stays horizontal on narrow viewports

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -829,6 +829,22 @@ html, body {
     flex-wrap: wrap;
   }
 
+  @media (max-width: 1200px) {
+    .problem-screen-panel {
+      flex-wrap: nowrap;
+      justify-content: flex-start;
+      align-items: stretch;
+      width: max-content;
+      max-width: none;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    #problem-screen {
+      overflow-x: auto;
+    }
+  }
+
   .problem-screen-panel #problemCanvasContainer {
     margin: 0 auto;
   }


### PR DESCRIPTION
## Summary
- keep the problem canvas and right panel aligned horizontally by preventing wrapping on narrow screens
- allow the problem screen panel to exceed the viewport width while enabling horizontal scrolling for access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3ae3fa51c833294e6e4298e828219