### PR TITLE
Align canvas cell corner radius

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1,5 +1,13 @@
 import { CELL, GAP, coord, newWire, newBlock } from './model.js';
-import { drawGrid, renderContent, setupCanvas, drawBlock, drawPanel } from './renderer.js';
+import {
+  drawGrid,
+  renderContent,
+  setupCanvas,
+  drawBlock,
+  drawPanel,
+  roundRect,
+  CELL_CORNER_RADIUS
+} from './renderer.js';
 import { evaluateCircuit, startEngine } from './engine.js';
 
 let keydownHandler = null;
@@ -776,11 +784,17 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     const dr = Number.isFinite(offset?.dr) ? offset.dr : 0;
     const dc = Number.isFinite(offset?.dc) ? offset.dc : 0;
     overlayCtx.fillStyle = invalid ? 'rgba(255,0,0,0.35)' : 'rgba(0,128,255,0.3)';
+    const radius = Math.max(1, CELL_CORNER_RADIUS * getScale());
+    const fillRoundedCell = rect => {
+      overlayCtx.beginPath();
+      roundRect(overlayCtx, rect.x, rect.y, rect.w, rect.h, radius);
+      overlayCtx.fill();
+    };
     sel.blocks.forEach(id => {
       const b = circuit.blocks[id];
       if (b) {
         const rect = cellRect(b.pos.r + dr, b.pos.c + dc);
-        overlayCtx.fillRect(rect.x, rect.y, rect.w, rect.h);
+        fillRoundedCell(rect);
       }
     });
     sel.wires.forEach(id => {
@@ -788,7 +802,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       if (w) {
         w.path.forEach(p => {
           const rect = cellRect(p.r + dr, p.c + dc);
-          overlayCtx.fillRect(rect.x, rect.y, rect.w, rect.h);
+          fillRoundedCell(rect);
         });
       }
     });

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -1,5 +1,7 @@
 import { CELL, GAP } from './model.js';
 
+export const CELL_CORNER_RADIUS = 6;
+
 const PITCH = CELL + GAP;
 
 const DEFAULT_GRID_STYLE = {
@@ -15,7 +17,7 @@ const DEFAULT_GRID_STYLE = {
   gridFillB: null,
   gridStroke: '#ddd',
   gridLineWidth: 1,
-  cellRadius: 3,
+  cellRadius: CELL_CORNER_RADIUS,
   borderColor: '#666',
   borderWidth: GAP
 };
@@ -33,7 +35,7 @@ function resolveGridStyle(options = {}) {
   return style;
 }
 
-function roundRect(ctx, x, y, w, h, r = 6) {
+export function roundRect(ctx, x, y, w, h, r = 6) {
   ctx.beginPath();
   ctx.moveTo(x + r, y);
   ctx.lineTo(x + w - r, y);
@@ -342,7 +344,7 @@ export function drawBlock(ctx, block, offsetX = 0, hovered = false, camera = nul
     grad.addColorStop(1, '#d0d0ff');
   }
   ctx.fillStyle = grad;
-  roundRect(ctx, x, y, size, size, 6 * shadowScale);
+  roundRect(ctx, x, y, size, size, Math.max(1, CELL_CORNER_RADIUS * shadowScale));
   ctx.fill();
 
   // Highlight active INPUT/OUTPUT/JUNCTION blocks with a dashed border
@@ -383,7 +385,8 @@ export function drawWire(ctx, wire, phase = 0, offsetX = 0, camera = null) {
       ? camera.cellToScreenCell(p).y
       : GAP + p.r * PITCH;
     const size = CELL * scale;
-    ctx.fillRect(x, y, size, size);
+    roundRect(ctx, x, y, size, size, Math.max(1, CELL_CORNER_RADIUS * scale));
+    ctx.fill();
   }
   ctx.beginPath();
   const start = wire.path[0];


### PR DESCRIPTION
## Summary
- export a shared cell corner radius and round-rectangle helper from the renderer
- render blocks, wire highlights, and selection overlays using the unified rounded corner size
- update selection painting to respect camera scale while keeping rounded corners consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8cc9f9bf48332b0fc95e672895f30