### PR TITLE
Ensure stage cards hide before rendering

### DIFF
--- a/src/modules/levels.js
+++ b/src/modules/levels.js
@@ -260,10 +260,16 @@ export function selectChapter(idx) {
 }
 
 export async function renderStageList(stageList) {
-  await loadClearedLevelsFromDb();
   const stageListEl = document.getElementById('stageList');
   if (!stageListEl) return;
+
+  stageListEl.querySelectorAll('.stageCard').forEach(card => {
+    card.style.opacity = '0';
+    card.style.transform = 'scale(0.96)';
+  });
+
   stageListEl.innerHTML = '';
+  await loadClearedLevelsFromDb();
   stageList.forEach((level, idx) => {
     const card = document.createElement('div');
     card.className = 'stageCard';


### PR DESCRIPTION
## Summary
- hide any existing stage cards before re-rendering the stage list so that transitions start from a transparent state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9022f2fd48332946603e5a2edfdf3