### PR TITLE
Implement dynamic IN/OUT palette for Lab Mode

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -41,7 +41,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     camera: externalCamera = null,
     unboundedGrid = false,
     canvasSize = null,
-    panelDrawOptions = {}
+    panelDrawOptions = {},
+    dynamicPaletteConfig = null
   } = options;
   const camera = externalCamera && typeof externalCamera.screenToCell === 'function'
     ? externalCamera
@@ -59,6 +60,10 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   let paletteItems = [];
   let groupRects = [];
   const clampToBounds = !unboundedGrid;
+  const dynamicConfig = dynamicPaletteConfig && typeof dynamicPaletteConfig === 'object'
+    ? dynamicPaletteConfig
+    : null;
+  const dynamicPaletteItems = new Map();
 
   if (paletteGroups.length > 0) {
     const colWidth =
@@ -71,7 +76,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       const padding = GROUP_PADDING;
       let currentY = y + padding + LABEL_H + 5;
       g.items.forEach(it => {
-        paletteItems.push({
+        const paletteItem = {
           type: it.type,
           label: it.label || it.type,
           x: x + padding,
@@ -80,7 +85,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
           h: PALETTE_ITEM_H - 20,
           hidden:
             forceHideInOut && (it.type === 'INPUT' || it.type === 'OUTPUT'),
-        });
+        };
+        paletteItems.push(paletteItem);
+        if (dynamicConfig?.[it.type]) {
+          if (!dynamicPaletteItems.has(it.type)) {
+            dynamicPaletteItems.set(it.type, []);
+          }
+          dynamicPaletteItems.get(it.type).push(paletteItem);
+        }
         currentY += PALETTE_ITEM_H;
       });
       const groupHeight = LABEL_H + 5 + g.items.length * PALETTE_ITEM_H + padding * 2 - 10;
@@ -102,6 +114,16 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       h: PALETTE_ITEM_H - 20,
       hidden: forceHideInOut && (type === 'INPUT' || type === 'OUTPUT'),
     }));
+    if (dynamicConfig) {
+      paletteItems.forEach(item => {
+        if (dynamicConfig[item.type]) {
+          if (!dynamicPaletteItems.has(item.type)) {
+            dynamicPaletteItems.set(item.type, []);
+          }
+          dynamicPaletteItems.get(item.type).push(item);
+        }
+      });
+    }
     canvasHeight = Math.max(canvasHeight, palette.length * PALETTE_ITEM_H + 20);
   }
 
@@ -302,6 +324,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function hidePaletteItem(type, label) {
+    if (dynamicConfig?.[type]) return;
     const item = paletteItems.find(it => it.type === type && it.label === label);
     if (item) {
       item.hidden = true;
@@ -310,6 +333,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function showPaletteItem(type, label) {
+    if (dynamicConfig?.[type]) return;
     const item = paletteItems.find(it => it.type === type && it.label === label);
     if (item) {
       if (forceHideInOut && (type === 'INPUT' || type === 'OUTPUT')) return;
@@ -334,7 +358,45 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function syncPaletteWithCircuit() {
+    const usedNamesByType = new Map();
+    Object.values(circuit.blocks).forEach(b => {
+      if (!usedNamesByType.has(b.type)) {
+        usedNamesByType.set(b.type, new Set());
+      }
+      usedNamesByType.get(b.type).add(b.name);
+    });
+
+    if (dynamicConfig) {
+      dynamicPaletteItems.forEach((items, type) => {
+        const config = dynamicConfig[type];
+        if (!config) return;
+        const prefix = typeof config.prefix === 'string' ? config.prefix : '';
+        const startIndex = Number.isFinite(config.startIndex) ? config.startIndex : 1;
+        const used = usedNamesByType.get(type) || new Set();
+        const available = [];
+        let current = startIndex;
+        while (available.length < items.length) {
+          const candidate = `${prefix}${current}`;
+          if (!used.has(candidate)) {
+            available.push(candidate);
+          }
+          current += 1;
+        }
+        items.forEach((item, index) => {
+          const label = available[index];
+          item.label = label;
+          item.name = label;
+          if (forceHideInOut && (item.type === 'INPUT' || item.type === 'OUTPUT')) {
+            item.hidden = true;
+          } else {
+            item.hidden = false;
+          }
+        });
+      });
+    }
+
     paletteItems.forEach(it => {
+      if (dynamicConfig?.[it.type]) return;
       if (it.type === 'INPUT' || it.type === 'OUTPUT') {
         if (forceHideInOut) {
           it.hidden = true;
@@ -1110,7 +1172,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     snapshot();
   }
 
-  updateUsageCounts();
+  syncPaletteWithCircuit();
   snapshot();
   return {
     state,

--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -9,6 +9,7 @@ function collectPaletteGroups() {
   Object.values(blockSets).forEach(list => {
     (list || []).forEach(block => {
       if (!block || !block.type) return;
+      if (block.type === 'INPUT' || block.type === 'OUTPUT') return;
       const key = `${block.type}:${block.name || ''}`;
       if (!unique.has(key)) {
         unique.set(key, {
@@ -21,9 +22,6 @@ function collectPaletteGroups() {
 
   if (!unique.size) {
     [
-      { type: 'INPUT', name: 'A' },
-      { type: 'INPUT', name: 'B' },
-      { type: 'OUTPUT', name: 'OUT' },
       { type: 'AND' },
       { type: 'OR' },
       { type: 'NOT' },
@@ -34,10 +32,19 @@ function collectPaletteGroups() {
     });
   }
 
-  const blocks = Array.from(unique.values()).map(block => ({
+  const dynamicInputs = Array.from({ length: 5 }).map((_, i) => ({
+    type: 'INPUT',
+    name: `IN${i + 1}`,
+  }));
+  const dynamicOutputs = Array.from({ length: 5 }).map((_, i) => ({
+    type: 'OUTPUT',
+    name: `OUT${i + 1}`,
+  }));
+  const otherBlocks = Array.from(unique.values()).map(block => ({
     type: block.type,
     name: block.name,
   }));
+  const blocks = [...dynamicInputs, ...dynamicOutputs, ...otherBlocks];
   return buildPaletteGroups(blocks);
 }
 
@@ -101,6 +108,10 @@ function createLabController() {
       paletteGroups,
       panelWidth: 220,
       camera: labCamera,
+      dynamicPaletteConfig: {
+        INPUT: { prefix: 'IN', startIndex: 1 },
+        OUTPUT: { prefix: 'OUT', startIndex: 1 },
+      },
       unboundedGrid: true,
       canvasSize: { width: innerWidth, height: innerHeight },
       panelDrawOptions: {


### PR DESCRIPTION
## Summary
- ensure the Lab palette seeds IN1–IN5 and OUT1–OUT5 while filtering out other input/output labels
- add controller support for dynamic palettes that surface the lowest unused IN/OUT numbers
- initialize the Lab controller with the new dynamic palette behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e512eda578833288c553ec00ee0a96