### PR TITLE
Clamp camera pan and zoom within grid bounds

### DIFF
--- a/src/canvas/camera.js
+++ b/src/canvas/camera.js
@@ -10,6 +10,94 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
   let viewportHeight = 0;
   let panel = panelWidth;
   let changeHandler = null;
+  let worldWidth = Number.POSITIVE_INFINITY;
+  let worldHeight = Number.POSITIVE_INFINITY;
+  let clampToBounds = false;
+  let minScaleForBounds = 0;
+
+  function getEffectiveViewportWidth() {
+    return Math.max(0, viewportWidth - panel);
+  }
+
+  function getEffectiveViewportHeight() {
+    return Math.max(0, viewportHeight);
+  }
+
+  function hasFiniteWidth() {
+    return Number.isFinite(worldWidth);
+  }
+
+  function hasFiniteHeight() {
+    return Number.isFinite(worldHeight);
+  }
+
+  function clampNumber(value, min, max) {
+    if (min > max) {
+      return (min + max) / 2;
+    }
+    return Math.max(min, Math.min(max, value));
+  }
+
+  function clampOrigin() {
+    if (!clampToBounds) return;
+    const effectiveWidth = getEffectiveViewportWidth();
+    const effectiveHeight = getEffectiveViewportHeight();
+    if (hasFiniteWidth() && currentScale > 0) {
+      const visibleWidth = effectiveWidth / currentScale;
+      const maxOriginX = worldWidth - visibleWidth;
+      if (Number.isFinite(maxOriginX)) {
+        if (maxOriginX >= 0) {
+          originX = clampNumber(originX, 0, maxOriginX);
+        } else {
+          originX = maxOriginX / 2;
+        }
+      }
+    }
+    if (hasFiniteHeight() && currentScale > 0) {
+      const visibleHeight = effectiveHeight / currentScale;
+      const maxOriginY = worldHeight - visibleHeight;
+      if (Number.isFinite(maxOriginY)) {
+        if (maxOriginY >= 0) {
+          originY = clampNumber(originY, 0, maxOriginY);
+        } else {
+          originY = maxOriginY / 2;
+        }
+      }
+    }
+  }
+
+  function updateBoundConstraints() {
+    if (!clampToBounds) {
+      minScaleForBounds = 0;
+      return;
+    }
+    const effectiveWidth = getEffectiveViewportWidth();
+    const effectiveHeight = getEffectiveViewportHeight();
+    let nextMinScale = 0;
+    if (hasFiniteWidth() && worldWidth > 0 && effectiveWidth > 0) {
+      nextMinScale = Math.max(nextMinScale, effectiveWidth / worldWidth);
+    }
+    if (hasFiniteHeight() && worldHeight > 0 && effectiveHeight > 0) {
+      nextMinScale = Math.max(nextMinScale, effectiveHeight / worldHeight);
+    }
+    if (!Number.isFinite(nextMinScale) || nextMinScale < 0) {
+      nextMinScale = 0;
+    }
+    minScaleForBounds = nextMinScale;
+    if (minScaleForBounds > 0 && currentScale < minScaleForBounds) {
+      currentScale = minScaleForBounds;
+    }
+    clampOrigin();
+  }
+
+  function clampScaleToBounds(nextScale) {
+    let scaleValue = nextScale;
+    if (!Number.isFinite(scaleValue) || scaleValue <= 0) return null;
+    if (clampToBounds && minScaleForBounds > 0) {
+      scaleValue = Math.max(scaleValue, minScaleForBounds);
+    }
+    return scaleValue;
+  }
 
   function notifyChange() {
     if (typeof changeHandler === 'function') {
@@ -21,12 +109,14 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     if (!Number.isFinite(width) || !Number.isFinite(height)) return;
     viewportWidth = width;
     viewportHeight = height;
+    updateBoundConstraints();
     notifyChange();
   }
 
   function setPanelWidth(width) {
     if (!Number.isFinite(width)) return;
     panel = width;
+    updateBoundConstraints();
     notifyChange();
   }
 
@@ -34,20 +124,23 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     if (!Number.isFinite(dx) || !Number.isFinite(dy)) return;
     originX -= dx / currentScale;
     originY -= dy / currentScale;
+    clampOrigin();
     notifyChange();
   }
 
   function setScale(nextScale, pivotX, pivotY) {
-    if (!Number.isFinite(nextScale) || nextScale <= 0) return;
+    const clamped = clampScaleToBounds(nextScale);
+    if (!Number.isFinite(clamped) || clamped <= 0) return;
     if (pivotX !== undefined && pivotY !== undefined) {
       const before = screenToWorld(pivotX, pivotY);
-      currentScale = nextScale;
+      currentScale = clamped;
       const after = screenToWorld(pivotX, pivotY);
       originX += before.x - after.x;
       originY += before.y - after.y;
     } else {
-      currentScale = nextScale;
+      currentScale = clamped;
     }
+    clampOrigin();
     notifyChange();
   }
 
@@ -94,6 +187,20 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     };
   }
 
+  function setBounds(width, height, { clamp = true } = {}) {
+    const normalizedWidth = Number.isFinite(width) && width >= 0
+      ? width
+      : Number.POSITIVE_INFINITY;
+    const normalizedHeight = Number.isFinite(height) && height >= 0
+      ? height
+      : Number.POSITIVE_INFINITY;
+    worldWidth = normalizedWidth;
+    worldHeight = normalizedHeight;
+    clampToBounds = Boolean(clamp) && (hasFiniteWidth() || hasFiniteHeight());
+    updateBoundConstraints();
+    notifyChange();
+  }
+
   function setOnChange(handler) {
     changeHandler = typeof handler === 'function' ? handler : null;
   }
@@ -102,6 +209,7 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     originX = 0;
     originY = 0;
     currentScale = scale;
+    updateBoundConstraints();
     notifyChange();
   }
 
@@ -110,6 +218,7 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     setScale,
     setViewport,
     setPanelWidth,
+    setBounds,
     screenToCell,
     screenToWorld,
     worldToScreen,

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -124,6 +124,11 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   if (useCamera) {
     camera.setPanelWidth(panelTotalWidth);
     camera.setViewport(canvasWidth, canvasHeight);
+    camera.setBounds(
+      clampToBounds ? baseGridWidth : undefined,
+      clampToBounds ? baseGridHeight : undefined,
+      { clamp: clampToBounds }
+    );
   }
   let bgCtx = setupCanvas(bgCanvas, canvasWidth, canvasHeight);
   let contentCtx = setupCanvas(contentCanvas, canvasWidth, canvasHeight);


### PR DESCRIPTION
## Summary
- add camera bound management to keep finite grids within view during pan and zoom
- hook controller up to provide grid dimensions to the shared camera instance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5fea9bd6c8332b4c1bd1c73e60a66