### PR TITLE
Fix lab mode keyboard shortcuts persisting after exit

### DIFF
--- a/src/modules/labMode.js
+++ b/src/modules/labMode.js
@@ -245,6 +245,8 @@ function hideLabScreen() {
   if (firstScreen) firstScreen.style.display = '';
   document.body.classList.remove('lab-mode-active');
   removeLabResizeHandler();
+  labController?.destroy?.();
+  labController = null;
   const titleEl = document.getElementById('gameTitle');
   if (titleEl) {
     const fallbackTitle = originalGameTitleText || '🧠 Bitwiser';


### PR DESCRIPTION
## Summary
- destroy the lab-mode controller when leaving lab mode so keyboard handlers are removed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8f7bc5624833287952a2280cf3c8c