### PR TITLE
Update lab panel styling and fix canvas alignment

### DIFF
--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -104,17 +104,17 @@ function createLabController() {
       canvasSize: { width: innerWidth, height: innerHeight },
       panelDrawOptions: {
         grid: {
-          background: '#0c0f19',
-          panelFill: 'rgba(28,34,54,0.65)',
-          gridFillA: 'rgba(255,255,255,0.06)',
-          gridFillB: 'rgba(255,255,255,0.1)',
-          gridStroke: 'rgba(255,255,255,0.15)'
+          background: '#eef2ff',
+          panelFill: 'rgba(248,250,252,0.96)',
+          gridFillA: 'rgba(148,163,184,0.16)',
+          gridFillB: 'rgba(148,163,184,0.28)',
+          gridStroke: 'rgba(100,116,139,0.25)'
         },
         panel: {
-          background: 'rgba(255,255,255,0.25)',
-          border: 'rgba(255,255,255,0.4)',
-          labelColor: '#eef2ff',
-          itemGradient: ['rgba(245,246,255,0.95)', 'rgba(214,220,255,0.9)']
+          background: '#ffffff',
+          border: 'rgba(148,163,184,0.55)',
+          labelColor: '#1e293b',
+          itemGradient: ['rgba(241,245,249,1)', 'rgba(226,232,240,1)']
         }
       }
     }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2684,8 +2684,6 @@ html, body {
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
   display: block;
 }
 
@@ -2730,20 +2728,23 @@ body.lab-mode-active {
   height: 100vh;
   max-height: 100vh;
   overflow-y: auto;
-  background: linear-gradient(180deg, rgba(18, 22, 36, 0.92), rgba(12, 16, 28, 0.94));
-  padding: 1.5rem 1.25rem;
-  box-shadow: -12px 0 30px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg, rgba(245, 247, 255, 0.96), rgba(231, 236, 255, 0.98));
+  padding: 1.75rem 1.5rem;
+  box-shadow: -12px 0 28px rgba(15, 23, 42, 0.18);
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
+  color: #1e293b;
   z-index: 30;
 }
 
 .lab-right-panel .main-button,
 .lab-right-panel button {
-  background: rgba(255, 255, 255, 0.15);
-  color: #f8f9ff;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: #ffffff;
+  color: #1e293b;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.12);
 }
 
 .lab-right-panel .main-button:hover,
 .lab-right-panel button:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: #f8fafc;
 }


### PR DESCRIPTION
## Summary
- lighten the lab right panel with a brighter background, subtle border, and refined button styling
- fix background/content canvas alignment so pointer interactions line up with rendered cells
- refresh the lab palette rendering colors for an opaque panel feel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e50232e7d483329e313bb1817a6b14