### PR TITLE
Show cleared modal without waiting for toast dismissal

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -572,16 +572,23 @@ document.addEventListener('keydown', e => {
 
 // 회로 저장 완료 모달
 function showCircuitSavedModal({ message, canShare, loginRequired } = {}) {
+  let hasContinued = false;
+  const continueFlow = () => {
+    if (hasContinued) return;
+    hasContinued = true;
+    const clearedLevel = gradingController.consumePendingClearedLevel();
+    if (clearedLevel !== null && clearedLevel !== undefined) {
+      showClearedModal(clearedLevel, clearedModalOptions);
+    }
+  };
+
+  continueFlow();
+
   showCircuitSavedToast({
     message,
     canShare,
     loginRequired,
-    onContinue: () => {
-      const clearedLevel = gradingController.consumePendingClearedLevel();
-      if (clearedLevel !== null && clearedLevel !== undefined) {
-        showClearedModal(clearedLevel, clearedModalOptions);
-      }
-    }
+    onContinue: continueFlow
   });
 }
 


### PR DESCRIPTION
## Summary
- allow the cleared modal to appear immediately after circuit save rather than waiting for toast dismissal
- guard the follow-up flow so the modal only opens once even when the toast closes later

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8f62624f48332942dbd7843b22146