### PR TITLE
Replace circuit save modals with toast notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,25 +421,7 @@
         </div>
       </div>
     </div>
-    <!-- GIF 생성 중 로딩 화면 -->
-    <div id="gifLoadingModal" class="modal" style="display:none;">
-      <div class="modal-content">
-        <p id="gifLoadingText">GIF 생성중...</p>
-        <div id="saveProgressContainer" style="display:none;">
-          <div id="saveProgressBar"></div>
-        </div>
-      </div>
-    </div>
-    <!-- 회로 저장 완료 모달 -->
-    <div id="circuitSavedModal" class="modal" style="display:none;">
-      <div class="modal-content">
-        <p id="circuitSaved"></p>
-        <div class="modal-buttons">
-          <button id="savedShareBtn"></button>
-          <button id="savedNextBtn"></button>
-        </div>
-      </div>
-    </div>
+    <div id="toastContainer" class="toast-container" aria-live="polite" aria-atomic="true"></div>
     <div id="clearedModal" class="modal" style="display: none;">
       <div class="modal-content">
         <h2 id="clearedTitle">스테이지 <span id="clearedStageNumber"></span> 클리어!</h2>

--- a/src/modules/toast.js
+++ b/src/modules/toast.js
@@ -1,0 +1,187 @@
+export function createToastManager(container) {
+  const toastContainer = ensureContainer(container);
+  const toasts = new Map();
+
+  function show(options = {}) {
+    const {
+      id = `toast-${Date.now()}`,
+      message = '',
+      autoHide = false,
+      duration = 4000,
+      spinner = false,
+      progress = null,
+      actions = [],
+      dismissible = true,
+      onClose
+    } = options;
+
+    if (toasts.has(id)) {
+      remove(id, { silent: true });
+    }
+
+    const toastEl = document.createElement('div');
+    toastEl.className = 'toast';
+
+    if (dismissible) {
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'toast-close';
+      closeBtn.type = 'button';
+      closeBtn.setAttribute('aria-label', 'Close');
+      closeBtn.innerHTML = '&times;';
+      closeBtn.addEventListener('click', () => remove(id));
+      toastEl.appendChild(closeBtn);
+    }
+
+    const bodyEl = document.createElement('div');
+    bodyEl.className = 'toast-body';
+
+    const spinnerEl = document.createElement('div');
+    spinnerEl.className = 'toast-spinner';
+    if (!spinner) {
+      spinnerEl.style.display = 'none';
+    }
+
+    const contentEl = document.createElement('div');
+    contentEl.className = 'toast-content';
+
+    const messageEl = document.createElement('div');
+    messageEl.className = 'toast-message';
+    messageEl.textContent = message;
+
+    const progressEl = document.createElement('div');
+    progressEl.className = 'toast-progress';
+    const progressBarEl = document.createElement('div');
+    progressBarEl.className = 'toast-progress-bar';
+    progressEl.appendChild(progressBarEl);
+    if (progress == null) {
+      progressEl.style.display = 'none';
+    } else {
+      progressBarEl.style.width = `${clampPercent(progress)}%`;
+    }
+
+    const actionsEl = document.createElement('div');
+    actionsEl.className = 'toast-actions';
+    if (!actions || !actions.length) {
+      actionsEl.style.display = 'none';
+    } else {
+      actions.forEach(action => {
+        if (!action || typeof action.label === 'undefined') return;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = String(action.label);
+        btn.addEventListener('click', () => {
+          try {
+            if (typeof action.onClick === 'function') {
+              action.onClick();
+            }
+          } finally {
+            if (action.closeOnClick !== false) {
+              remove(id);
+            }
+          }
+        });
+        actionsEl.appendChild(btn);
+      });
+    }
+
+    bodyEl.appendChild(spinnerEl);
+    contentEl.appendChild(messageEl);
+    contentEl.appendChild(progressEl);
+    contentEl.appendChild(actionsEl);
+    bodyEl.appendChild(contentEl);
+
+    toastEl.appendChild(bodyEl);
+    toastContainer.appendChild(toastEl);
+
+    const toastRecord = {
+      element: toastEl,
+      messageEl,
+      progressEl,
+      progressBarEl,
+      spinnerEl,
+      onClose,
+      timeoutId: null
+    };
+
+    if (autoHide) {
+      const delay = typeof duration === 'number' && duration > 0 ? duration : 4000;
+      toastRecord.timeoutId = window.setTimeout(() => remove(id), delay);
+    }
+
+    toasts.set(id, toastRecord);
+    return id;
+  }
+
+  function update(id, updates = {}) {
+    const toast = toasts.get(id);
+    if (!toast) return;
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'message') && toast.messageEl) {
+      toast.messageEl.textContent = String(updates.message ?? '');
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'progress') && toast.progressEl && toast.progressBarEl) {
+      const value = updates.progress;
+      if (value == null || Number.isNaN(value)) {
+        toast.progressEl.style.display = 'none';
+      } else {
+        toast.progressEl.style.display = '';
+        toast.progressBarEl.style.width = `${clampPercent(value)}%`;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'spinner') && toast.spinnerEl) {
+      const showSpinner = Boolean(updates.spinner);
+      toast.spinnerEl.style.display = showSpinner ? '' : 'none';
+    }
+  }
+
+  function remove(id, { silent = false } = {}) {
+    const toast = toasts.get(id);
+    if (!toast) return false;
+    toasts.delete(id);
+
+    if (toast.timeoutId) {
+      window.clearTimeout(toast.timeoutId);
+    }
+
+    const { element, onClose } = toast;
+    element.dataset.state = 'closing';
+
+    let removed = false;
+    const cleanup = () => {
+      if (removed) return;
+      removed = true;
+      element.remove();
+      if (!silent && typeof onClose === 'function') {
+        onClose();
+      }
+    };
+
+    element.addEventListener('animationend', cleanup, { once: true });
+    window.setTimeout(cleanup, 220);
+
+    return true;
+  }
+
+  return { show, update, remove };
+}
+
+function clampPercent(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.min(100, Math.max(0, num));
+}
+
+function ensureContainer(existingContainer) {
+  if (existingContainer && existingContainer instanceof HTMLElement) {
+    return existingContainer;
+  }
+  const container = document.createElement('div');
+  container.id = 'toastContainer';
+  container.className = 'toast-container';
+  container.setAttribute('aria-live', 'polite');
+  container.setAttribute('aria-atomic', 'true');
+  document.body.appendChild(container);
+  return container;
+}

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2130,3 +2130,165 @@ html, body {
   transform: translateX(3px);
 }
 
