### PR TITLE
Add inline difficulty filters for user problems

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,27 +295,59 @@
                 <button type="button" class="user-problem-filter-toggle" data-user-problem-toggle="onlyPopular" aria-pressed="false">
                   ♥ <span id="userProblemFilterPopular">인기</span>
                 </button>
-                <details id="userProblemAdvancedFilters" class="user-problems-advanced">
-                  <summary id="userProblemAdvancedSummary">⚙ 필터</summary>
-                  <div class="user-problems-advanced-grid">
-                    <label id="userProblemFilterGridLabel" for="userProblemFilterGrid">그리드 크기</label>
-                    <select id="userProblemFilterGrid">
-                      <option id="userProblemFilterGridAnyOption" value="all">전체</option>
-                    </select>
-                    <label id="userProblemFilterDifficultyLabel" for="userProblemFilterDifficulty">난이도</label>
-                    <select id="userProblemFilterDifficulty">
-                      <option id="userProblemFilterDifficultyAll" value="all">전체</option>
-                      <option id="userProblemFilterDifficultyEasy" value="easy">쉬움</option>
-                      <option id="userProblemFilterDifficultyNormal" value="normal">보통</option>
-                      <option id="userProblemFilterDifficultyHard" value="hard">어려움</option>
-                    </select>
-                    <label id="userProblemFilterMinLikesLabel" for="userProblemMinLikes">좋아요 수 이상</label>
-                    <input id="userProblemMinLikes" type="number" min="0" inputmode="numeric" placeholder="0" />
-                    <label id="userProblemFilterCreatorLabel" for="userProblemCreatorFilter">제작자</label>
-                    <input id="userProblemCreatorFilter" type="text" placeholder="예: garden" />
-                    <button id="userProblemResetFilters" type="button" class="user-problem-reset">필터 초기화</button>
+                <div class="user-problem-difficulty-group" role="group" aria-labelledby="userProblemFilterDifficultyLabel">
+                  <span id="userProblemFilterDifficultyLabel" class="user-problem-difficulty-label">난이도</span>
+                  <div class="user-problem-difficulty-buttons">
+                    <button
+                      type="button"
+                      class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                      data-user-problem-difficulty="all"
+                      aria-pressed="true"
+                    >
+                      <span id="userProblemFilterDifficultyAll">전체</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                      data-user-problem-difficulty="1"
+                      aria-pressed="false"
+                    >
+                      1
+                    </button>
+                    <button
+                      type="button"
+                      class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                      data-user-problem-difficulty="2"
+                      aria-pressed="false"
+                    >
+                      2
+                    </button>
+                    <button
+                      type="button"
+                      class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                      data-user-problem-difficulty="3"
+                      aria-pressed="false"
+                    >
+                      3
+                    </button>
+                    <button
+                      type="button"
+                      class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                      data-user-problem-difficulty="4"
+                      aria-pressed="false"
+                    >
+                      4
+                    </button>
+                    <button
+                      type="button"
+                      class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                      data-user-problem-difficulty="5"
+                      aria-pressed="false"
+                    >
+                      5
+                    </button>
                   </div>
-                </details>
+                </div>
               </div>
               <div id="userProblemResultSummary" class="user-problem-result-summary"></div>
             </div>

