### PR TITLE
Fix palette refresh when removing IO blocks from problem editor

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1550,9 +1550,13 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
           state.draggingBlock.name
         );
       }
+      const removedExistingBlock =
+        !placed && Boolean(state.draggingBlock && state.draggingBlock.id);
       if (placed) {
         renderContent(contentCtx, circuit, 0, panelTotalWidth, state.hoverBlockId, camera);
         updateUsageCounts();
+        snapshot();
+      } else if (removedExistingBlock) {
         snapshot();
       }
       if (placed || state.draggingBlock.id) clearSelection();


### PR DESCRIPTION
## Summary
- ensure dragging an existing IN/OUT block out of the grid records a snapshot so the palette is refreshed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e77c8e35fc83328eb47f12c492e62f