### PR TITLE
Fix lab mode intro trigger and restore shortcuts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -503,6 +503,9 @@ document.getElementById("showIntroBtn").addEventListener("click", () => {
 });
 
 document.getElementById("gameTitle").addEventListener("click", () => {
+  if (document.body.classList.contains('lab-mode-active')) {
+    return;
+  }
   const level = getCurrentLevel();
   const customProblem = getActiveCustomProblem();
   if (level != null) {


### PR DESCRIPTION
## Summary
- prevent the stage intro modal from opening when the lab mode title is clicked
- keep the lab mode controller alive across re-entries and rebind its keyboard shortcuts so toggles keep working
- expose a reusable keyboard binding helper on the canvas controller for lab mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e51880239c83328819dbab44514dc3