### PR TITLE
Allow native gestures when zooming or panning hits limits

### DIFF
--- a/src/canvas/camera.js
+++ b/src/canvas/camera.js
@@ -121,16 +121,25 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
   }
 
   function pan(dx, dy) {
-    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return;
+    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return false;
+    const beforeX = originX;
+    const beforeY = originY;
     originX -= dx / currentScale;
     originY -= dy / currentScale;
     clampOrigin();
-    notifyChange();
+    const changed =
+      Math.abs(originX - beforeX) > 1e-6 ||
+      Math.abs(originY - beforeY) > 1e-6;
+    if (changed) notifyChange();
+    return changed;
   }
 
   function setScale(nextScale, pivotX, pivotY) {
     const clamped = clampScaleToBounds(nextScale);
-    if (!Number.isFinite(clamped) || clamped <= 0) return;
+    if (!Number.isFinite(clamped) || clamped <= 0) return false;
+    const beforeScale = currentScale;
+    const beforeOriginX = originX;
+    const beforeOriginY = originY;
     if (pivotX !== undefined && pivotY !== undefined) {
       const before = screenToWorld(pivotX, pivotY);
       currentScale = clamped;
@@ -141,7 +150,12 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
       currentScale = clamped;
     }
     clampOrigin();
-    notifyChange();
+    const changed =
+      Math.abs(currentScale - beforeScale) > 1e-6 ||
+      Math.abs(originX - beforeOriginX) > 1e-6 ||
+      Math.abs(originY - beforeOriginY) > 1e-6;
+    if (changed) notifyChange();
+    return changed;
   }
 
   function screenToWorld(x, y) {


### PR DESCRIPTION
## Summary
- track whether camera pan or scale calls actually change the viewport
- let pinch gestures fall back to the browser zoom when the grid is already at its minimum scale
- allow touch panning to defer to native scrolling when the camera cannot move further

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6049316788332b0734a164431ab6e