### PR TITLE
Ensure canvas height accommodates block panel

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -145,6 +145,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       canvas.dataset.panelWidth = String(panelTotalWidth);
       canvas.dataset.gridBaseWidth = String(baseGridWidth);
       canvas.dataset.gridBaseHeight = String(baseGridHeight);
+      canvas.dataset.minCanvasHeight = String(minCanvasHeight);
     });
   }
 
@@ -279,8 +280,9 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   function resizeCanvas(width, height) {
     if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+    const enforcedHeight = Math.max(height, minCanvasHeight || 0);
     canvasWidth = width;
-    canvasHeight = height;
+    canvasHeight = enforcedHeight;
     gridWidth = Math.max(0, canvasWidth - panelTotalWidth);
     gridHeight = canvasHeight;
     bgCtx = setupCanvas(bgCanvas, canvasWidth, canvasHeight);


### PR DESCRIPTION
## Summary
- expose the minimum canvas height through dataset metadata for each grid canvas
- clamp resize operations so the canvas never shrinks below the block panel height, preventing palette clipping on small grids

## Testing
- no tests (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e7bf19dd6c8332bad7f99119bc0871