### PR TITLE
Delay guest nickname reservation until needed

### DIFF
--- a/src/modules/rank.js
+++ b/src/modules/rank.js
@@ -1,4 +1,5 @@
 import { getUsername } from './storage.js';
+import { ensureUsernameRegistered } from './authUI.js';
 
 const fallbackTranslate = key => key;
 
@@ -162,8 +163,11 @@ export function showOverallRanking(options = {}) {
   });
 }
 
-export function saveRanking(levelId, blockCounts, usedWires, hintsUsed) {
-  const nickname = getUsername() || '익명';
+export async function saveRanking(levelId, blockCounts, usedWires, hintsUsed) {
+  let nickname = getUsername() || '익명';
+  if (nickname && nickname !== '익명') {
+    nickname = await ensureUsernameRegistered(nickname);
+  }
   const entry = {
     nickname,
     blockCounts,
@@ -174,8 +178,11 @@ export function saveRanking(levelId, blockCounts, usedWires, hintsUsed) {
   db.ref(`rankings/${levelId}`).push(entry);
 }
 
-export function saveProblemRanking(problemKey, blockCounts, usedWires, hintsUsed) {
-  const nickname = getUsername() || '익명';
+export async function saveProblemRanking(problemKey, blockCounts, usedWires, hintsUsed) {
+  let nickname = getUsername() || '익명';
+  if (nickname && nickname !== '익명') {
+    nickname = await ensureUsernameRegistered(nickname);
+  }
   const entry = {
     nickname,
     blockCounts,


### PR DESCRIPTION
## Summary
- keep guest nickname assignment local-only and add an async helper to reserve usernames on demand
- update Google merge flows to reserve nicknames only when needed and keep Firebase records in sync after conflicts
- ensure ranking submissions reserve the active guest nickname before saving leaderboard entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8d3e63a2c8332ab537aebbf5d5343