### PR TITLE
Revamp lab mode layout and add infinite grid panning

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,6 +396,7 @@
         <!-- 우측: 시뮬레이트 + 안내 + 삭제 -->
         <div class="rightPanel" id="rightPanel"
           style="display: flex; flex-direction: column; align-items: center; gap: 1rem;">
+          <button id="exitLabBtn" class="lab-exit-btn" type="button">← 메인으로</button>
           <h1 id="gameTitle" title="ℹ️ 스테이지 안내">🧠 Bitwiser</h1>
           <button id="gradeButton" class="main-button">채점하기</button>
           <div style="text-align: center; line-height: 1.6;">
@@ -440,23 +441,6 @@
         </div>
       </div>
       <div id="circuitError">회로에 오류가 존재합니다</div>
-      <div id="labPanels" class="lab-overlay-panels" style="display:none" aria-hidden="true">
-        <div class="lab-panel lab-info-panel">
-          <div class="lab-panel-header">
-            <h2 class="lab-panel-title">🔬 실험실</h2>
-            <button id="exitLabBtn" class="lab-close-btn" type="button">← 메인으로</button>
-          </div>
-          <p class="lab-panel-text">격자 위에서 자유롭게 회로를 실험해 보세요.</p>
-        </div>
-        <div class="lab-panel lab-shortcuts-panel">
-          <h3 class="lab-panel-title">⌨️ 단축키</h3>
-          <ul class="lab-shortcuts-list">
-            <li><kbd>Ctrl</kbd> / <kbd>Cmd</kbd> - 도선 그리기</li>
-            <li><kbd>Shift</kbd> - 도선·블록 삭제</li>
-            <li><kbd>R</kbd> - 회로 초기화</li>
-          </ul>
-        </div>
-      </div>
       </div>
       <!-- 메뉴바 -->
       <div id="menuBar">

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -51,6 +51,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   let canvasHeight = gridHeight;
   let paletteItems = [];
   let groupRects = [];
+  let viewOffset = { x: 0, y: 0 };
 
   if (paletteGroups.length > 0) {
     const colWidth =
@@ -97,10 +98,19 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     canvasHeight = Math.max(canvasHeight, palette.length * PALETTE_ITEM_H + 20);
   }
 
-  const canvasWidth = panelTotalWidth + gridWidth;
-  const bgCtx = setupCanvas(bgCanvas, canvasWidth, canvasHeight);
-  const contentCtx = setupCanvas(contentCanvas, canvasWidth, canvasHeight);
-  const overlayCtx = setupCanvas(overlayCanvas, canvasWidth, canvasHeight);
+  const minCanvasHeight = canvasHeight;
+  const minCanvasWidth = panelTotalWidth + gridWidth;
+  let canvasWidth = minCanvasWidth;
+  if (infiniteGrid) {
+    const viewportWidth = window.innerWidth || canvasWidth;
+    const viewportHeight = window.innerHeight || canvasHeight;
+    canvasWidth = Math.max(canvasWidth, viewportWidth);
+    canvasHeight = Math.max(canvasHeight, viewportHeight);
+  }
+
+  let bgCtx = setupCanvas(bgCanvas, canvasWidth, canvasHeight);
+  let contentCtx = setupCanvas(contentCanvas, canvasWidth, canvasHeight);
+  let overlayCtx = setupCanvas(overlayCanvas, canvasWidth, canvasHeight);
 
   const state = {
     mode: 'idle',
@@ -115,11 +125,38 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     selection: null,
     selecting: false,
     selectStart: null,
+    panning: false,
+    panStart: null,
   };
 
   const undoStack = [];
   const redoStack = [];
   let hasInitialSnapshot = false;
