### PR TITLE
Add lab mode canvas layout with floating panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,6 +440,23 @@
         </div>
       </div>
       <div id="circuitError">회로에 오류가 존재합니다</div>
+      <div id="labPanels" class="lab-overlay-panels" style="display:none" aria-hidden="true">
+        <div class="lab-panel lab-info-panel">
+          <div class="lab-panel-header">
+            <h2 class="lab-panel-title">🔬 실험실</h2>
+            <button id="exitLabBtn" class="lab-close-btn" type="button">← 메인으로</button>
+          </div>
+          <p class="lab-panel-text">격자 위에서 자유롭게 회로를 실험해 보세요.</p>
+        </div>
+        <div class="lab-panel lab-shortcuts-panel">
+          <h3 class="lab-panel-title">⌨️ 단축키</h3>
+          <ul class="lab-shortcuts-list">
+            <li><kbd>Ctrl</kbd> / <kbd>Cmd</kbd> - 도선 그리기</li>
+            <li><kbd>Shift</kbd> - 도선·블록 삭제</li>
+            <li><kbd>R</kbd> - 회로 초기화</li>
+          </ul>
+        </div>
+      </div>
       </div>
       <!-- 메뉴바 -->
       <div id="menuBar">

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -38,6 +38,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     panelWidth = 180,
     forceHideInOut = false,
     onCircuitModified,
+    infiniteGrid = false,
   } = options;
   const gap = 10;
   const PALETTE_ITEM_H = 50;
@@ -174,7 +175,9 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     applyState(next);
   }
 
