### PR TITLE
Ensure fixed IO user problems start with disabled IO values

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1456,7 +1456,8 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
           type: state.type,
           name: state.name,
           pos: { r, c },
-          value: state.type === 'INPUT' ? state.value === '1' : false,
+          // Fixed IN/OUT blocks always start in the disabled (0) state.
+          value: false,
           fixed: true,
         });
       }


### PR DESCRIPTION
## Summary
- reset fixed IN/OUT blocks to start in the disabled (0) state when loading user-created problems
- add documentation comment clarifying the intended initial value

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e61f73a1b48332b4d1705dce6f8411