### PR TITLE
Clean up canvas controller event listeners and stop animation loops

### DIFF
--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -61,6 +61,7 @@ export function getActiveController() {
 }
 
 export function destroyPlayContext() {
+  playController?.stopEngine?.();
   playController?.destroy?.();
   playController = null;
   playCircuit = null;
@@ -69,6 +70,7 @@ export function destroyPlayContext() {
 
 export function destroyProblemContext({ destroyController = true } = {}) {
   if (destroyController) {
+    problemController?.stopEngine?.();
     problemController?.destroy?.();
   }
   problemController = null;


### PR DESCRIPTION
## Summary
- track overlay and document event listeners in the canvas controller so they can all be removed during destroy
- update the canvas engine helper to return a cancel handle and ensure controllers and grid contexts stop it during teardown
- expose the new stopEngine helper from controllers and call it when destroying play/problem contexts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e618801378833294a68d58167479e3