### PR TITLE
Fix lab mode history toolbar bindings

### DIFF
--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -167,6 +167,8 @@ function createLabController({ preserveCircuit = false } = {}) {
       wireStatusInfo: document.getElementById('wireStatusInfo'),
       wireDeleteInfo: document.getElementById('wireDeleteInfo'),
       wireSelectInfo: document.getElementById('wireSelectInfo'),
+      undoButton: document.getElementById('undoBtn'),
+      redoButton: document.getElementById('redoBtn'),
       usedBlocksEl: document.getElementById('usedBlocks'),
       usedWiresEl: document.getElementById('usedWires')
     },


### PR DESCRIPTION
## Summary
- wire the lab mode controller up to the shared undo/redo buttons so the history toolbar reacts to circuit changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e753f7961483328f74ccd6e160bbc2