### PR TITLE
Add confetti celebration when stages are cleared

### DIFF
--- a/src/modules/confetti.js
+++ b/src/modules/confetti.js
@@ -1,0 +1,56 @@
+const CONFETTI_MODULE_URL = 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.module.mjs';
+
+let confettiModulePromise = null;
+
+function loadConfettiModule() {
+  if (!confettiModulePromise) {
+    confettiModulePromise = import(CONFETTI_MODULE_URL);
+  }
+  return confettiModulePromise;
+}
+
+function randomInRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+export async function launchConfetti(options = {}) {
+  if (typeof window === 'undefined') return;
+
+  const { default: confetti } = await loadConfettiModule();
+  const duration = options.duration ?? 2000;
+  const endTime = Date.now() + duration;
+  const defaults = {
+    startVelocity: 40,
+    spread: 360,
+    ticks: 60,
+    zIndex: 9999,
+    gravity: 0.9
+  };
+
+  const interval = window.setInterval(() => {
+    const timeLeft = endTime - Date.now();
+
+    if (timeLeft <= 0) {
+      window.clearInterval(interval);
+      return;
+    }
+
+    const particleCount = Math.round(80 * (timeLeft / duration));
+
+    confetti({
+      ...defaults,
+      particleCount,
+      origin: { x: randomInRange(0.1, 0.3), y: Math.random() * 0.3 }
+    });
+
+    confetti({
+      ...defaults,
+      particleCount,
+      origin: { x: randomInRange(0.7, 0.9), y: Math.random() * 0.3 }
+    });
+  }, 250);
+}
+
+if (typeof window !== 'undefined') {
+  window.launchBitwiserConfetti = launchConfetti;
+}

--- a/src/modules/grading.js
+++ b/src/modules/grading.js
@@ -1,3 +1,5 @@
+import { launchConfetti } from './confetti.js';
+
 const WAIT_BETWEEN_TESTS = 100;
 
 function defaultTranslate(t) {
@@ -359,6 +361,8 @@ export function createGradingController(config = {}) {
       return;
     }
 
+    launchConfetti().catch(error => console.error('Confetti failed:', error));
+
     const { saveSuccess, loginNeeded, statusMessage } = await attemptAutoSave({
       getAutoSaveSetting,
       getCurrentUser,
@@ -490,7 +494,13 @@ export function createGradingController(config = {}) {
 
     appendReturnButton({ gradingArea: elements.gradingArea, t: translate, returnToEditScreen });
 
-    if (!allCorrect || !key) {
+    if (!allCorrect) {
+      return;
+    }
+
+    launchConfetti().catch(error => console.error('Confetti failed:', error));
+
+    if (!key) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- add a reusable confetti helper that lazy-loads canvas-confetti when needed
- trigger the confetti celebration after perfect grading results for stages and custom problems

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e6281c3e9c83328552629896aecad2