### PR TITLE
Disable mobile double-tap zoom behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <title>Bitwiser</title>
     <link rel="stylesheet" href="style.v1.4.css">
     <style>
@@ -574,6 +577,27 @@
         </div>
       </div>
     </div>
+    <script>
+      (function () {
+        let lastTouchEnd = 0;
+
+        document.addEventListener(
+          "touchend",
+          function (event) {
+            const now = Date.now();
+            if (now - lastTouchEnd <= 300) {
+              event.preventDefault();
+            }
+            lastTouchEnd = now;
+          },
+          { passive: false }
+        );
+
+        document.addEventListener("gesturestart", function (event) {
+          event.preventDefault();
+        });
+      })();
+    </script>
     <script>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {


### PR DESCRIPTION
## Summary
- prevent double-tap zoom across the game by disallowing viewport scaling on mobile
- add a defensive script to swallow rapid touchend and gesturestart events that trigger zoom

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6130b850c8332b07ca66a6c8cb765