### PR TITLE
Fix mobile pinch zoom stability and disable double tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       rel="stylesheet" />
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#ffffff">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="description" content="논리 회로 퍼즐 게임 - 블록을 조합해 회로를 구현하세요!">
     <meta property="og:title" content="Bitwiser">
     <meta property="og:description" content="논리 회로 퍼즐 게임 - 블록을 조합해 회로를 구현하세요!">

--- a/src/canvas/camera.js
+++ b/src/canvas/camera.js
@@ -133,6 +133,21 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
     return changed;
   }
 
+  function setOrigin(nextOriginX, nextOriginY) {
+    if (!Number.isFinite(nextOriginX) || !Number.isFinite(nextOriginY)) {
+      return false;
+    }
+    const prevX = originX;
+    const prevY = originY;
+    originX = nextOriginX;
+    originY = nextOriginY;
+    clampOrigin();
+    const changed =
+      Math.abs(originX - prevX) > 1e-5 || Math.abs(originY - prevY) > 1e-5;
+    notifyChange();
+    return changed;
+  }
+
   function setScale(nextScale, pivotX, pivotY) {
     const clamped = clampScaleToBounds(nextScale);
     if (!Number.isFinite(clamped) || clamped <= 0) return;
@@ -220,6 +235,7 @@ export function createCamera({ panelWidth = 0, scale = 1 } = {}) {
 
   return {
     pan,
+    setOrigin,
     setScale,
     setViewport,
     setPanelWidth,


### PR DESCRIPTION
## Summary
- keep pinch gestures anchored to their grid positions by scaling around the touch midpoint and updating the camera origin directly
- track recent taps and add a restrictive viewport meta tag to prevent double-tap page zoom on mobile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e60e081b68833280fd5046a6957071