+
+  function getGridBounds() {
+    return {
+      left: panelTotalWidth + viewOffset.x,
+      top: viewOffset.y,
+      right: panelTotalWidth + viewOffset.x + gridWidth,
+      bottom: viewOffset.y + gridHeight,
+    };
+  }
+
+  function isPointInGrid(x, y) {
+    const bounds = getGridBounds();
+    return x >= bounds.left && x < bounds.right && y >= bounds.top && y < bounds.bottom;
+  }
+
+  function toGridSpace(x, y) {
+    return { x: x - viewOffset.x, y: y - viewOffset.y };
+  }
+
+  function cellToCanvas(r, c) {
+    return {
+      x: panelTotalWidth + GAP + c * (CELL + GAP) + viewOffset.x,
+      y: GAP + r * (CELL + GAP) + viewOffset.y,
+    };
+  }
 
   function notifyCircuitModified() {
     if (typeof onCircuitModified === 'function') {
@@ -154,7 +191,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     state.selection = null;
     overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     syncPaletteWithCircuit();
-    renderContent(contentCtx, circuit, 0, panelTotalWidth);
+    renderStatic();
     updateUsageCounts();
     updateButtons();
     notifyCircuitModified();
@@ -177,11 +214,58 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, {
     infinite: infiniteGrid,
+    translateX: viewOffset.x,
+    translateY: viewOffset.y,
   });
   drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects);
-  startEngine(contentCtx, circuit, (ctx, circ, phase) =>
-    renderContent(ctx, circ, phase, panelTotalWidth, state.hoverBlockId)
-  );
+  const renderPhase = (_ctx, circ, phase) =>
+    renderContent(contentCtx, circ, phase, panelTotalWidth, state.hoverBlockId, {
+      translateX: viewOffset.x,
+      translateY: viewOffset.y,
+    });
+  startEngine(contentCtx, circuit, renderPhase);
+
+  function renderStatic() {
+    renderPhase(contentCtx, circuit, 0);
+  }
+
+  function redrawAll({ preserveOverlay = false } = {}) {
+    drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, {
+      infinite: infiniteGrid,
+      translateX: viewOffset.x,
+      translateY: viewOffset.y,
+    });
+    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects);
+    renderStatic();
+    if (!preserveOverlay) {
+      overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
+      if (state.selection) drawSelection();
+    }
+  }
+
+  function resizeForViewport() {
+    if (!infiniteGrid) return;
+    const viewportWidth = window.innerWidth || canvasWidth;
+    const viewportHeight = window.innerHeight || canvasHeight;
+    const desiredWidth = Math.max(minCanvasWidth, viewportWidth);
+    const desiredHeight = Math.max(minCanvasHeight, viewportHeight);
+    if (desiredWidth === canvasWidth && desiredHeight === canvasHeight) return;
+    canvasWidth = desiredWidth;
+    canvasHeight = desiredHeight;
+    bgCtx = setupCanvas(bgCanvas, canvasWidth, canvasHeight);
+    contentCtx = setupCanvas(contentCanvas, canvasWidth, canvasHeight);
+    overlayCtx = setupCanvas(overlayCanvas, canvasWidth, canvasHeight);
+    [bgCanvas, contentCanvas, overlayCanvas].forEach(c => {
+      if (c) c.dataset.scale = '1';
+    });
+    redrawAll();
+  }
+
+  let resizeHandler = null;
+  if (infiniteGrid) {
+    resizeHandler = () => resizeForViewport();
+    window.addEventListener('resize', resizeHandler);
+  }
 
   function redrawPanel() {
     drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects);
@@ -257,24 +341,16 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     sel.blocks.forEach(id => {
       const b = circuit.blocks[id];
       if (b) {
-        overlayCtx.fillRect(
-          panelTotalWidth + GAP + b.pos.c * (CELL + GAP),
-          GAP + b.pos.r * (CELL + GAP),
-          CELL,
-          CELL
-        );
+        const { x, y } = cellToCanvas(b.pos.r, b.pos.c);
+        overlayCtx.fillRect(x, y, CELL, CELL);
       }
     });
     sel.wires.forEach(id => {
       const w = circuit.wires[id];
       if (w) {
         w.path.forEach(p => {
-          overlayCtx.fillRect(
-            panelTotalWidth + GAP + p.c * (CELL + GAP),
-            GAP + p.r * (CELL + GAP),
-            CELL,
-            CELL
-          );
+          const { x, y } = cellToCanvas(p.r, p.c);
+          overlayCtx.fillRect(x, y, CELL, CELL);
         });
       }
     });
@@ -333,7 +409,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     sel.c1 += dc;
     sel.c2 += dc;
 