--- a/src/modules/problemEditor.js
+++ b/src/modules/problemEditor.js
@@ -783,10 +783,25 @@ function normalizeText(text) {
 
 function matchesDifficultyFilter(value, filter) {
   if (filter === 'all') return true;
-  if (filter === 'easy') return value <= 2;
-  if (filter === 'normal') return value === 3;
-  if (filter === 'hard') return value >= 4;
-  return true;
+
+  const numericFilter = Number.parseInt(filter, 10);
+  if (Number.isNaN(numericFilter)) return true;
+
+  const numericValue = Number.parseInt(value, 10);
+  if (Number.isNaN(numericValue)) return true;
+
+  return numericValue === numericFilter;
+}
+
+function updateDifficultyToggleUI() {
+  document
+    .querySelectorAll('.user-problem-difficulty-toggle')
+    .forEach(button => {
+      const buttonValue = button.dataset.userProblemDifficulty || 'all';
+      const isActive = userProblemFilterState.difficulty === buttonValue;
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
 }
 
 function updateFilterToggleUI() {
@@ -821,11 +836,6 @@ function updateFilterControlValues() {
     gridSelect.value = userProblemFilterState.gridSize;
   }
 
-  const difficultySelect = document.getElementById('userProblemFilterDifficulty');
-  if (difficultySelect && difficultySelect.value !== userProblemFilterState.difficulty) {
-    difficultySelect.value = userProblemFilterState.difficulty;
-  }
-
   const minLikesInput = document.getElementById('userProblemMinLikes');
   if (minLikesInput) {
     minLikesInput.value = userProblemFilterState.minLikes
@@ -837,12 +847,15 @@ function updateFilterControlValues() {
   if (creatorInput && creatorInput.value !== userProblemFilterState.creatorFilter) {
     creatorInput.value = userProblemFilterState.creatorFilter;
   }
+
+  updateDifficultyToggleUI();
 }
 
 function resetUserProblemFilters() {
   userProblemFilterState = { ...DEFAULT_USER_PROBLEM_FILTERS };
   updateFilterControlValues();
   updateFilterToggleUI();
+  updateDifficultyToggleUI();
   if (!userProblemListLoading) {
     updateUserProblemListUI();
   }
@@ -883,6 +896,25 @@ function ensureUserProblemControls() {
       button.addEventListener('click', () => {
         userProblemFilterState[key] = !userProblemFilterState[key];
         updateFilterToggleUI();
+        updateDifficultyToggleUI();
+        if (!userProblemListLoading) {
+          updateUserProblemListUI();
+        }
+      });
+    });
+
+  document
+    .querySelectorAll('.user-problem-difficulty-toggle')
+    .forEach(button => {
+      const difficultyValue = button.dataset.userProblemDifficulty;
+      if (!difficultyValue) return;
+
+      button.addEventListener('click', () => {
+        const previous = userProblemFilterState.difficulty;
+        userProblemFilterState.difficulty =
+          difficultyValue === previous ? 'all' : difficultyValue;
+
+        updateDifficultyToggleUI();
         if (!userProblemListLoading) {
           updateUserProblemListUI();
         }
@@ -893,16 +925,6 @@ function ensureUserProblemControls() {
   if (gridSelect) {
     gridSelect.addEventListener('change', () => {
       userProblemFilterState.gridSize = gridSelect.value;
-      if (!userProblemListLoading) {
-        updateUserProblemListUI();
-      }
-    });
-  }
-
-  const difficultySelect = document.getElementById('userProblemFilterDifficulty');
-  if (difficultySelect) {
-    difficultySelect.addEventListener('change', () => {
-      userProblemFilterState.difficulty = difficultySelect.value;
       if (!userProblemListLoading) {
         updateUserProblemListUI();
       }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -923,6 +923,25 @@ html, body {
     gap: 0.5rem;
   }
 
+  .user-problem-difficulty-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding-left: 0.25rem;
+  }
+
+  .user-problem-difficulty-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #475569;
+  }
+
+  .user-problem-difficulty-buttons {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
   .user-problem-filter-toggle {
     display: inline-flex;
     align-items: center;
@@ -952,6 +971,12 @@ html, body {
 
   .user-problem-filter-toggle span {
     font-size: 0.9rem;
+  }
+
+  .user-problem-difficulty-toggle {
+    min-width: 2.35rem;
+    justify-content: center;
+    padding-inline: 0.75rem;
   }
 
   .user-problems-advanced {


### PR DESCRIPTION
## Summary
- replace the collapsible advanced filters with inline difficulty buttons for user problems
- update the user problem filter logic to drive the new difficulty buttons
- style the new difficulty filter group for the toolbar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c5116b0c83328b213a4a901c1b47