### PR TITLE
Brighten lab panels and correct canvas alignment

### DIFF
--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -40,12 +40,25 @@ function resetTransformAndClear(ctx) {
   ctx.restore();
 }
 
-function drawInfiniteGrid(ctx, camera, { background = '#0d101a', panelFill = 'rgba(22, 26, 42, 0.6)', gridFillA = 'rgba(255,255,255,0.05)', gridFillB = 'rgba(255,255,255,0.08)', gridStroke = 'rgba(255,255,255,0.12)' } = {}) {
+function drawInfiniteGrid(
+  ctx,
+  camera,
+  {
+    background = '#0d101a',
+    panelFill = 'rgba(22, 26, 42, 0.6)',
+    gridFillA = 'rgba(255,255,255,0.05)',
+    gridFillB = 'rgba(255,255,255,0.08)',
+    gridStroke = 'rgba(255,255,255,0.12)'
+  } = {}
+) {
   if (!camera) return;
   resetTransformAndClear(ctx);
   const { panelWidth, scale, originX, originY } = camera.getState();
-  const width = ctx.canvas.width;
-  const height = ctx.canvas.height;
+  const baseWidth = Number.parseFloat(ctx.canvas.dataset?.baseWidth || '');
+  const baseHeight = Number.parseFloat(ctx.canvas.dataset?.baseHeight || '');
+  const dpr = Number.parseFloat(ctx.canvas.dataset?.dpr || '') || window.devicePixelRatio || 1;
+  const width = Number.isFinite(baseWidth) ? baseWidth : ctx.canvas.width / dpr;
+  const height = Number.isFinite(baseHeight) ? baseHeight : ctx.canvas.height / dpr;
 
   ctx.fillStyle = background;
   ctx.fillRect(0, 0, width, height);

--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -104,17 +104,17 @@ function createLabController() {
       canvasSize: { width: innerWidth, height: innerHeight },
       panelDrawOptions: {
         grid: {
-          background: '#0c0f19',
-          panelFill: 'rgba(28,34,54,0.65)',
-          gridFillA: 'rgba(255,255,255,0.06)',
-          gridFillB: 'rgba(255,255,255,0.1)',
-          gridStroke: 'rgba(255,255,255,0.15)'
+          background: '#eaf0ff',
+          panelFill: 'rgba(240, 244, 255, 0.95)',
+          gridFillA: 'rgba(148, 163, 184, 0.16)',
+          gridFillB: 'rgba(148, 163, 184, 0.24)',
+          gridStroke: 'rgba(99, 102, 241, 0.28)'
         },
         panel: {
-          background: 'rgba(255,255,255,0.25)',
-          border: 'rgba(255,255,255,0.4)',
-          labelColor: '#eef2ff',
-          itemGradient: ['rgba(245,246,255,0.95)', 'rgba(214,220,255,0.9)']
+          background: 'rgba(248, 250, 255, 0.98)',
+          border: 'rgba(148, 163, 184, 0.55)',
+          labelColor: '#1e293b',
+          itemGradient: ['rgba(226, 232, 255, 0.95)', 'rgba(199, 210, 254, 0.92)']
         }
       }
     }

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -132,6 +132,12 @@ html, body {
     align-items: center;
     gap: 1rem;
     flex-shrink: 0;
+    background: linear-gradient(180deg, rgba(248, 250, 255, 0.96), rgba(228, 233, 255, 0.94));
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 18px;
+    padding: 1.75rem 1.5rem;
+    box-shadow: 0 18px 40px rgba(99, 102, 241, 0.18);
+    color: #1e293b;
   }
 
   #gameTitle {
@@ -2720,7 +2726,7 @@ html, body {
 
 body.lab-mode-active {
   overflow: hidden;
-  background-color: #070a12;
+  background-color: #eef2ff;
 }
 
 .lab-right-panel {
@@ -2730,20 +2736,23 @@ body.lab-mode-active {
   height: 100vh;
   max-height: 100vh;
   overflow-y: auto;
-  background: linear-gradient(180deg, rgba(18, 22, 36, 0.92), rgba(12, 16, 28, 0.94));
-  padding: 1.5rem 1.25rem;
-  box-shadow: -12px 0 30px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg, rgba(248, 250, 255, 0.98), rgba(226, 232, 255, 0.96));
+  padding: 2rem 1.75rem;
+  box-shadow: -14px 0 40px rgba(99, 102, 241, 0.2);
+  border-left: 1px solid rgba(148, 163, 184, 0.45);
+  color: #0f172a;
   z-index: 30;
 }
 
 .lab-right-panel .main-button,
 .lab-right-panel button {
-  background: rgba(255, 255, 255, 0.15);
-  color: #f8f9ff;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: linear-gradient(180deg, #ffffff 0%, #e0e7ff 100%);
+  color: #1e293b;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.18);
 }
 
 .lab-right-panel .main-button:hover,
 .lab-right-panel button:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: linear-gradient(180deg, #f8fafc 0%, #c7d2fe 100%);
 }


### PR DESCRIPTION
## Summary
- brighten the right panel styling and buttons so the lab UI no longer appears black
- give the lab palette canvas an opaque panel look with updated colours and borders
- fix lab canvas alignment on high-DPI displays by basing infinite grid rendering on CSS dimensions

## Testing
- Manual verification in browser (lab mode)


------
https://chatgpt.com/codex/tasks/task_e_68e50232e7d483329e313bb1817a6b14