### PR TITLE
Enhance user problem panel readability

### DIFF
--- a/src/modules/problemEditor.js
+++ b/src/modules/problemEditor.js
@@ -921,31 +921,80 @@ function createUserProblemListItem(problem) {
   if (problem.solvedByMe) item.classList.add('solved');
   item.tabIndex = 0;
 
+  const createBadge = (icon, label, value) => {
+    const badge = document.createElement('span');
+    badge.className = 'problem-item-badge';
+
+    const badgeIcon = document.createElement('span');
+    badgeIcon.className = 'problem-item-badge-icon';
+    badgeIcon.setAttribute('aria-hidden', 'true');
+    badgeIcon.textContent = icon;
+
+    const badgeText = document.createElement('span');
+    badgeText.className = 'problem-item-badge-text';
+
+    const badgeLabel = document.createElement('span');
+    badgeLabel.className = 'problem-item-badge-label';
+    badgeLabel.textContent = label;
+
+    const badgeValue = document.createElement('span');
+    badgeValue.className = 'problem-item-badge-value';
+    badgeValue.textContent = value;
+
+    badgeText.append(badgeLabel, badgeValue);
+    badge.append(badgeIcon, badgeText);
+
+    return badge;
+  };
+
   const header = document.createElement('div');
   header.className = 'problem-item-header';
+
+  const titleGroup = document.createElement('div');
+  titleGroup.className = 'problem-item-title-group';
 
   const title = document.createElement('span');
   title.className = 'problem-item-title';
   title.textContent = problem.title;
 
-  const grid = document.createElement('span');
-  grid.className = 'problem-item-grid';
-  grid.textContent = `${problem.gridRows}×${problem.gridCols}`;
+  titleGroup.append(title);
 
-  header.append(title, grid);
+  const headerBadges = document.createElement('div');
+  headerBadges.className = 'problem-item-header-badges';
+
+  const gridBadgeLabel = translate('problemGridSizeLabel', '격자 크기');
+  const gridBadgeValue = `${problem.gridRows}×${problem.gridCols}`;
+  const gridBadge = createBadge('🔢', gridBadgeLabel, gridBadgeValue);
+  headerBadges.appendChild(gridBadge);
+
+  header.append(titleGroup, headerBadges);
 
   const meta = document.createElement('div');
   meta.className = 'problem-item-meta';
 
   const creator = document.createElement('span');
-  creator.textContent = `${translate('thCreator', '제작자')}: ${problem.creator}${problem.isMine ? ' (나)' : ''}`;
+  creator.className = 'problem-item-meta-entry';
+  const creatorIcon = document.createElement('span');
+  creatorIcon.className = 'problem-item-meta-icon';
+  creatorIcon.setAttribute('aria-hidden', 'true');
+  creatorIcon.textContent = '👤';
+  const creatorText = document.createElement('span');
+  creatorText.textContent = `${translate('thCreator', '제작자')}: ${problem.creator}${problem.isMine ? ' (나)' : ''}`;
+  creator.append(creatorIcon, creatorText);
 
   const createdAt = document.createElement('span');
+  createdAt.className = 'problem-item-meta-entry';
+  const createdAtIcon = document.createElement('span');
+  createdAtIcon.className = 'problem-item-meta-icon';
+  createdAtIcon.setAttribute('aria-hidden', 'true');
+  createdAtIcon.textContent = '📅';
   const createdAtLabel = translate('thCreatedAt', '제작일');
   const createdAtValue = problem.createdAt
     ? problem.createdAt.toLocaleDateString()
     : '-';
-  createdAt.textContent = `${createdAtLabel}: ${createdAtValue}`;
+  const createdAtText = document.createElement('span');
+  createdAtText.textContent = `${createdAtLabel}: ${createdAtValue}`;
+  createdAt.append(createdAtIcon, createdAtText);
 
   meta.append(creator, createdAt);
 
@@ -955,18 +1004,17 @@ function createUserProblemListItem(problem) {
   const stats = document.createElement('div');
   stats.className = 'problem-item-stats';
 
-  const solvedInfo = document.createElement('span');
-  solvedInfo.textContent = `${translate('thSolved', '해결 수')}: ${problem.solved}`;
-  stats.appendChild(solvedInfo);
+  const solvedLabel = translate('thSolved', '해결 수');
+  const solvedBadge = createBadge('✅', solvedLabel, String(problem.solved));
+  stats.appendChild(solvedBadge);
 
-  const difficultyInfo = document.createElement('span');
   const difficultyLabel = translate('problemDifficultyLabel', '난이도');
   const difficultyStars = formatDifficultyStars(problem.difficulty);
   const difficultyValue = difficultyStars
     ? difficultyStars
     : translate('problemDifficultyUnknown', '미정');
-  difficultyInfo.textContent = `${difficultyLabel}: ${difficultyValue}`;
-  stats.appendChild(difficultyInfo);
+  const difficultyBadge = createBadge('⭐', difficultyLabel, difficultyValue);
+  stats.appendChild(difficultyBadge);
 
   const actions = document.createElement('div');
   actions.className = 'problem-item-actions';

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1699,25 +1699,31 @@ html, body {
   .problem-item {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
-    padding: 1.15rem 1.35rem;
-    border-radius: 16px;
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 252, 0.92));
-    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+    gap: 0.75rem;
+    padding: 1.25rem 1.5rem;
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: linear-gradient(155deg, rgba(255, 255, 255, 0.97), rgba(241, 245, 249, 0.94));
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.14);
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
   }
 
   .problem-item:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 20px 38px rgba(59, 130, 246, 0.22);
