### PR TITLE
Fix pointer coordinate normalization for scaled grids

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -559,7 +559,11 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   // 공통 포인터 좌표 계산 (마우스/터치)
   function getPointerPos(e) {
     const rect = e.target.getBoundingClientRect();
-    const scale = parseFloat(e.target?.dataset.scale || '1');
+    const shouldNormalize = !useCamera;
+    const rawScale = shouldNormalize
+      ? parseFloat(e.target?.dataset.scale || '1')
+      : 1;
+    const scale = Number.isFinite(rawScale) && rawScale > 0 ? rawScale : 1;
     const point = e.touches?.[0] || e.changedTouches?.[0] || e;
     return {
       x: (point.clientX - rect.left) / scale,


### PR DESCRIPTION
## Summary
- avoid double-applying scale factors when the play grid uses the camera-based renderer
- normalize pointer positions only for CSS-scaled canvases so clicks match cells after resizing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5f95fad7c83329e2bfdf49e2f9645