### PR TITLE
Add difficulty toggle filters to user problems screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,27 +295,48 @@
                 <button type="button" class="user-problem-filter-toggle" data-user-problem-toggle="onlyPopular" aria-pressed="false">
                   ♥ <span id="userProblemFilterPopular">인기</span>
                 </button>
-                <details id="userProblemAdvancedFilters" class="user-problems-advanced">
-                  <summary id="userProblemAdvancedSummary">⚙ 필터</summary>
-                  <div class="user-problems-advanced-grid">
-                    <label id="userProblemFilterGridLabel" for="userProblemFilterGrid">그리드 크기</label>
-                    <select id="userProblemFilterGrid">
-                      <option id="userProblemFilterGridAnyOption" value="all">전체</option>
-                    </select>
-                    <label id="userProblemFilterDifficultyLabel" for="userProblemFilterDifficulty">난이도</label>
-                    <select id="userProblemFilterDifficulty">
-                      <option id="userProblemFilterDifficultyAll" value="all">전체</option>
-                      <option id="userProblemFilterDifficultyEasy" value="easy">쉬움</option>
-                      <option id="userProblemFilterDifficultyNormal" value="normal">보통</option>
-                      <option id="userProblemFilterDifficultyHard" value="hard">어려움</option>
-                    </select>
-                    <label id="userProblemFilterMinLikesLabel" for="userProblemMinLikes">좋아요 수 이상</label>
-                    <input id="userProblemMinLikes" type="number" min="0" inputmode="numeric" placeholder="0" />
-                    <label id="userProblemFilterCreatorLabel" for="userProblemCreatorFilter">제작자</label>
-                    <input id="userProblemCreatorFilter" type="text" placeholder="예: garden" />
-                    <button id="userProblemResetFilters" type="button" class="user-problem-reset">필터 초기화</button>
-                  </div>
-                </details>
+                <div class="user-problem-difficulty-group" role="group" aria-label="난이도">
+                  <button
+                    type="button"
+                    class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                    data-user-problem-difficulty="1"
+                    aria-pressed="true"
+                  >
+                    ⭐ 1
+                  </button>
+                  <button
+                    type="button"
+                    class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                    data-user-problem-difficulty="2"
+                    aria-pressed="true"
+                  >
+                    ⭐⭐ 2
+                  </button>
+                  <button
+                    type="button"
+                    class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                    data-user-problem-difficulty="3"
+                    aria-pressed="true"
+                  >
+                    ⭐⭐⭐ 3
+                  </button>
+                  <button
+                    type="button"
+                    class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                    data-user-problem-difficulty="4"
+                    aria-pressed="true"
+                  >
+                    ⭐⭐⭐⭐ 4
+                  </button>
+                  <button
+                    type="button"
+                    class="user-problem-filter-toggle user-problem-difficulty-toggle"
+                    data-user-problem-difficulty="5"
+                    aria-pressed="true"
+                  >
+                    ⭐⭐⭐⭐⭐ 5
+                  </button>
+                </div>
               </div>
               <div id="userProblemResultSummary" class="user-problem-result-summary"></div>
             </div>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -923,6 +923,12 @@ html, body {
     gap: 0.5rem;
   }
 
+  .user-problem-difficulty-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
   .user-problem-filter-toggle {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- replace the advanced user problem filters with inline difficulty toggle buttons
- simplify the filtering logic to use the new difficulty selection and remove unused controls
- add styling to keep the new difficulty buttons aligned with existing filter toggles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c5116b0c83328b213a4a901c1b47