-    border-color: rgba(59, 130, 246, 0.55);
+    transform: translateY(-4px);
+    box-shadow: 0 24px 48px rgba(59, 130, 246, 0.22);
+    border-color: rgba(59, 130, 246, 0.5);
+    background: linear-gradient(155deg, rgba(255, 255, 255, 0.99), rgba(241, 245, 249, 0.96));
+  }
+
+  .problem-item:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.55);
+    outline-offset: 3px;
   }
 
   .problem-item.solved {
     border-color: rgba(34, 197, 94, 0.55);
-    box-shadow: 0 18px 36px rgba(34, 197, 94, 0.2);
+    box-shadow: 0 20px 42px rgba(34, 197, 94, 0.18);
   }
 
   .problem-item-header,
@@ -1726,37 +1732,54 @@ html, body {
     justify-content: space-between;
     gap: 1rem;
     flex-wrap: wrap;
-    align-items: baseline;
+    align-items: flex-start;
+  }
+
+  .problem-item-title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
   }
 
   .problem-item-title {
-    font-size: 1.05rem;
+    font-size: 1.1rem;
     font-weight: 700;
     color: #0f172a;
+    line-height: 1.35;
+    word-break: keep-all;
   }
 
-  .problem-item-grid {
-    font-size: 0.95rem;
-    font-weight: 500;
-    color: #475569;
+  .problem-item-header-badges {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-left: auto;
   }
 
   .problem-item-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.65rem;
-    font-size: 0.9rem;
-    color: #475569;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.6rem;
+    padding: 0.75rem 0.85rem;
+    background: rgba(226, 232, 240, 0.45);
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    font-size: 0.92rem;
+    color: #334155;
   }
 
-  .problem-item-meta span {
+  .problem-item-meta-entry {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(226, 232, 240, 0.7);
-    color: #1e293b;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  .problem-item-meta-icon {
+    font-size: 1rem;
+    line-height: 1;
   }
 
   .problem-item-footer {
@@ -1766,15 +1789,52 @@ html, body {
   .problem-item-stats {
     display: flex;
     align-items: center;
-    gap: 0.85rem;
-    font-size: 0.9rem;
-    color: #1f2937;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+  }
+
+  .problem-item-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.45rem 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(248, 250, 252, 0.9);
+    color: #1e293b;
+    box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.6);
+  }
+
+  .problem-item-badge-icon {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .problem-item-badge-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.1;
+  }
+
+  .problem-item-badge-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(71, 85, 105, 0.9);
+  }
+
+  .problem-item-badge-value {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #0f172a;
+    white-space: nowrap;
   }
 
   .problem-item-actions {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin-left: auto;
   }
 
   .problem-item button {
@@ -1787,17 +1847,18 @@ html, body {
     gap: 0.35rem;
     padding: 0.45rem 0.85rem;
     border-radius: 999px;
-    border: 1px solid rgba(244, 63, 94, 0.4);
-    background: linear-gradient(140deg, rgba(248, 113, 113, 0.2), rgba(244, 63, 94, 0.12));
+    border: 1px solid rgba(244, 63, 94, 0.35);
+    background: linear-gradient(140deg, rgba(248, 113, 113, 0.18), rgba(244, 63, 94, 0.1));
     color: #be123c;
     font-weight: 600;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   }
 
   .problem-item .likeBtn:hover {
     background: rgba(244, 63, 94, 0.24);
     border-color: rgba(244, 63, 94, 0.55);
     transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(244, 63, 94, 0.18);
   }
 
   .problem-item .likeBtn.active {


### PR DESCRIPTION
## Summary
- restructure user problem list items with clearer badge layout and metadata icons for easier scanning
- refresh user problem card styling to add breathing room, focus states, and less oppressive visuals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e757b4f9808332848feefca537b675