-    renderContent(contentCtx, circuit, 0, panelTotalWidth);
+    renderStatic();
     overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     drawSelection();
     snapshot();
@@ -436,7 +512,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       circuit.blocks = fixed;
       circuit.wires = {};
       syncPaletteWithCircuit();
-      renderContent(contentCtx, circuit, 0, panelTotalWidth);
+      renderStatic();
       updateUsageCounts();
       clearSelection();
       snapshot();
@@ -467,6 +543,10 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       document.removeEventListener('keyup', keyupHandler);
       keyupHandler = null;
     }
+    if (resizeHandler) {
+      window.removeEventListener('resize', resizeHandler);
+      resizeHandler = null;
+    }
   }
 
   wireBtn?.addEventListener('click', () => {
@@ -484,9 +564,22 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     state.pointerDown = { x, y };
     state.pointerMoved = false;
     let handled = false;
+    if (e.button === 1 && infiniteGrid) {
+      state.panning = true;
+      state.panStart = {
+        x,
+        y,
+        offsetX: viewOffset.x,
+        offsetY: viewOffset.y,
+      };
+      handled = true;
+      e.preventDefault();
+      return handled;
+    }
     if (e.button === 2) {
-      if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
-        const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      if (isPointInGrid(x, y)) {
+        const gridPos = toGridSpace(x, y);
+        const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
         state.selecting = true;
         state.selectStart = cell;
         state.selection = null;
@@ -496,10 +589,11 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       e.preventDefault();
     } else {
       if (state.selection) {
-        const inGrid = x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight;
+        const inGrid = isPointInGrid(x, y);
         let inside = false;
         if (inGrid) {
-          const cell = pxToCell(x, y, circuit, panelTotalWidth);
+          const gridPos = toGridSpace(x, y);
+          const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
           if (
             cell.r >= state.selection.r1 &&
             cell.r <= state.selection.r2 &&
@@ -520,8 +614,9 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
           state.draggingBlock = { type: item.type, name: item.label };
           handled = true;
         }
-      } else if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
-        const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      } else if (isPointInGrid(x, y)) {
+        const gridPos = toGridSpace(x, y);
+        const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
         if (state.mode === 'wireDrawing') {
           if (blockAt(cell)) {
             state.wireTrace = [coord(cell.r, cell.c)];
@@ -562,7 +657,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
               }
             });
           }
-          renderContent(contentCtx, circuit, 0, panelTotalWidth);
+          renderStatic();
           updateUsageCounts();
           if (deleted) {
             clearSelection();
@@ -596,12 +691,20 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   function handlePointerUp(e) {
     const { x, y } = getPointerPos(e);
+    if (state.panning && e.button === 1) {
+      state.panning = false;
+      state.panStart = null;
+      state.pointerDown = null;
+      state.pointerMoved = false;
+      return;
+    }
     if (state.selecting && e.button === 2) {
       state.selecting = false;
       state.pointerDown = null;
       state.pointerMoved = false;
-      if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
-        const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      if (isPointInGrid(x, y)) {
+        const gridPos = toGridSpace(x, y);
+        const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
         const r1 = Math.min(state.selectStart.r, cell.r);
         const c1 = Math.min(state.selectStart.c, cell.c);
         const r2 = Math.max(state.selectStart.r, cell.r);
@@ -633,13 +736,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       return;
     }
     if (!state.pointerMoved && state.mode === 'idle') {
-      if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
-        const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      if (isPointInGrid(x, y)) {
+        const gridPos = toGridSpace(x, y);
+        const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
         const blk = blockAt(cell);
         if (blk && blk.type === 'INPUT') {
           blk.value = !blk.value;
           evaluateCircuit(circuit);
-          renderContent(contentCtx, circuit, 0, panelTotalWidth);
+          renderStatic();
         }
       }
     }
@@ -650,7 +754,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
         const endBlock = blockAt(state.wireTrace[state.wireTrace.length - 1]);
         circuit.wires[id] = newWire({ id, path: [...state.wireTrace], startBlockId: startBlock.id, endBlockId: endBlock.id });
         endBlock.inputs = [...(endBlock.inputs || []), startBlock.id];
-        renderContent(contentCtx, circuit, 0, panelTotalWidth);
+        renderStatic();
         updateUsageCounts();
         clearSelection();
         snapshot();
@@ -658,8 +762,9 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
     } else if (state.draggingBlock) {
       let placed = false;
-      if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
-        const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      if (isPointInGrid(x, y)) {
+        const gridPos = toGridSpace(x, y);
+        const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
         if (state.draggingBlock.id) {
           const collision = blockAt(cell) || cellHasWire(cell);
           const target = collision ? state.draggingBlock.origPos : cell;
@@ -712,7 +817,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
         );
       }
       if (placed) {
-        renderContent(contentCtx, circuit, 0, panelTotalWidth);
+        renderStatic();
         updateUsageCounts();
         snapshot();
       }
@@ -735,31 +840,39 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     overlayCanvas.addEventListener('mouseup', handlePointerUp);
     overlayCanvas.addEventListener('touchend', handlePointerUp);
 
-    function handlePointerMove(e) {
+  function handlePointerMove(e) {
     const { x, y } = getPointerPos(e);
     if (state.pointerDown) {
       const dx = x - state.pointerDown.x;
       const dy = y - state.pointerDown.y;
       if (Math.abs(dx) > 5 || Math.abs(dy) > 5) state.pointerMoved = true;
     }
+    if (state.panning && state.panStart) {
+      viewOffset.x = state.panStart.offsetX + (x - state.panStart.x);
+      viewOffset.y = state.panStart.offsetY + (y - state.panStart.y);
+      redrawAll();
+      return;
+    }
     if (state.selecting) {
-      if (x < panelTotalWidth || x >= canvasWidth || y < 0 || y >= gridHeight) {
+      if (!isPointInGrid(x, y)) {
         overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
         return;
       }
-      const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      const gridPos = toGridSpace(x, y);
+      const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
       const r1 = Math.min(state.selectStart.r, cell.r);
       const c1 = Math.min(state.selectStart.c, cell.c);
       const r2 = Math.max(state.selectStart.r, cell.r);
       const c2 = Math.max(state.selectStart.c, cell.c);
+      const topLeft = cellToCanvas(r1, c1);
       overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
       overlayCtx.save();
       overlayCtx.strokeStyle = 'rgba(0,128,255,0.8)';
       overlayCtx.lineWidth = 1;
       overlayCtx.setLineDash([4, 4]);
       overlayCtx.strokeRect(
-        panelTotalWidth + GAP + c1 * (CELL + GAP),
-        GAP + r1 * (CELL + GAP),
+        topLeft.x,
+        topLeft.y,
         (c2 - c1 + 1) * (CELL + GAP) - GAP,
         (r2 - r1 + 1) * (CELL + GAP) - GAP
       );
@@ -768,8 +881,9 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     }
     if (state.mode === 'wireDrawing' && state.wireTrace.length > 0 && (e.buttons === 1 || e.touches)) {
       state.hoverBlockId = null;
-      if (x < panelTotalWidth || x >= canvasWidth || y < 0 || y >= gridHeight) return;
-      const cell = pxToCell(x, y, circuit, panelTotalWidth);
+      if (!isPointInGrid(x, y)) return;
+      const gridPos = toGridSpace(x, y);
+      const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
       const last = state.wireTrace[state.wireTrace.length - 1];
       if (!last || last.r !== cell.r || last.c !== cell.c) {
         state.wireTrace.push(coord(cell.r, cell.c));
@@ -787,71 +901,69 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       overlayCtx.lineWidth = 2;
       overlayCtx.setLineDash([8, 8]);
       overlayCtx.beginPath();
-      overlayCtx.moveTo(
-        panelTotalWidth + GAP + state.wireTrace[0].c * (CELL + GAP) + CELL / 2,
-        GAP + state.wireTrace[0].r * (CELL + GAP) + CELL / 2
-      );
+      const startPos = cellToCanvas(state.wireTrace[0].r, state.wireTrace[0].c);
+      overlayCtx.moveTo(startPos.x + CELL / 2, startPos.y + CELL / 2);
       state.wireTrace.forEach(p => {
-        overlayCtx.lineTo(
-          panelTotalWidth + GAP + p.c * (CELL + GAP) + CELL / 2,
-          GAP + p.r * (CELL + GAP) + CELL / 2
-        );
+        const pos = cellToCanvas(p.r, p.c);
+        overlayCtx.lineTo(pos.x + CELL / 2, pos.y + CELL / 2);
       });
       overlayCtx.lineTo(x, y);
       overlayCtx.stroke();
       overlayCtx.restore();
+      return;
+    }
+    if (isPointInGrid(x, y)) {
+      const gridPos = toGridSpace(x, y);
+      const cell = pxToCell(gridPos.x, gridPos.y, circuit, panelTotalWidth);
+      const hovered = blockAt(cell);
+      state.hoverBlockId = hovered ? hovered.id : null;
+      if (state.dragCandidate && (cell.r !== state.dragCandidate.start.r || cell.c !== state.dragCandidate.start.c)) {
+        const b = circuit.blocks[state.dragCandidate.id];
+        if (b) {
+          const removedWires = [];
+          Object.keys(circuit.wires).forEach(wid => {
+            const w = circuit.wires[wid];
+            if (w.startBlockId === state.dragCandidate.id || w.endBlockId === state.dragCandidate.id) {
+              removedWires.push(w);
+              const endB = circuit.blocks[w.endBlockId];
+              if (endB) endB.inputs = (endB.inputs || []).filter(x => x !== w.startBlockId);
+              delete circuit.wires[wid];
+            }
+          });
+          state.draggingBlock = {
+            id: state.dragCandidate.id,
+            type: b.type,
+            name: b.name,
+            origPos: b.pos,
+            wires: removedWires,
+          };
+          delete circuit.blocks[state.dragCandidate.id];
+          renderStatic();
+          updateUsageCounts();
+          clearSelection();
+        }
+        state.dragCandidate = null;
+      }
+      overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
+      if (state.draggingBlock) {
+        overlayCtx.save();
+        overlayCtx.globalAlpha = 0.5;
+        overlayCtx.translate(viewOffset.x, viewOffset.y);
+        drawBlock(
+          overlayCtx,
+          { type: state.draggingBlock.type, name: state.draggingBlock.name, pos: cell },
+          panelTotalWidth
+        );
+        overlayCtx.restore();
+      }
+      if (state.selection && !state.draggingBlock && state.wireTrace.length === 0) {
+        drawSelection();
+      }
     } else {
-      if (x >= panelTotalWidth && x < canvasWidth && y >= 0 && y < gridHeight) {
-        const cell = pxToCell(x, y, circuit, panelTotalWidth);
-        const hovered = blockAt(cell);
-        state.hoverBlockId = hovered ? hovered.id : null;
-        if (state.dragCandidate && (cell.r !== state.dragCandidate.start.r || cell.c !== state.dragCandidate.start.c)) {
-          const b = circuit.blocks[state.dragCandidate.id];
-          if (b) {
-            const removedWires = [];
-            Object.keys(circuit.wires).forEach(wid => {
-              const w = circuit.wires[wid];
-              if (w.startBlockId === state.dragCandidate.id || w.endBlockId === state.dragCandidate.id) {
-                removedWires.push(w);
-                const endB = circuit.blocks[w.endBlockId];
-                if (endB) endB.inputs = (endB.inputs || []).filter(x => x !== w.startBlockId);
-                delete circuit.wires[wid];
-              }
-            });
-            state.draggingBlock = {
-              id: state.dragCandidate.id,
-              type: b.type,
-              name: b.name,
-              origPos: b.pos,
-              wires: removedWires
-            };
-            delete circuit.blocks[state.dragCandidate.id];
-            renderContent(contentCtx, circuit, 0, panelTotalWidth);
-            updateUsageCounts();
-            clearSelection();
-          }
-          state.dragCandidate = null;
-        }
-        overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
-        if (state.draggingBlock) {
-          overlayCtx.save();
-          overlayCtx.globalAlpha = 0.5;
-          drawBlock(
-            overlayCtx,
-            { type: state.draggingBlock.type, name: state.draggingBlock.name, pos: cell },
-            panelTotalWidth
-          );
-          overlayCtx.restore();
-        }
-        if (state.selection && !state.draggingBlock && state.wireTrace.length === 0) {
-          drawSelection();
-        }
-      } else {
-        state.hoverBlockId = null;
-        overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
-        if (state.selection && !state.draggingBlock && state.wireTrace.length === 0) {
-          drawSelection();
-        }
+      state.hoverBlockId = null;
+      overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
+      if (state.selection && !state.draggingBlock && state.wireTrace.length === 0) {
+        drawSelection();
       }
     }
   }
@@ -875,17 +987,19 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function handleDocUp(e) {
+    if (state.panning) {
+      state.panning = false;
+      state.panStart = null;
+      state.pointerDown = null;
+      state.pointerMoved = false;
+    }
     if (state.draggingBlock) {
       const rect = overlayCanvas.getBoundingClientRect();
       const scale = parseFloat(overlayCanvas.dataset.scale || '1');
       const point = e.changedTouches?.[0] || e;
       const ox = (point.clientX - rect.left) / scale;
       const oy = (point.clientY - rect.top) / scale;
-      const outsideGrid =
-        ox < panelTotalWidth ||
-        ox >= canvasWidth ||
-        oy < 0 ||
-        oy >= gridHeight;
+      const outsideGrid = !isPointInGrid(ox, oy);
       if (outsideGrid && state.draggingBlock.id) {
         if (
           state.draggingBlock.type === 'INPUT' ||
@@ -901,7 +1015,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
             delete circuit.wires[wid];
           }
         });
-        renderContent(contentCtx, circuit, 0, panelTotalWidth);
+        renderStatic();
         updateUsageCounts();
       }
       state.draggingBlock = null;
@@ -946,7 +1060,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       w.path = w.path.map(p => ({ r: p.r + dy, c: p.c + dx }));
     });
     overlayCtx.clearRect(0, 0, canvasWidth, canvasHeight);
-    renderContent(contentCtx, circuit, 0, panelTotalWidth, state.hoverBlockId);
+    renderStatic();
     snapshot();
     return true;
   }
@@ -969,7 +1083,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       }
     });
     syncPaletteWithCircuit();
-    renderContent(contentCtx, circuit, 0, panelTotalWidth);
+    renderStatic();
     undoStack.length = 0;
     redoStack.length = 0;
     snapshot();

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -33,12 +33,13 @@ export function setupCanvas(canvas, width, height) {
 
 // Draw grid as individual tiles with gaps similar to GIF rendering
 export function drawGrid(ctx, rows, cols, offsetX = 0, options = {}) {
-  const { infinite = false } = options;
+  const { infinite = false, translateX = 0, translateY = 0 } = options;
   const width = cols * (CELL + GAP) + GAP;
   const height = rows * (CELL + GAP) + GAP;
   const tileSize = CELL + GAP;
   ctx.save();
-
+  ctx.translate(translateX, translateY);
+  ctx.clearRect(-translateX, -translateY, ctx.canvas.width, ctx.canvas.height);
   if (infinite) {
     const patternCanvas = document.createElement('canvas');
     patternCanvas.width = tileSize;
@@ -167,12 +168,23 @@ export function drawWire(ctx, wire, phase = 0, offsetX = 0) {
 }
 
 // Render the circuit: wires then blocks to keep z-order
-export function renderContent(ctx, circuit, phase = 0, offsetX = 0, hoverId = null) {
-  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+export function renderContent(
+  ctx,
+  circuit,
+  phase = 0,
+  offsetX = 0,
+  hoverId = null,
+  options = {}
+) {
+  const { translateX = 0, translateY = 0 } = options;
+  ctx.save();
+  ctx.translate(translateX, translateY);
+  ctx.clearRect(-translateX, -translateY, ctx.canvas.width, ctx.canvas.height);
   Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase, offsetX));
   Object.values(circuit.blocks).forEach(b =>
     drawBlock(ctx, b, offsetX, b.id === hoverId)
   );
+  ctx.restore();
 }
 
 // Draw palette on the left panel

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -128,11 +128,12 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
   const gridContainer = document.getElementById(containerId);
   if (!gridContainer) return;
 
-  const margin = 20;
+  const isLabMode = document.body?.classList?.contains('lab-mode');
+  const margin = isLabMode ? 0 : 20;
   let availableWidth = window.innerWidth - margin * 2;
   let availableHeight = window.innerHeight - margin * 2;
 
-  if (containerId === 'canvasContainer') {
+  if (!isLabMode && containerId === 'canvasContainer') {
     const menuBar = document.getElementById('menuBar');
     if (menuBar) {
       const menuRect = menuBar.getBoundingClientRect();

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2697,11 +2697,9 @@ body.lab-mode #gameArea {
 }
 
 body.lab-mode #gameLayout {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
 }
 
 body.lab-mode #canvasContainer {
@@ -2710,6 +2708,7 @@ body.lab-mode #canvasContainer {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 }
 
 body.lab-mode #canvasContainer canvas {
@@ -2718,7 +2717,7 @@ body.lab-mode #canvasContainer canvas {
 
 body.lab-mode #rightPanel {
   position: absolute;
-  top: 4vh;
+  top: clamp(1.5rem, 4vh, 3rem);
   right: clamp(1.5rem, 4vw, 4rem);
   background: rgba(255, 255, 255, 0.95);
   border-radius: 24px;
@@ -2745,97 +2744,29 @@ body.lab-mode #moveButtonWrapper {
   background: transparent;
 }
 
-body.lab-mode #labPanels {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  pointer-events: none;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0) 45%, rgba(161, 177, 255, 0.12) 100%);
+.lab-exit-btn {
+  display: none;
 }
 
-body.lab-mode .lab-panel {
-  pointer-events: auto;
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 24px;
-  padding: clamp(1rem, 2vw, 1.75rem);
-  margin: clamp(1.5rem, 3vw, 3rem);
-  box-shadow: 0 20px 55px rgba(53, 66, 122, 0.22);
-  color: #1e293b;
-}
-
-body.lab-mode .lab-info-panel {
-  align-self: flex-start;
-  max-width: min(28rem, 38vw);
-}
-
-body.lab-mode .lab-shortcuts-panel {
-  align-self: flex-end;
-  max-width: min(20rem, 30vw);
-}
-
-body.lab-mode .lab-panel-title {
-  margin: 0;
-  font-size: clamp(1.1rem, 2vw, 1.5rem);
-  font-weight: 700;
-}
-
-body.lab-mode .lab-panel-text {
-  margin-top: 0.75rem;
-  margin-bottom: 0;
-  line-height: 1.6;
-  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
-}
-
-body.lab-mode .lab-panel-header {
-  display: flex;
+body.lab-mode .lab-exit-btn {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-body.lab-mode .lab-close-btn {
+  gap: 0.25rem;
+  align-self: flex-end;
   border: none;
   background: linear-gradient(135deg, #4c6ef5, #5f8bff);
   color: #fff;
-  font-size: 0.95rem;
-  padding: 0.55rem 1.1rem;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
   cursor: pointer;
-  box-shadow: 0 10px 25px rgba(76, 110, 245, 0.35);
+  box-shadow: 0 10px 20px rgba(76, 110, 245, 0.35);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-body.lab-mode .lab-close-btn:hover {
+body.lab-mode .lab-exit-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 30px rgba(76, 110, 245, 0.45);
-}
-
-body.lab-mode .lab-shortcuts-list {
-  list-style: none;
-  padding: 0;
-  margin: 0.75rem 0 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
-body.lab-mode .lab-shortcuts-list li {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
-}
-
-body.lab-mode kbd {
-  display: inline-block;
-  padding: 0.2rem 0.45rem;
-  border-radius: 6px;
-  border: 1px solid #cbd5f5;
-  background: rgba(241, 245, 255, 0.85);
-  font-family: 'Noto Sans KR', sans-serif;
-  font-size: 0.85em;
-  box-shadow: inset 0 -2px 0 rgba(99, 102, 241, 0.25);
+  box-shadow: 0 16px 28px rgba(76, 110, 245, 0.45);
 }
 
 body.lab-mode #gridOverlay {


### PR DESCRIPTION
## Summary
- remove the lab overlay panels and relocate the exit button inside the right panel
- refresh the lab-mode layout so the canvas fills the viewport and style the new exit control
- add infinite grid panning by translating renderers and handling viewport resize updates
- update the renderer and grid zoom helper to respect the new translation logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4d643f5148332a8ba50d1b235f9bd