### PR TITLE
Refine guest nickname reservation logic

### DIFF
--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -1,4 +1,5 @@
 const USERNAME_KEY = 'username';
+const USERNAME_RESERVATION_KEY = 'usernameReservationKey';
 const HINT_COOLDOWN_KEY = 'hintCooldownUntil';
 const AUTO_SAVE_KEY = 'autoSaveCircuit';
 
@@ -31,6 +32,14 @@ export function getUsername() {
 
 export function setUsername(name) {
   safeSetItem(USERNAME_KEY, name);
+}
+
+export function getUsernameReservationKey() {
+  return safeGetItem(USERNAME_RESERVATION_KEY);
+}
+
+export function setUsernameReservationKey(key) {
+  safeSetItem(USERNAME_RESERVATION_KEY, key);
 }
 
 export function getHintProgress(stage) {


### PR DESCRIPTION
## Summary
- avoid registering guest nicknames immediately and add an asynchronous helper that reserves names only when required
- update Google merge/account flows to rely on the new helper and react to nickname conflicts gracefully
- ensure ranking saves invoke the helper before writing results and persist reservation metadata in storage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8d3e63a2c8332ab537aebbf5d5343