### PR TITLE
Allow browser defaults when gestures hit grid bounds

### DIFF
--- a/src/canvas/camera.js
+++ b/src/canvas/camera.js
@@ -121,11 +121,16 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
   }
 
   function pan(dx, dy) {
-    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return;
+    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return false;
+    const prevX = originX;
+    const prevY = originY;
     originX -= dx / currentScale;
     originY -= dy / currentScale;
     clampOrigin();
+    const changed =
+      Math.abs(originX - prevX) > 1e-5 || Math.abs(originY - prevY) > 1e-5;
     notifyChange();
+    return changed;
   }
 
   function setScale(nextScale, pivotX, pivotY) {


### PR DESCRIPTION
## Summary
- allow pinch gestures on bounded grids to fall back to the browser zoom when no further scaling or panning is possible
- only prevent default on touch drags when the interaction actually moves the grid or elements, reusing the camera pan result
- return whether the camera moved during panning so gesture handlers can detect blocked movement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6049316788332b0734a164431ab6e