### PR TITLE
Enable panning with left drag on empty grid cells

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -890,6 +890,18 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
               state.dragCandidate = { id: bid, start: cell };
             }
             handled = true;
+          } else if (
+            useCamera &&
+            isPrimary &&
+            state.mode === 'idle' &&
+            !bid &&
+            !cellHasWire(cell)
+          ) {
+            state.panning = true;
+            state.panLast = { x, y };
+            state.pointerDown = null;
+            handled = true;
+            e.preventDefault();
           }
         }
       }


### PR DESCRIPTION
## Summary
- allow camera panning to start when dragging the primary mouse button over empty grid cells
- keep existing drag interactions intact by checking for blocks and wires before initiating a pan

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e602c7738c8332abd8e4599be88e60