-  drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth);
+  drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, {
+    infinite: infiniteGrid,
+  });
   drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects);
   startEngine(contentCtx, circuit, (ctx, circ, phase) =>
     renderContent(ctx, circ, phase, panelTotalWidth, state.hoverBlockId)

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -32,13 +32,44 @@ export function setupCanvas(canvas, width, height) {
 }
 
 // Draw grid as individual tiles with gaps similar to GIF rendering
-export function drawGrid(ctx, rows, cols, offsetX = 0) {
+export function drawGrid(ctx, rows, cols, offsetX = 0, options = {}) {
+  const { infinite = false } = options;
   const width = cols * (CELL + GAP) + GAP;
   const height = rows * (CELL + GAP) + GAP;
+  const tileSize = CELL + GAP;
   ctx.save();
-  ctx.fillStyle = '#fff';
+
+  if (infinite) {
+    const patternCanvas = document.createElement('canvas');
+    patternCanvas.width = tileSize;
+    patternCanvas.height = tileSize;
+    const pctx = patternCanvas.getContext('2d');
+    pctx.fillStyle = '#f6f8ff';
+    pctx.fillRect(0, 0, tileSize, tileSize);
+    pctx.strokeStyle = '#dbe0f5';
+    pctx.lineWidth = 1;
+    roundRect(pctx, GAP / 2, GAP / 2, CELL, CELL, 3);
+    pctx.stroke();
+    const pattern = ctx.createPattern(patternCanvas, 'repeat');
+    if (pattern) {
+      ctx.fillStyle = pattern;
+      ctx.fillRect(
+        offsetX - tileSize * 4,
+        -tileSize * 4,
+        ctx.canvas.width + tileSize * 8,
+        ctx.canvas.height + tileSize * 8
+      );
+    } else {
+      ctx.fillStyle = '#f6f8ff';
+      ctx.fillRect(offsetX, 0, ctx.canvas.width - offsetX, ctx.canvas.height);
+    }
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+  } else {
+    ctx.fillStyle = '#fff';
+  }
   ctx.fillRect(offsetX, 0, width, height);
-  ctx.strokeStyle = '#ddd';
+
+  ctx.strokeStyle = infinite ? '#cfd5ec' : '#ddd';
   ctx.lineWidth = 1;
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
@@ -48,9 +79,13 @@ export function drawGrid(ctx, rows, cols, offsetX = 0) {
       ctx.stroke();
     }
   }
-  ctx.strokeStyle = '#666';
-  ctx.lineWidth = GAP;
-  ctx.strokeRect(offsetX + GAP / 2, GAP / 2, width - GAP, height - GAP);
+
+  if (!infinite) {
+    ctx.strokeStyle = '#666';
+    ctx.lineWidth = GAP;
+    ctx.strokeRect(offsetX + GAP / 2, GAP / 2, width - GAP, height - GAP);
+  }
+
   ctx.restore();
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ import {
   setupGrid,
   setGridDimensions,
   clearGrid,
+  destroyPlayContext,
   moveCircuit,
   setupMenuToggle,
   collapseMenuBarForMobile,
@@ -129,6 +130,26 @@ const TOAST_IDS = {
 };
 let activeSavedToastId = null;
 
+const LAB_GRID_SIZE = { rows: 18, cols: 24 };
+const LAB_BLOCK_LIBRARY = [
+  { type: 'INPUT', name: 'IN1' },
+  { type: 'INPUT', name: 'IN2' },
+  { type: 'INPUT', name: 'IN3' },
+  { type: 'INPUT', name: 'IN4' },
+  { type: 'OUTPUT', name: 'OUT1' },
+  { type: 'OUTPUT', name: 'OUT2' },
+  { type: 'OUTPUT', name: 'OUT3' },
+  { type: 'OUTPUT', name: 'OUT4' },
+  { type: 'AND' },
+  { type: 'OR' },
+  { type: 'NOT' },
+  { type: 'JUNCTION' }
+];
+
+let labPaletteGroups = null;
+let labEntering = false;
+let previousGameTitle = null;
+
 function showGifLoadingToast(message) {
   if (!message) return;
   toastManager.show({
@@ -142,6 +163,15 @@ function showGifLoadingToast(message) {
 
 function hideGifLoadingToast() {
   toastManager.remove(TOAST_IDS.gif, { silent: true });
+}
+
+function getLabPaletteGroups() {
+  if (!labPaletteGroups) {
+    labPaletteGroups = buildPaletteGroups(
+      LAB_BLOCK_LIBRARY.map(block => ({ ...block }))
+    );
+  }
+  return labPaletteGroups;
 }
 
 function showCircuitSavingToast(message) {
@@ -447,6 +477,88 @@ const chapterStageScreen = document.getElementById("chapterStageScreen");
 const gameScreen = document.getElementById("gameScreen");
 const firstScreen = document.getElementById('firstScreen');
 const chapterListEl = document.getElementById("chapterList");
+
+const labBtn = document.getElementById('labBtn');
+const exitLabBtn = document.getElementById('exitLabBtn');
+const labPanels = document.getElementById('labPanels');
+const gameTitleEl = document.getElementById('gameTitle');
+
+async function openLabScreen() {
+  if (labEntering) return;
+  labEntering = true;
+  const rightPanelEl = document.getElementById('rightPanel');
+  try {
+    lockOrientationLandscape();
+    const paletteGroups = getLabPaletteGroups();
+    await setupGrid(
+      'canvasContainer',
+      LAB_GRID_SIZE.rows,
+      LAB_GRID_SIZE.cols,
+      paletteGroups,
+      { infiniteGrid: true }
+    );
+    document.body.classList.add('game-active');
+    document.body.classList.add('lab-mode');
+    if (firstScreen) firstScreen.style.display = 'none';
+    if (gameScreen) gameScreen.style.display = 'block';
+    if (rightPanelEl) rightPanelEl.style.display = 'flex';
+    if (labPanels) {
+      labPanels.style.display = 'flex';
+      labPanels.setAttribute('aria-hidden', 'false');
+    }
+    if (gameTitleEl) {
+      previousGameTitle = gameTitleEl.textContent;
+      gameTitleEl.textContent = '🔬 Lab';
+    }
+    adjustGridZoom('canvasContainer');
+    window.dispatchEvent(new Event('resize'));
+  } catch (err) {
+    console.error('Failed to open lab screen', err);
+  } finally {
+    labEntering = false;
+  }
+}
+
+function closeLabScreen() {
+  if (!document.body.classList.contains('lab-mode')) return;
+  document.body.classList.remove('lab-mode');
+  document.body.classList.remove('game-active');
+  if (labPanels) {
+    labPanels.style.display = 'none';
+    labPanels.setAttribute('aria-hidden', 'true');
+  }
+  const rightPanelEl = document.getElementById('rightPanel');
+  if (rightPanelEl) {
+    rightPanelEl.style.display = 'none';
+  }
+  if (gameTitleEl) {
+    gameTitleEl.textContent = previousGameTitle || '🧠 Bitwiser';
+  }
+  previousGameTitle = null;
+  destroyPlayContext();
+  if (gameScreen) gameScreen.style.display = 'none';
+  if (firstScreen) firstScreen.style.display = '';
+}
+
+if (labBtn) {
+  labBtn.addEventListener('click', () => {
+    if (document.body.classList.contains('lab-mode')) return;
+    openLabScreen();
+  });
+}
+
+if (exitLabBtn) {
+  exitLabBtn.addEventListener('click', () => {
+    closeLabScreen();
+  });
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && document.body.classList.contains('lab-mode')) {
+    e.preventDefault();
+    closeLabScreen();
+  }
+});
 
 document.getElementById("toggleChapterList").onclick = () => {
   chapterListEl.classList.toggle('hidden');

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1215,7 +1215,7 @@ html, body {
     /* 전역 모달보다 위에 */
   }
 
-  #rankingModal .modal-content {
+#rankingModal .modal-content {
     /* 내용 크기에 맞춰 자동 조절 */
     display: inline-block !important;
     margin: auto !important;
@@ -2661,5 +2661,184 @@ html, body {
     border-radius: 0.8rem;
     padding: 0.9rem 1rem;
   }
+}
+
+
+#labPanels {
+  display: none;
+}
+
+body.lab-mode {
+  background: radial-gradient(circle at top left, #f4f6ff 0%, #e4e8ff 40%, #eef1ff 100%);
+  color: #0f172a;
+}
+
+body.lab-mode #firstScreen,
+body.lab-mode #chapterStageScreen,
+body.lab-mode #user-problems-screen,
+body.lab-mode #problem-screen {
+  display: none !important;
+}
+
+body.lab-mode #gameScreen {
+  display: block !important;
+}
+
+body.lab-mode #menuBar {
+  display: none !important;
+}
+
+body.lab-mode #gameArea {
+  width: 100vw;
+  height: 100vh;
+  padding: 0;
+  position: relative;
+  background: transparent;
+}
+
+body.lab-mode #gameLayout {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+body.lab-mode #canvasContainer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body.lab-mode #canvasContainer canvas {
+  pointer-events: auto;
+}
+
+body.lab-mode #rightPanel {
+  position: absolute;
+  top: 4vh;
+  right: clamp(1.5rem, 4vw, 4rem);
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 24px;
+  padding: clamp(1rem, 2vw, 1.75rem);
+  box-shadow: 0 25px 60px rgba(61, 74, 125, 0.25);
+  max-width: min(24rem, 32vw);
+  width: min(24rem, 32vw);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+}
+
+body.lab-mode #rightPanel h1 {
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  margin-bottom: 0.75rem;
+}
+
+body.lab-mode #rightPanel button.main-button {
+  width: 100%;
+}
+
+body.lab-mode #moveButtonWrapper {
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+body.lab-mode #labPanels {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0) 45%, rgba(161, 177, 255, 0.12) 100%);
+}
+
+body.lab-mode .lab-panel {
+  pointer-events: auto;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: clamp(1rem, 2vw, 1.75rem);
+  margin: clamp(1.5rem, 3vw, 3rem);
+  box-shadow: 0 20px 55px rgba(53, 66, 122, 0.22);
+  color: #1e293b;
+}
+
+body.lab-mode .lab-info-panel {
+  align-self: flex-start;
+  max-width: min(28rem, 38vw);
+}
+
+body.lab-mode .lab-shortcuts-panel {
+  align-self: flex-end;
+  max-width: min(20rem, 30vw);
+}
+
+body.lab-mode .lab-panel-title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.5rem);
+  font-weight: 700;
+}
+
+body.lab-mode .lab-panel-text {
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+  line-height: 1.6;
+  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
+}
+
+body.lab-mode .lab-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+body.lab-mode .lab-close-btn {
+  border: none;
+  background: linear-gradient(135deg, #4c6ef5, #5f8bff);
+  color: #fff;
+  font-size: 0.95rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(76, 110, 245, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.lab-mode .lab-close-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(76, 110, 245, 0.45);
+}
+
+body.lab-mode .lab-shortcuts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+body.lab-mode .lab-shortcuts-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
+}
+
+body.lab-mode kbd {
+  display: inline-block;
+  padding: 0.2rem 0.45rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+  background: rgba(241, 245, 255, 0.85);
+  font-family: 'Noto Sans KR', sans-serif;
+  font-size: 0.85em;
+  box-shadow: inset 0 -2px 0 rgba(99, 102, 241, 0.25);
+}
+
+body.lab-mode #gridOverlay {
+  display: none;
 }
 


### PR DESCRIPTION
## Summary
- hook the lab button into a dedicated lab mode that reuses the game canvas with floating UI panels and an exit control
- update the renderer and styling so the lab canvas shows an infinite-feeling grid with polished white panel treatments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4cd298ae08332adf4b694bcd7976d