### PR TITLE
Implement immersive lab mode canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,15 @@
       </div>
     </div>
 
+    <div id="labScreen" style="display:none;">
+      <div id="labCanvasContainer">
+        <canvas id="labBgCanvas"></canvas>
+        <canvas id="labContentCanvas"></canvas>
+        <canvas id="labOverlayCanvas"></canvas>
+      </div>
+      <button id="labExitBtn" class="lab-exit-btn" type="button" aria-label="메인으로 돌아가기">⟲ 메인으로</button>
+    </div>
+
     <div id="problem-screen" class="screen" style="display:none;">
       <div class="panel-overlay problem-screen-panel">
         <div id="problemCanvasContainer" style="position:relative;margin:auto;">

--- a/src/canvas/camera.js
+++ b/src/canvas/camera.js
@@ -1,0 +1,122 @@
+import { CELL, GAP } from './model.js';
+
+const PITCH = CELL + GAP;
+
+export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
+  let originX = 0;
+  let originY = 0;
+  let currentScale = scale;
+  let viewportWidth = 0;
+  let viewportHeight = 0;
+  let panel = panelWidth;
+  let changeHandler = null;
+
+  function notifyChange() {
+    if (typeof changeHandler === 'function') {
+      changeHandler(getState());
+    }
+  }
+
+  function setViewport(width, height) {
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+    viewportWidth = width;
+    viewportHeight = height;
+    notifyChange();
+  }
+
+  function setPanelWidth(width) {
+    if (!Number.isFinite(width)) return;
+    panel = width;
+    notifyChange();
+  }
+
+  function pan(dx, dy) {
+    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return;
+    originX -= dx / currentScale;
+    originY -= dy / currentScale;
+    notifyChange();
+  }
+
+  function setScale(nextScale, pivotX, pivotY) {
+    if (!Number.isFinite(nextScale) || nextScale <= 0) return;
+    if (pivotX !== undefined && pivotY !== undefined) {
+      const before = screenToWorld(pivotX, pivotY);
+      currentScale = nextScale;
+      const after = screenToWorld(pivotX, pivotY);
+      originX += before.x - after.x;
+      originY += before.y - after.y;
+    } else {
+      currentScale = nextScale;
+    }
+    notifyChange();
+  }
+
+  function screenToWorld(x, y) {
+    return {
+      x: originX + (x - panel) / currentScale,
+      y: originY + y / currentScale
+    };
+  }
+
+  function worldToScreen(x, y) {
+    return {
+      x: panel + (x - originX) * currentScale,
+      y: (y - originY) * currentScale
+    };
+  }
+
+  function screenToCell(x, y) {
+    const world = screenToWorld(x, y);
+    return {
+      r: Math.floor((world.y - GAP) / PITCH),
+      c: Math.floor((world.x - GAP) / PITCH)
+    };
+  }
+
+  function cellToScreenCell({ r, c }) {
+    const worldX = GAP + c * PITCH;
+    const worldY = GAP + r * PITCH;
+    return worldToScreen(worldX, worldY);
+  }
+
+  function getScale() {
+    return currentScale;
+  }
+
+  function getState() {
+    return {
+      originX,
+      originY,
+      scale: currentScale,
+      viewportWidth,
+      viewportHeight,
+      panelWidth: panel
+    };
+  }
+
+  function setOnChange(handler) {
+    changeHandler = typeof handler === 'function' ? handler : null;
+  }
+
+  function reset() {
+    originX = 0;
+    originY = 0;
+    currentScale = scale;
+    notifyChange();
+  }
+
+  return {
+    pan,
+    setScale,
+    setViewport,
+    setPanelWidth,
+    screenToCell,
+    screenToWorld,
+    worldToScreen,
+    cellToScreenCell,
+    getScale,
+    getState,
+    setOnChange,
+    reset
+  };
+}

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -1,5 +1,7 @@
 import { CELL, GAP } from './model.js';
 
