### PR TITLE
Fix lab canvas coordinate alignment

### DIFF
--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -234,10 +234,6 @@ export function renderContent(ctx, circuit, phase = 0, offsetX = 0, hoverId = nu
   resetTransformAndClear(ctx);
   ctx.save();
   if (camera) {
-    const { panelWidth, originX, originY, scale } = camera.getState();
-    ctx.translate(panelWidth, 0);
-    ctx.scale(scale, scale);
-    ctx.translate(-originX, -originY);
     offsetX = 0;
   }
   Object.values(circuit.wires).forEach(w => drawWire(ctx, w, phase, offsetX, camera));


### PR DESCRIPTION
## Summary
- remove the extra camera-based transforms when rendering content so lab canvases share the same coordinate space

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5068952708332807dcb7f349dc79d