### PR TITLE
Fix canvas height when grid is scaled down

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -78,7 +78,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   const clampToBounds = !unboundedGrid;
   let baseGridWidth = gridWidth;
   let baseGridHeight = gridHeight;
-  let minCanvasHeight;
+  let dynamicMinCanvasHeight;
 
   if (paletteGroups.length > 0) {
     const colWidth =
@@ -125,7 +125,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     canvasHeight = Math.max(canvasHeight, palette.length * PALETTE_ITEM_H + 20);
   }
 
-  minCanvasHeight = canvasHeight;
+  dynamicMinCanvasHeight = canvasHeight;
 
   let canvasWidth = panelTotalWidth + gridWidth;
   if (canvasSize && Number.isFinite(canvasSize.width) && Number.isFinite(canvasSize.height)) {
@@ -158,7 +158,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       canvas.dataset.gridBaseHeight = String(baseGridHeight);
       canvas.dataset.gridViewportWidth = String(Math.max(0, gridWidth));
       canvas.dataset.gridViewportHeight = String(Math.max(0, gridHeight));
-      canvas.dataset.minCanvasHeight = String(minCanvasHeight);
+      canvas.dataset.minCanvasHeight = String(dynamicMinCanvasHeight);
     });
   }
 
@@ -291,12 +291,23 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     });
   }
 
-  function resizeCanvas(width, height) {
+  function resolveMinCanvasHeight(options) {
+    if (options && typeof options === 'object' && options !== null) {
+      const override = Number.parseFloat(options.minHeight);
+      if (Number.isFinite(override)) {
+        dynamicMinCanvasHeight = Math.max(0, override);
+      }
+    }
+    return dynamicMinCanvasHeight;
+  }
+
+  function resizeCanvas(width, height, options) {
     if (!Number.isFinite(width) || !Number.isFinite(height)) return;
     const normalizedGridHeight = Math.max(0, height);
     const normalizedCanvasWidth = Math.max(width, panelTotalWidth);
     const normalizedGridWidth = Math.max(0, normalizedCanvasWidth - panelTotalWidth);
-    const nextCanvasHeight = Math.max(normalizedGridHeight, minCanvasHeight);
+    const effectiveMinHeight = resolveMinCanvasHeight(options);
+    const nextCanvasHeight = Math.max(normalizedGridHeight, effectiveMinHeight);
 
     canvasWidth = normalizedCanvasWidth;
     canvasHeight = nextCanvasHeight;

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -233,9 +233,13 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
 
     const targetWidth = resolvedPanelWidth + resolvedGridWidth * scale;
     const targetHeight = resolvedGridHeight * scale;
-    const targetCanvasHeight = Math.max(targetHeight, resolvedMinCanvasHeight);
+    const safeAvailableHeight = Math.max(0, gridAvailableHeight);
+    const minHeightOverride = safeAvailableHeight > 0
+      ? Math.min(resolvedMinCanvasHeight, safeAvailableHeight)
+      : resolvedMinCanvasHeight;
+    const targetCanvasHeight = Math.max(targetHeight, minHeightOverride);
 
-    controller.resizeCanvas(targetWidth, targetHeight);
+    controller.resizeCanvas(targetWidth, targetHeight, { minHeight: minHeightOverride });
     camera.reset?.();
     camera.setScale?.(scale);
 


### PR DESCRIPTION
## Summary
- allow the grid zoom helper to cap the canvas height to the available viewport when scaling down
- let the canvas controller accept a minimum height override so the DOM height follows the scaled grid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8fc00a1708332acc6992d9f78f6d2