### PR TITLE
Delay guest nickname reservation until needed

### DIFF
--- a/src/modules/rank.js
+++ b/src/modules/rank.js
@@ -1,4 +1,5 @@
 import { getUsername } from './storage.js';
+import { ensureUsernameRegistered } from './authUI.js';
 
 const fallbackTranslate = key => key;
 
@@ -162,8 +163,15 @@ export function showOverallRanking(options = {}) {
   });
 }
 
-export function saveRanking(levelId, blockCounts, usedWires, hintsUsed) {
-  const nickname = getUsername() || '익명';
+export async function saveRanking(levelId, blockCounts, usedWires, hintsUsed) {
+  let nickname = getUsername() || '익명';
+  if (nickname !== '익명' && typeof ensureUsernameRegistered === 'function') {
+    try {
+      nickname = await ensureUsernameRegistered(nickname);
+    } catch (err) {
+      console.error('Failed to ensure nickname before saving ranking', err);
+    }
+  }
   const entry = {
     nickname,
     blockCounts,
@@ -174,8 +182,15 @@ export function saveRanking(levelId, blockCounts, usedWires, hintsUsed) {
   db.ref(`rankings/${levelId}`).push(entry);
 }
 
-export function saveProblemRanking(problemKey, blockCounts, usedWires, hintsUsed) {
-  const nickname = getUsername() || '익명';
+export async function saveProblemRanking(problemKey, blockCounts, usedWires, hintsUsed) {
+  let nickname = getUsername() || '익명';
+  if (nickname !== '익명' && typeof ensureUsernameRegistered === 'function') {
+    try {
+      nickname = await ensureUsernameRegistered(nickname);
+    } catch (err) {
+      console.error('Failed to ensure nickname before saving problem ranking', err);
+    }
+  }
   const entry = {
     nickname,
     blockCounts,

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -1,4 +1,5 @@
 const USERNAME_KEY = 'username';
+const USERNAME_RESERVATION_KEY = 'usernameReservationKey';
 const HINT_COOLDOWN_KEY = 'hintCooldownUntil';
 const AUTO_SAVE_KEY = 'autoSaveCircuit';
 
@@ -31,6 +32,14 @@ export function getUsername() {
 
 export function setUsername(name) {
   safeSetItem(USERNAME_KEY, name);
+}
+
+export function getUsernameReservationKey() {
+  return safeGetItem(USERNAME_RESERVATION_KEY);
+}
+
+export function setUsernameReservationKey(value) {
+  safeSetItem(USERNAME_RESERVATION_KEY, value);
 }
 
 export function getHintProgress(stage) {


### PR DESCRIPTION
## Summary
- stop writing guest nicknames to the database at assignment time and store reservation metadata locally
- add an async helper that reserves nicknames only when accounts merge or rankings are saved, updating Google login flows accordingly
- ensure ranking saves trigger nickname reservation so guests receive a unique name before submitting scores

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e8d3e63a2c8332ab537aebbf5d5343