### PR TITLE
Enable scrolling for user problem list

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1540,6 +1540,7 @@ html, body {
   .user-problems-panel {
     align-items: stretch;
     max-height: calc(100vh - 4rem);
+    overflow: hidden;
   }
 
   .user-problems-content {
@@ -1547,6 +1548,9 @@ html, body {
     gap: 1.5rem;
     width: 100%;
     align-items: flex-start;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .user-problems-sidebar {
@@ -1564,6 +1568,8 @@ html, body {
     width: 100%;
     display: flex;
     justify-content: center;
+    align-items: stretch;
+    overflow: hidden;
   }
 
   /* 사용자 문제 목록 */
@@ -1578,6 +1584,7 @@ html, body {
     overflow-y: auto;
     padding-right: 0.25rem;
     min-height: 0;
+    max-height: 100%;
   }
 
   .problem-item {


### PR DESCRIPTION
## Summary
- allow the user problem list panel to occupy remaining height of the screen
- ensure the list container and panel clip overflow so the list scrolls inside the panel
- keep the list itself constrained to the available height while enabling vertical scrolling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4c03a3f2483328706730eb76ffbf5