### PR TITLE
Improve Lab Mode palette styling and layout

### DIFF
--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -230,9 +230,32 @@ export function drawWire(ctx, wire, phase = 0, offsetX = 0, camera = null) {
 }
 
 // Render the circuit: wires then blocks to keep z-order
-export function renderContent(ctx, circuit, phase = 0, offsetX = 0, hoverId = null, camera = null) {
+export function renderContent(
+  ctx,
+  circuit,
+  phase = 0,
+  offsetX = 0,
+  hoverId = null,
+  camera = null
+) {
   resetTransformAndClear(ctx);
+  const panelClipWidth = offsetX;
+  const baseWidth = Number.parseFloat(ctx.canvas.dataset?.baseWidth || '');
+  const baseHeight = Number.parseFloat(ctx.canvas.dataset?.baseHeight || '');
+  const dpr = Number.parseFloat(ctx.canvas.dataset?.dpr || '') || window.devicePixelRatio || 1;
+  const clipWidth = Number.isFinite(baseWidth) ? baseWidth : ctx.canvas.width / dpr;
+  const clipHeight = Number.isFinite(baseHeight) ? baseHeight : ctx.canvas.height / dpr;
   ctx.save();
+  if (panelClipWidth > 0) {
+    ctx.beginPath();
+    ctx.rect(
+      panelClipWidth,
+      0,
+      Math.max(0, clipWidth - panelClipWidth),
+      clipHeight
+    );
+    ctx.clip();
+  }
   if (camera) {
     offsetX = 0;
   }
@@ -249,9 +272,16 @@ export function drawPanel(ctx, items, panelWidth, canvasHeight, groups = [], opt
     background = '#ffffff',
     border = '#ddd',
     labelColor = '#555',
-    itemGradient = ['#f0f0ff', '#d0d0ff']
+    itemGradient = ['#f0f0ff', '#d0d0ff'],
+    panelBackground = null
   } = options;
   ctx.clearRect(0, 0, panelWidth, canvasHeight);
+  if (panelBackground) {
+    ctx.save();
+    ctx.fillStyle = panelBackground;
+    ctx.fillRect(0, 0, panelWidth, canvasHeight);
+    ctx.restore();
+  }
   groups.forEach(g => {
     ctx.save();
     ctx.fillStyle = background;

--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -47,6 +47,7 @@ let labCircuit = null;
 let labCamera = null;
 let rightPanelPlaceholder = null;
 let originalGradeDisplay = '';
+let originalGameTitleText = '';
 
 function moveRightPanelInto(container) {
   const rightPanel = document.getElementById('rightPanel');
@@ -104,14 +105,15 @@ function createLabController() {
       canvasSize: { width: innerWidth, height: innerHeight },
       panelDrawOptions: {
         grid: {
-          background: '#eaf0ff',
-          panelFill: 'rgba(240, 244, 255, 0.95)',
+          background: '#e4ecff',
+          panelFill: '#eef2ff',
           gridFillA: 'rgba(148, 163, 184, 0.16)',
           gridFillB: 'rgba(148, 163, 184, 0.24)',
           gridStroke: 'rgba(99, 102, 241, 0.28)'
         },
         panel: {
-          background: 'rgba(248, 250, 255, 0.98)',
+          panelBackground: '#f8faff',
+          background: '#f0f4ff',
           border: 'rgba(148, 163, 184, 0.55)',
           labelColor: '#1e293b',
           itemGradient: ['rgba(226, 232, 255, 0.95)', 'rgba(199, 210, 254, 0.92)']
@@ -135,6 +137,13 @@ function showLabScreen() {
   moveRightPanelInto(labScreen);
   labScreen.style.display = 'block';
   document.body.classList.add('lab-mode-active');
+  const titleEl = document.getElementById('gameTitle');
+  if (titleEl) {
+    if (!originalGameTitleText) {
+      originalGameTitleText = titleEl.textContent || '';
+    }
+    titleEl.textContent = '🔬 Lab Mode';
+  }
   if (!labInitialized) {
     createLabController();
     labInitialized = true;
@@ -151,6 +160,11 @@ function hideLabScreen() {
   const firstScreen = document.getElementById('firstScreen');
   if (firstScreen) firstScreen.style.display = '';
   document.body.classList.remove('lab-mode-active');
+  const titleEl = document.getElementById('gameTitle');
+  if (titleEl) {
+    const fallbackTitle = originalGameTitleText || '🧠 Bitwiser';
+    titleEl.textContent = fallbackTitle;
+  }
 }
 
 export function initializeLabMode() {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2700,8 +2700,8 @@ html, body {
 
 .lab-exit-btn {
   position: fixed;
-  top: 1.5rem;
-  left: 1.5rem;
+  bottom: 1.5rem;
+  right: 1.5rem;
   padding: 0.6rem 1.25rem;
   border-radius: 999px;
   border: none;


### PR DESCRIPTION
## Summary
- make the Lab Mode palette draw with an opaque background and refreshed color palette
- prevent panned circuit elements from overlapping the palette area by clipping the content canvas
- update the Lab Mode title text and reposition the exit button to the lower-right corner

## Testing
- Manually opened Lab Mode in the browser to verify the updated layout

------
https://chatgpt.com/codex/tasks/task_e_68e50c87c4548332843cdcf1619d3129