+.toast-container {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 2100;
+  max-width: min(360px, calc(100vw - 2.5rem));
+  pointer-events: none;
+}
+
+.toast {
+  background: rgba(28, 28, 30, 0.94);
+  color: #fff;
+  border-radius: 0.9rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2);
+  padding: 1rem 1.1rem 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  pointer-events: auto;
+  animation: toast-in 180ms ease-out;
+  position: relative;
+}
+
+.toast[data-state="closing"] {
+  animation: toast-out 140ms ease-in forwards;
+}
+
+.toast-body {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.toast-spinner {
+  flex: none;
+  width: 1.2rem;
+  height: 1.2rem;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: toast-spin 1s linear infinite;
+  margin-top: 0.1rem;
+}
+
+.toast-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.toast-message {
+  line-height: 1.45;
+  word-break: keep-all;
+}
+
+.toast-progress {
+  height: 0.35rem;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.toast-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #00c6ff, #0078ff);
+  transition: width 160ms ease-out;
+}
+
+.toast-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.toast-actions button {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.toast-actions button:hover,
+.toast-actions button:focus {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.toast-close {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 1.1rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.toast-close:hover,
+.toast-close:focus {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+}
+
+@keyframes toast-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 600px) {
+  .toast-container {
+    right: 0.75rem;
+    bottom: 0.75rem;
+    max-width: calc(100vw - 1.5rem);
+  }
+
+  .toast {
+    border-radius: 0.8rem;
+    padding: 0.9rem 1rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- replace the GIF loading and circuit saved modals with a reusable toast container
- add a toast manager module and wire GIF export, circuit saves, and auto-save flows to use progressive toast notifications
- restyle the UI with toast-specific CSS and surface share/continue actions through the new notifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3dbd3c8d08332b9fd5449426679bf