### PR TITLE
Make lab mode grid infinite and revert to default colors

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -43,6 +43,10 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     canvasSize = null,
     panelDrawOptions = {}
   } = options;
+  const gridDrawOptions = unboundedGrid
+    ? { ...(panelDrawOptions.grid || {}), unbounded: true }
+    : panelDrawOptions.grid;
+  const panelStyleOptions = panelDrawOptions.panel;
   const camera = externalCamera && typeof externalCamera.screenToCell === 'function'
     ? externalCamera
     : null;
@@ -201,8 +205,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function refreshBackground() {
-    drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, camera, panelDrawOptions.grid);
-    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects, panelDrawOptions.panel);
+    drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, camera, gridDrawOptions);
+    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects, panelStyleOptions);
   }
 
   function refreshContent() {
@@ -291,14 +295,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     applyState(next);
   }
 
-  drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, camera, panelDrawOptions.grid);
-  drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects, panelDrawOptions.panel);
+  drawGrid(bgCtx, circuit.rows, circuit.cols, panelTotalWidth, camera, gridDrawOptions);
+  drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects, panelStyleOptions);
   startEngine(contentCtx, circuit, (ctx, circ, phase) =>
     renderContent(ctx, circ, phase, panelTotalWidth, state.hoverBlockId, camera)
   );
 
   function redrawPanel() {
-    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects, panelDrawOptions.panel);
+    drawPanel(bgCtx, paletteItems, panelTotalWidth, canvasHeight, groupRects, panelStyleOptions);
   }
 
   function hidePaletteItem(type, label) {

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -149,6 +149,11 @@ function drawInfiniteGrid(ctx, camera, options = {}) {
 
 // Draw grid as individual tiles with gaps similar to GIF rendering
 export function drawGrid(ctx, rows, cols, offsetX = 0, camera = null, options = {}) {
+  const { unbounded, ...styleOptions } = options || {};
+  if (unbounded && camera) {
+    drawInfiniteGrid(ctx, camera, styleOptions);
+    return;
+  }
   const {
     background,
     panelFill,
@@ -160,7 +165,7 @@ export function drawGrid(ctx, rows, cols, offsetX = 0, camera = null, options = 
     cellRadius,
     borderColor,
     borderWidth
-  } = resolveGridStyle(options);
+  } = resolveGridStyle(styleOptions);
 
   resetTransformAndClear(ctx);
 

--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -176,13 +176,6 @@ function createLabController({ preserveCircuit = false } = {}) {
       canvasSize: { width: innerWidth, height: innerHeight },
       onCircuitModified: applyDynamicIOPalette,
       panelDrawOptions: {
-        grid: {
-          background: '#e4ecff',
-          panelFill: '#eef2ff',
-          gridFillA: 'rgba(148, 163, 184, 0.16)',
-          gridFillB: 'rgba(148, 163, 184, 0.24)',
-          gridStroke: 'rgba(99, 102, 241, 0.28)'
-        },
         panel: {
           panelBackground: '#f8faff',
           background: '#f0f4ff',


### PR DESCRIPTION
## Summary
- allow the canvas renderer to draw an infinite tiled grid when lab mode uses the camera
- propagate the unbounded grid flag from the controller so lab mode skips drawing a border
- remove the custom lab grid palette to fall back to the default white styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5f03c3750833299b940ed37df11d9