### PR TITLE
Add undo and redo controls to circuit editor toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,6 +196,28 @@
                   <img src="assets/icon_reset.svg" alt="" class="status-toolbar__icon">
                 </button>
               </div>
+              <div class="history-toolbar" role="group" aria-label="되돌리기 및 다시 실행">
+                <button
+                  id="problemUndoBtn"
+                  class="status-toolbar__button"
+                  type="button"
+                  title="되돌리기 (Z)"
+                  aria-label="되돌리기"
+                  disabled
+                >
+                  <img src="assets/icon_undo.svg" alt="" class="status-toolbar__icon">
+                </button>
+                <button
+                  id="problemRedoBtn"
+                  class="status-toolbar__button"
+                  type="button"
+                  title="다시 실행 (Y)"
+                  aria-label="다시 실행"
+                  disabled
+                >
+                  <img src="assets/icon_redo.svg" alt="" class="status-toolbar__icon">
+                </button>
+              </div>
               <div id="problemUsageSection" style="width:100%;">
                 <table id="problemUsageTable">
                   <tr>
@@ -439,6 +461,28 @@
             <button id="DeleteAllInfo" class="status-toolbar__button" type="button"
               title="R - 회로 초기화" aria-label="R - 회로 초기화">
               <img src="assets/icon_reset.svg" alt="" class="status-toolbar__icon">
+            </button>
+          </div>
+          <div class="history-toolbar" role="group" aria-label="되돌리기 및 다시 실행">
+            <button
+              id="undoBtn"
+              class="status-toolbar__button"
+              type="button"
+              title="되돌리기 (Z)"
+              aria-label="되돌리기"
+              disabled
+            >
+              <img src="assets/icon_undo.svg" alt="" class="status-toolbar__icon">
+            </button>
+            <button
+              id="redoBtn"
+              class="status-toolbar__button"
+              type="button"
+              title="다시 실행 (Y)"
+              aria-label="다시 실행"
+              disabled
+            >
+              <img src="assets/icon_redo.svg" alt="" class="status-toolbar__icon">
             </button>
           </div>
           <div id="usageSection" style="width:100%;">

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -308,6 +308,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     } else {
       hasInitialSnapshot = true;
     }
+    updateButtons();
   }
 
   function applyState(str) {
@@ -375,8 +376,20 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   const wireBtn = ui.wireStatusInfo;
   const delBtn = ui.wireDeleteInfo;
   const selectBtn = ui.wireSelectInfo;
+  const undoBtn = ui.undoButton;
+  const redoBtn = ui.redoButton;
   const usedBlocksEl = ui.usedBlocksEl;
   const usedWiresEl = ui.usedWiresEl;
+
+  bindEvent(undoBtn, 'click', e => {
+    e.preventDefault();
+    undo();
+  });
+
+  bindEvent(redoBtn, 'click', e => {
+    e.preventDefault();
+    redo();
+  });
 
   function updateUsageCounts() {
     const blockCount = Object.keys(circuit.blocks).length;
@@ -679,6 +692,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     wireBtn?.classList.toggle('active', isWireMode);
     delBtn?.classList.toggle('active', isDeleteMode);
     selectBtn?.classList.toggle('active', isSelectMode);
+    const canUndo = undoStack.length > 1;
+    const canRedo = redoStack.length > 0;
+    if (undoBtn) {
+      undoBtn.disabled = !canUndo;
+    }
+    if (redoBtn) {
+      redoBtn.disabled = !canRedo;
+    }
   }
 
   // 공통 포인터 좌표 계산 (마우스/터치)

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -327,6 +327,12 @@ export function setupGrid(
           wireSelectInfo: document.getElementById(
             prefix ? `${prefix}WireSelectInfo` : 'wireSelectInfo'
           ),
+          undoButton: document.getElementById(
+            prefix ? `${prefix}UndoBtn` : 'undoBtn'
+          ),
+          redoButton: document.getElementById(
+            prefix ? `${prefix}RedoBtn` : 'redoBtn'
+          ),
           usedBlocksEl: document.getElementById(
             prefix ? `${prefix}UsedBlocks` : 'usedBlocks'
           ),

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -265,13 +265,18 @@ html, body {
     color: #fff;
   }
 
-  .status-toolbar {
+  .status-toolbar,
+  .history-toolbar {
     display: flex;
     gap: 0.5rem;
     align-items: center;
     justify-content: center;
     flex-wrap: wrap;
     padding: 0.5rem 0;
+  }
+
+  .history-toolbar {
+    margin-bottom: 0.25rem;
   }
 
   .status-toolbar__button {
@@ -303,6 +308,19 @@ html, body {
 
   .status-toolbar__button:active {
     transform: translateY(1px);
+  }
+
+  .status-toolbar__button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    box-shadow: none;
+    border-color: #e5e7eb;
+  }
+
+  .status-toolbar__button:disabled:hover,
+  .status-toolbar__button:disabled:focus-visible {
+    border-color: #e5e7eb;
+    box-shadow: none;
   }
 
   .status-toolbar__icon {


### PR DESCRIPTION
## Summary
- add undo and redo buttons to both circuit editing toolbars and wire them to the existing history logic
- disable the history controls when undo or redo are unavailable and align their styling with other toolbar buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e74bd358c08332a70bae7273c926ce