+const PITCH = CELL + GAP;
+
 function roundRect(ctx, x, y, w, h, r = 6) {
   ctx.beginPath();
   ctx.moveTo(x + r, y);
@@ -31,10 +33,76 @@ export function setupCanvas(canvas, width, height) {
   return ctx;
 }
 
+function resetTransformAndClear(ctx) {
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  ctx.restore();
+}
+
+function drawInfiniteGrid(ctx, camera, { background = '#0d101a', panelFill = 'rgba(22, 26, 42, 0.6)', gridFillA = 'rgba(255,255,255,0.05)', gridFillB = 'rgba(255,255,255,0.08)', gridStroke = 'rgba(255,255,255,0.12)' } = {}) {
+  if (!camera) return;
+  resetTransformAndClear(ctx);
+  const { panelWidth, scale, originX, originY } = camera.getState();
+  const width = ctx.canvas.width;
+  const height = ctx.canvas.height;
+
+  ctx.fillStyle = background;
+  ctx.fillRect(0, 0, width, height);
+
+  if (panelWidth > 0) {
+    ctx.save();
+    ctx.shadowColor = 'rgba(0,0,0,0.25)';
+    ctx.shadowBlur = 20;
+    ctx.shadowOffsetY = 6;
+    ctx.fillStyle = panelFill;
+    ctx.fillRect(0, 0, panelWidth, height);
+    ctx.restore();
+  }
+
+  const pitchScaled = PITCH * scale;
+  const cellScaled = CELL * scale;
+
+  const visibleWidth = (width - panelWidth) / scale;
+  const visibleHeight = height / scale;
+  const startWorldX = originX;
+  const endWorldX = originX + visibleWidth;
+  const startWorldY = originY;
+  const endWorldY = originY + visibleHeight;
+
+  const startCol = Math.floor((startWorldX - GAP) / PITCH) - 1;
+  const endCol = Math.ceil((endWorldX - GAP) / PITCH) + 1;
+  const startRow = Math.floor((startWorldY - GAP) / PITCH) - 1;
+  const endRow = Math.ceil((endWorldY - GAP) / PITCH) + 1;
+
+  ctx.save();
+  for (let r = startRow; r <= endRow; r++) {
+    for (let c = startCol; c <= endCol; c++) {
+      const topLeft = camera.cellToScreenCell({ r, c });
+      const { x, y } = topLeft;
+      if (x + cellScaled < panelWidth - pitchScaled) continue;
+      ctx.save();
+      ctx.fillStyle = (r + c) % 2 === 0 ? gridFillA : gridFillB;
+      ctx.strokeStyle = gridStroke;
+      ctx.lineWidth = Math.max(1, scale);
+      roundRect(ctx, x, y, cellScaled, cellScaled, 4 * scale);
+      ctx.fill();
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+  ctx.restore();
+}
+
 // Draw grid as individual tiles with gaps similar to GIF rendering
-export function drawGrid(ctx, rows, cols, offsetX = 0) {
-  const width = cols * (CELL + GAP) + GAP;
-  const height = rows * (CELL + GAP) + GAP;
+export function drawGrid(ctx, rows, cols, offsetX = 0, camera = null, options = {}) {
+  if (camera) {
+    drawInfiniteGrid(ctx, camera, options);
+    return;
+  }
+  resetTransformAndClear(ctx);
+  const width = cols * PITCH + GAP;
+  const height = rows * PITCH + GAP;
   ctx.save();
   ctx.fillStyle = '#fff';
   ctx.fillRect(offsetX, 0, width, height);
@@ -42,8 +110,8 @@ export function drawGrid(ctx, rows, cols, offsetX = 0) {
   ctx.lineWidth = 1;
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
-      const x = offsetX + GAP + c * (CELL + GAP);
-      const y = GAP + r * (CELL + GAP);
+      const x = offsetX + GAP + c * PITCH;
+      const y = GAP + r * PITCH;
       roundRect(ctx, x, y, CELL, CELL, 3);
       ctx.stroke();
     }
@@ -55,20 +123,31 @@ export function drawGrid(ctx, rows, cols, offsetX = 0) {
 }
 
 // Blocks are drawn as rounded rectangles with text labels
-export function drawBlock(ctx, block, offsetX = 0, hovered = false) {
+export function drawBlock(ctx, block, offsetX = 0, hovered = false, camera = null) {
   const { r, c } = block.pos;
-  const x = offsetX + GAP + c * (CELL + GAP);
-  const y = GAP + r * (CELL + GAP);
+  let x;
+  let y;
+  let size = CELL;
+  if (camera) {
+    const point = camera.cellToScreenCell({ r, c });
+    x = point.x;
+    y = point.y;
+    size = CELL * camera.getScale();
+  } else {
+    x = offsetX + GAP + c * PITCH;
+    y = GAP + r * PITCH;
+  }
   ctx.save();
 
   // Drop shadow for a subtle 3D effect
+  const shadowScale = camera ? camera.getScale() : 1;
   ctx.shadowColor = 'rgba(0,0,0,0.25)';
-  ctx.shadowBlur = hovered ? 8 : 4;
-  ctx.shadowOffsetX = 2;
-  ctx.shadowOffsetY = 2;
+  ctx.shadowBlur = (hovered ? 8 : 4) * shadowScale;
+  ctx.shadowOffsetX = 2 * shadowScale;
+  ctx.shadowOffsetY = 2 * shadowScale;
 
   // Gradient fill for depth
-  const grad = ctx.createLinearGradient(x, y, x, y + CELL);
+  const grad = ctx.createLinearGradient(x, y, x, y + size);
   if (hovered) {
     grad.addColorStop(0, '#fdfdff');
     grad.addColorStop(1, '#c8c8ff');
@@ -77,81 +156,102 @@ export function drawBlock(ctx, block, offsetX = 0, hovered = false) {
     grad.addColorStop(1, '#d0d0ff');
   }
   ctx.fillStyle = grad;
-  roundRect(ctx, x, y, CELL, CELL, 6);
+  roundRect(ctx, x, y, size, size, 6 * shadowScale);
   ctx.fill();
 
   // Highlight active INPUT/OUTPUT/JUNCTION blocks with a dashed border
   ctx.shadowColor = 'transparent';
   if (block.value && ['INPUT', 'OUTPUT', 'JUNCTION'].includes(block.type)) {
     ctx.strokeStyle = '#000';
-    ctx.lineWidth = 2;
-    ctx.setLineDash([4, 4]);
+    ctx.lineWidth = 2 * shadowScale;
+    ctx.setLineDash([4 * shadowScale, 4 * shadowScale]);
     ctx.stroke();
     ctx.setLineDash([]);
   }
 
   // Text
   ctx.fillStyle = '#000';
-  ctx.font = 'bold 16px "Noto Sans KR", sans-serif';
+  ctx.font = `bold ${16 * shadowScale}px "Noto Sans KR", sans-serif`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(block.name || block.type, x + CELL / 2, y + CELL / 2);
+  ctx.fillText(block.name || block.type, x + size / 2, y + size / 2);
   ctx.restore();
 }
 
 // Draw a wire path with flowing dashed line
-export function drawWire(ctx, wire, phase = 0, offsetX = 0) {
+export function drawWire(ctx, wire, phase = 0, offsetX = 0, camera = null) {
   if (!wire.path || wire.path.length < 2) return;
   ctx.save();
   ctx.strokeStyle = '#111';
-  ctx.lineWidth = 2;
-  ctx.setLineDash([20, 20]);
-  ctx.lineDashOffset = (-phase) % 40;
+  const scale = camera ? camera.getScale() : 1;
+  ctx.lineWidth = 2 * scale;
+  ctx.setLineDash([20 * scale, 20 * scale]);
+  ctx.lineDashOffset = (-phase * scale) % (40 * scale);
   for (let i = 1; i < wire.path.length - 1; i++) {
     const p = wire.path[i];
     ctx.fillStyle = '#ffe';
-    const x = offsetX + GAP + p.c * (CELL + GAP);
-    const y = GAP + p.r * (CELL + GAP);
-    ctx.fillRect(x, y, CELL, CELL);
+    const x = camera
+      ? camera.cellToScreenCell(p).x
+      : offsetX + GAP + p.c * PITCH;
+    const y = camera
+      ? camera.cellToScreenCell(p).y
+      : GAP + p.r * PITCH;
+    const size = CELL * scale;
+    ctx.fillRect(x, y, size, size);
   }
   ctx.beginPath();
   const start = wire.path[0];
-  ctx.moveTo(
-    offsetX + GAP + start.c * (CELL + GAP) + CELL / 2,
-    GAP + start.r * (CELL + GAP) + CELL / 2
-  );
+  const startPos = camera
+    ? camera.cellToScreenCell(start)
+    : { x: offsetX + GAP + start.c * PITCH, y: GAP + start.r * PITCH };
+  ctx.moveTo(startPos.x + (CELL * scale) / 2, startPos.y + (CELL * scale) / 2);
   for (let i = 1; i < wire.path.length; i++) {
     const p = wire.path[i];
-    ctx.lineTo(
-      offsetX + GAP + p.c * (CELL + GAP) + CELL / 2,
-      GAP + p.r * (CELL + GAP) + CELL / 2
-    );
+    const pos = camera
+      ? camera.cellToScreenCell(p)
+      : { x: offsetX + GAP + p.c * PITCH, y: GAP + p.r * PITCH };
+    ctx.lineTo(pos.x + (CELL * scale) / 2, pos.y + (CELL * scale) / 2);
   }
   ctx.stroke();
   ctx.restore();
 }
 
 // Render the circuit: wires then blocks to keep z-order
-export function renderContent(ctx, circuit, phase = 0, offsetX = 0, hoverId = null) {
-  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-  Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase, offsetX));
+export function renderContent(ctx, circuit, phase = 0, offsetX = 0, hoverId = null, camera = null) {
+  resetTransformAndClear(ctx);
+  ctx.save();
+  if (camera) {
+    const { panelWidth, originX, originY, scale } = camera.getState();
+    ctx.translate(panelWidth, 0);
+    ctx.scale(scale, scale);
+    ctx.translate(-originX, -originY);
+    offsetX = 0;
+  }
+  Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase, offsetX, camera));
   Object.values(circuit.blocks).forEach(b =>
-    drawBlock(ctx, b, offsetX, b.id === hoverId)
+    drawBlock(ctx, b, offsetX, b.id === hoverId, camera)
   );
+  ctx.restore();
 }
 
 // Draw palette on the left panel
-export function drawPanel(ctx, items, panelWidth, canvasHeight, groups = []) {
+export function drawPanel(ctx, items, panelWidth, canvasHeight, groups = [], options = {}) {
+  const {
+    background = '#ffffff',
+    border = '#ddd',
+    labelColor = '#555',
+    itemGradient = ['#f0f0ff', '#d0d0ff']
+  } = options;
   ctx.clearRect(0, 0, panelWidth, canvasHeight);
   groups.forEach(g => {
     ctx.save();
-    ctx.fillStyle = '#fff';
-    ctx.strokeStyle = '#ddd';
+    ctx.fillStyle = background;
+    ctx.strokeStyle = border;
     ctx.lineWidth = 1;
     roundRect(ctx, g.x, g.y, g.w, g.h, 8);
     ctx.fill();
     ctx.stroke();
-    ctx.fillStyle = '#555';
+    ctx.fillStyle = labelColor;
     // group headings in Noto Sans KR
     ctx.font = 'bold 12px "Noto Sans KR", sans-serif';
     ctx.textAlign = 'center';
@@ -168,8 +268,8 @@ export function drawPanel(ctx, items, panelWidth, canvasHeight, groups = []) {
     ctx.shadowOffsetX = 2;
     ctx.shadowOffsetY = 2;
     const grad = ctx.createLinearGradient(item.x, item.y, item.x, item.y + item.h);
-    grad.addColorStop(0, '#f0f0ff');
-    grad.addColorStop(1, '#d0d0ff');
+    grad.addColorStop(0, itemGradient[0]);
+    grad.addColorStop(1, itemGradient[1]);
     ctx.fillStyle = grad;
     roundRect(ctx, item.x, item.y, item.w, item.h, 6);
     ctx.fill();

--- a/src/main.js
+++ b/src/main.js
@@ -73,6 +73,7 @@ import {
   showClearedModal,
   initializeRankingUI
 } from './modules/rank.js';
+import { initializeLabMode } from './modules/labMode.js';
 
 void uiModule;
 
@@ -817,6 +818,7 @@ const userProblemsScreen = document.getElementById('user-problems-screen');
 configureLevelModule({ renderUserProblemList });
 
 initializeHintUI();
+initializeLabMode();
 
 function placeFixedIO(problem) {
   getPlayController()?.placeFixedIO?.(problem);

--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -1,0 +1,168 @@
+import { makeCircuit } from '../canvas/model.js';
+import { createController } from '../canvas/controller.js';
+import { createCamera } from '../canvas/camera.js';
+import { buildPaletteGroups, getLevelBlockSets } from './levels.js';
+
+function collectPaletteGroups() {
+  const blockSets = typeof getLevelBlockSets === 'function' ? getLevelBlockSets() : {};
+  const unique = new Map();
+  Object.values(blockSets).forEach(list => {
+    (list || []).forEach(block => {
+      if (!block || !block.type) return;
+      const key = `${block.type}:${block.name || ''}`;
+      if (!unique.has(key)) {
+        unique.set(key, {
+          type: block.type,
+          name: block.name,
+        });
+      }
+    });
+  });
+
+  if (!unique.size) {
+    [
+      { type: 'INPUT', name: 'A' },
+      { type: 'INPUT', name: 'B' },
+      { type: 'OUTPUT', name: 'OUT' },
+      { type: 'AND' },
+      { type: 'OR' },
+      { type: 'NOT' },
+      { type: 'XOR' },
+      { type: 'JUNCTION', name: 'JUNC' }
+    ].forEach(block => {
+      unique.set(`${block.type}:${block.name || ''}`, block);
+    });
+  }
+
+  const blocks = Array.from(unique.values()).map(block => ({
+    type: block.type,
+    name: block.name,
+  }));
+  return buildPaletteGroups(blocks);
+}
+
+let labInitialized = false;
+let labController = null;
+let labCircuit = null;
+let labCamera = null;
+let rightPanelPlaceholder = null;
+let originalGradeDisplay = '';
+
+function moveRightPanelInto(container) {
+  const rightPanel = document.getElementById('rightPanel');
+  if (!rightPanel || !container) return;
+  if (!rightPanelPlaceholder) {
+    rightPanelPlaceholder = document.createElement('div');
+    rightPanelPlaceholder.style.display = 'none';
+    rightPanel.parentElement?.insertBefore(rightPanelPlaceholder, rightPanel);
+  }
+  container.appendChild(rightPanel);
+  const gradeButton = document.getElementById('gradeButton');
+  if (gradeButton) {
+    originalGradeDisplay = gradeButton.style.display;
+    gradeButton.style.display = 'none';
+  }
+  rightPanel.classList.add('lab-right-panel');
+}
+
+function restoreRightPanel() {
+  const rightPanel = document.getElementById('rightPanel');
+  if (!rightPanel || !rightPanelPlaceholder?.parentElement) return;
+  rightPanel.classList.remove('lab-right-panel');
+  rightPanelPlaceholder.parentElement.insertBefore(rightPanel, rightPanelPlaceholder);
+  const gradeButton = document.getElementById('gradeButton');
+  if (gradeButton) {
+    gradeButton.style.display = originalGradeDisplay;
+  }
+}
+
+function createLabController() {
+  const bgCanvas = document.getElementById('labBgCanvas');
+  const contentCanvas = document.getElementById('labContentCanvas');
+  const overlayCanvas = document.getElementById('labOverlayCanvas');
+  if (!bgCanvas || !contentCanvas || !overlayCanvas) return;
+
+  labCircuit = makeCircuit(24, 24);
+  const paletteGroups = collectPaletteGroups();
+  labCamera = createCamera({ panelWidth: 220 });
+
+  const { innerWidth, innerHeight } = window;
+  labController = createController(
+    { bgCanvas, contentCanvas, overlayCanvas },
+    labCircuit,
+    {
+      wireStatusInfo: document.getElementById('wireStatusInfo'),
+      wireDeleteInfo: document.getElementById('wireDeleteInfo'),
+      usedBlocksEl: document.getElementById('usedBlocks'),
+      usedWiresEl: document.getElementById('usedWires')
+    },
+    {
+      paletteGroups,
+      panelWidth: 220,
+      camera: labCamera,
+      unboundedGrid: true,
+      canvasSize: { width: innerWidth, height: innerHeight },
+      panelDrawOptions: {
+        grid: {
+          background: '#0c0f19',
+          panelFill: 'rgba(28,34,54,0.65)',
+          gridFillA: 'rgba(255,255,255,0.06)',
+          gridFillB: 'rgba(255,255,255,0.1)',
+          gridStroke: 'rgba(255,255,255,0.15)'
+        },
+        panel: {
+          background: 'rgba(255,255,255,0.25)',
+          border: 'rgba(255,255,255,0.4)',
+          labelColor: '#eef2ff',
+          itemGradient: ['rgba(245,246,255,0.95)', 'rgba(214,220,255,0.9)']
+        }
+      }
+    }
+  );
+
+  const resizeObserver = () => {
+    if (!labController?.resizeCanvas) return;
+    labController.resizeCanvas(window.innerWidth, window.innerHeight);
+  };
+  window.addEventListener('resize', resizeObserver);
+}
+
+function showLabScreen() {
+  const labScreen = document.getElementById('labScreen');
+  if (!labScreen) return;
+  const firstScreen = document.getElementById('firstScreen');
+  if (firstScreen) firstScreen.style.display = 'none';
+  moveRightPanelInto(labScreen);
+  labScreen.style.display = 'block';
+  document.body.classList.add('lab-mode-active');
+  if (!labInitialized) {
+    createLabController();
+    labInitialized = true;
+  } else {
+    labController?.resizeCanvas?.(window.innerWidth, window.innerHeight);
+  }
+}
+
+function hideLabScreen() {
+  const labScreen = document.getElementById('labScreen');
+  if (!labScreen) return;
+  labScreen.style.display = 'none';
+  restoreRightPanel();
+  const firstScreen = document.getElementById('firstScreen');
+  if (firstScreen) firstScreen.style.display = '';
+  document.body.classList.remove('lab-mode-active');
+}
+
+export function initializeLabMode() {
+  const labBtn = document.getElementById('labBtn');
+  if (!labBtn) return;
+  const exitBtn = document.getElementById('labExitBtn');
+
+  labBtn.addEventListener('click', () => {
+    showLabScreen();
+  });
+
+  exitBtn?.addEventListener('click', () => {
+    hideLabScreen();
+  });
+}

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2663,3 +2663,87 @@ html, body {
   }
 }
 
+
+#labScreen {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+#labCanvasContainer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+}
+
+#labCanvasContainer canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+#labBgCanvas,
+#labContentCanvas {
+  pointer-events: none;
+}
+
+#labOverlayCanvas {
+  pointer-events: auto;
+}
+
+.lab-exit-btn {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: rgba(25, 30, 48, 0.8);
+  color: #f5f7ff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  z-index: 25;
+}
+
+.lab-exit-btn:hover {
+  background: rgba(35, 40, 60, 0.9);
+}
+
+body.lab-mode-active {
+  overflow: hidden;
+  background-color: #070a12;
+}
+
+.lab-right-panel {
+  position: fixed !important;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  max-height: 100vh;
+  overflow-y: auto;
+  background: linear-gradient(180deg, rgba(18, 22, 36, 0.92), rgba(12, 16, 28, 0.94));
+  padding: 1.5rem 1.25rem;
+  box-shadow: -12px 0 30px rgba(0, 0, 0, 0.35);
+  z-index: 30;
+}
+
+.lab-right-panel .main-button,
+.lab-right-panel button {
+  background: rgba(255, 255, 255, 0.15);
+  color: #f8f9ff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.lab-right-panel .main-button:hover,
+.lab-right-panel button:hover {
+  background: rgba(255, 255, 255, 0.25);
+}


### PR DESCRIPTION
## Summary
- add a camera module and extend the canvas controller/renderer to support panning and floating palettes
- introduce a dedicated lab mode screen that moves the right panel into a fixed aside and renders grid/palette/blocks on a full-screen canvas
- style the new experience and expose the lab mode entry point from the main menu

## Testing
- `python3 -m http.server 8000` (for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e4fa24e9f48332835afcf3a5791fbb