### PR TITLE
Ensure canvas respects block panel height

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -145,6 +145,11 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       canvas.dataset.panelWidth = String(panelTotalWidth);
       canvas.dataset.gridBaseWidth = String(baseGridWidth);
       canvas.dataset.gridBaseHeight = String(baseGridHeight);
+      if (Number.isFinite(minCanvasHeight)) {
+        canvas.dataset.minCanvasHeight = String(minCanvasHeight);
+      } else {
+        delete canvas.dataset.minCanvasHeight;
+      }
     });
   }
 
@@ -279,8 +284,14 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
 
   function resizeCanvas(width, height) {
     if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+    const nextHeight = Number.isFinite(minCanvasHeight)
+      ? Math.max(height, minCanvasHeight)
+      : height;
+    if (Number.isFinite(nextHeight) && (!Number.isFinite(minCanvasHeight) || nextHeight > minCanvasHeight)) {
+      minCanvasHeight = nextHeight;
+    }
     canvasWidth = width;
-    canvasHeight = height;
+    canvasHeight = nextHeight;
     gridWidth = Math.max(0, canvasWidth - panelTotalWidth);
     gridHeight = canvasHeight;
     bgCtx = setupCanvas(bgCanvas, canvasWidth, canvasHeight);

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -161,6 +161,7 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
   const datasetWidth = parseFloat(firstCanvas.dataset?.baseWidth);
   const datasetHeight = parseFloat(firstCanvas.dataset?.baseHeight);
   const datasetDpr = parseFloat(firstCanvas.dataset?.dpr);
+  const datasetMinCanvasHeight = parseFloat(firstCanvas.dataset?.minCanvasHeight);
   let baseWidth;
   let baseHeight;
 
@@ -228,7 +229,10 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
     }
 
     const targetWidth = resolvedPanelWidth + resolvedGridWidth * scale;
-    const targetHeight = resolvedGridHeight * scale;
+    let targetHeight = resolvedGridHeight * scale;
+    if (Number.isFinite(datasetMinCanvasHeight)) {
+      targetHeight = Math.max(targetHeight, datasetMinCanvasHeight);
+    }
 
     controller.resizeCanvas(targetWidth, targetHeight);
     camera.reset?.();


### PR DESCRIPTION
## Summary
- persist the minimum palette height on canvas elements and enforce it whenever the controller resizes
- honor the stored minimum height while adjusting grid zoom so short grids still show the full block panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7bf19dd6c8332bad7f99119bc0871