### PR TITLE
Fix pinch zoom anchoring and disable double tap zoom

### DIFF
--- a/src/canvas/camera.js
+++ b/src/canvas/camera.js
@@ -133,6 +133,21 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     return changed;
   }
 
+  function setOrigin(nextOriginX, nextOriginY) {
+    if (!Number.isFinite(nextOriginX) || !Number.isFinite(nextOriginY)) {
+      return false;
+    }
+    const prevX = originX;
+    const prevY = originY;
+    originX = nextOriginX;
+    originY = nextOriginY;
+    clampOrigin();
+    const changed =
+      Math.abs(originX - prevX) > 1e-5 || Math.abs(originY - prevY) > 1e-5;
+    notifyChange();
+    return changed;
+  }
+
   function setScale(nextScale, pivotX, pivotY) {
     const clamped = clampScaleToBounds(nextScale);
     if (!Number.isFinite(clamped) || clamped <= 0) return;
@@ -220,6 +235,7 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
 
   return {
     pan,
+    setOrigin,
     setScale,
     setViewport,
     setPanelWidth,

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -54,6 +54,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   const MIN_CAMERA_SCALE = 0.2;
   const MAX_CAMERA_SCALE = 3;
   const ZOOM_SENSITIVITY = 0.0015;
+  const DOUBLE_TAP_DELAY_MS = 300;
   const gap = 10;
   const PALETTE_ITEM_H = 50;
   const LABEL_H = 20;
@@ -167,6 +168,9 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   const undoStack = [];
   const redoStack = [];
   let hasInitialSnapshot = false;
+
+  let lastSingleTouchTime = 0;
+  let doubleTapPrevented = false;
 
   const pitch = CELL + GAP;
 
@@ -645,29 +649,51 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     if (!Number.isFinite(distance) || distance <= 0) {
       return false;
     }
-    const previousScale = camera.getState().scale;
+    const previousCameraState = camera.getState();
+    const previousScale = previousCameraState.scale;
     const scaleRatio = distance / pinch.startDistance;
     const targetScale = clamp(pinch.startScale * scaleRatio, MIN_CAMERA_SCALE, MAX_CAMERA_SCALE);
     camera.setScale(targetScale);
-    const { scale: appliedScale, originX, originY } = camera.getState();
+    const {
+      scale: appliedScale,
+      originX,
+      originY,
+      panelWidth: appliedPanelWidth
+    } = camera.getState();
     const scaleChanged = Math.abs(appliedScale - previousScale) > 1e-4;
-    const desiredOriginX1 = pinch.world1.x - (pos1.x - panelTotalWidth) / appliedScale;
+    const panelForCalc = Number.isFinite(appliedPanelWidth)
+      ? appliedPanelWidth
+      : panelTotalWidth;
+    const desiredOriginsX = [];
+    const desiredOriginsY = [];
+    const desiredOriginX1 = pinch.world1.x - (pos1.x - panelForCalc) / appliedScale;
     const desiredOriginY1 = pinch.world1.y - pos1.y / appliedScale;
-    const desiredOriginX2 = pinch.world2.x - (pos2.x - panelTotalWidth) / appliedScale;
-    const desiredOriginY2 = pinch.world2.y - pos2.y / appliedScale;
-    const desiredOriginX = (desiredOriginX1 + desiredOriginX2) / 2;
-    const desiredOriginY = (desiredOriginY1 + desiredOriginY2) / 2;
-    const deltaOriginX = originX - desiredOriginX;
-    const deltaOriginY = originY - desiredOriginY;
-    let panChanged = false;
-    if (Math.abs(deltaOriginX) > 1e-4 || Math.abs(deltaOriginY) > 1e-4) {
-      panChanged = camera.pan(deltaOriginX * appliedScale, deltaOriginY * appliedScale);
+    if (Number.isFinite(desiredOriginX1) && Number.isFinite(desiredOriginY1)) {
+      desiredOriginsX.push(desiredOriginX1);
+      desiredOriginsY.push(desiredOriginY1);
     }
-    if (!scaleChanged && !panChanged && scaleRatio < 1 && clampToBounds) {
+    const desiredOriginX2 = pinch.world2.x - (pos2.x - panelForCalc) / appliedScale;
+    const desiredOriginY2 = pinch.world2.y - pos2.y / appliedScale;
+    if (Number.isFinite(desiredOriginX2) && Number.isFinite(desiredOriginY2)) {
+      desiredOriginsX.push(desiredOriginX2);
+      desiredOriginsY.push(desiredOriginY2);
+    }
+    let originChanged = false;
+    if (desiredOriginsX.length > 0 && desiredOriginsY.length > 0) {
+      const desiredOriginX = desiredOriginsX.reduce((sum, value) => sum + value, 0) / desiredOriginsX.length;
+      const desiredOriginY = desiredOriginsY.reduce((sum, value) => sum + value, 0) / desiredOriginsY.length;
+      const originNeedsUpdate =
+        Math.abs(originX - desiredOriginX) > 1e-4 ||
+        Math.abs(originY - desiredOriginY) > 1e-4;
+      if (originNeedsUpdate) {
+        originChanged = camera.setOrigin(desiredOriginX, desiredOriginY);
+      }
+    }
+    if (!scaleChanged && !originChanged && scaleRatio < 1 && clampToBounds) {
       endPinch();
       return false;
     }
-    return scaleChanged || panChanged;
+    return scaleChanged || originChanged;
   }
 
   function endPinch() {
@@ -917,6 +943,20 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   overlayCanvas.addEventListener('mousedown', handlePointerDown);
   overlayCanvas.addEventListener('touchstart', e => {
+    if (e.touches) {
+      if (e.touches.length === 1) {
+        const now = performance.now();
+        const isDoubleTap = now - lastSingleTouchTime < DOUBLE_TAP_DELAY_MS;
+        doubleTapPrevented = isDoubleTap;
+        if (isDoubleTap && e.cancelable) {
+          e.preventDefault();
+        }
+        lastSingleTouchTime = now;
+      } else {
+        lastSingleTouchTime = 0;
+        doubleTapPrevented = false;
+      }
+    }
     if (useCamera && e.touches && e.touches.length >= 2) {
       const started = startPinch(e);
       if (started) {
@@ -924,7 +964,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       }
     }
     const handled = handlePointerDown(e);
-    if (handled && !(clampToBounds && state.panning)) e.preventDefault();
+    if (handled && !(clampToBounds && state.panning) && e.cancelable) e.preventDefault();
   }, { passive: false });
   overlayCanvas.addEventListener('contextmenu', e => e.preventDefault());
 
@@ -1307,10 +1347,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }, { passive: false });
 
   overlayCanvas.addEventListener('touchend', e => {
+    if (doubleTapPrevented && e.cancelable) {
+      e.preventDefault();
+      doubleTapPrevented = false;
+    }
     if (state.pinch && (!e.touches || e.touches.length < 2)) {
       endPinch();
     }
-  });
+  }, { passive: false });
 
   overlayCanvas.addEventListener('touchcancel', () => {
     if (state.pinch) endPinch();

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1191,6 +1191,7 @@ html, body {
     position: absolute;
     top: 0;
     left: 0;
+    touch-action: none;
   }
 
   .blockIcon {
@@ -2687,6 +2688,7 @@ html, body {
   width: 100%;
   height: 100%;
   display: block;
+  touch-action: none;
 }
 
 #labBgCanvas,


### PR DESCRIPTION
## Summary
- add camera origin setter so pinch gestures can keep touch anchors stable on bounded grids
- update pinch handling to reuse recorded world coordinates and clamp-safe origin updates
- block mobile double-tap zoom through touch gesture guards and CSS touch-action adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e60e081b68833280fd5046a6957071