### PR TITLE
Keep stage list container height stable during rerender

### DIFF
--- a/src/modules/levels.js
+++ b/src/modules/levels.js
@@ -263,6 +263,11 @@ export async function renderStageList(stageList) {
   const stageListEl = document.getElementById('stageList');
   if (!stageListEl) return;
 
+  const previousHeight = stageListEl.offsetHeight;
+  if (previousHeight > 0) {
+    stageListEl.style.minHeight = `${previousHeight}px`;
+  }
+
   stageListEl.querySelectorAll('.stageCard').forEach(card => {
     card.style.opacity = '0';
     card.style.transform = 'scale(0.96)';
@@ -321,6 +326,15 @@ export async function renderStageList(stageList) {
       },
       { once: true }
     );
+  });
+
+  requestAnimationFrame(() => {
+    const measuredHeight = stageListEl.offsetHeight;
+    if (measuredHeight > 0) {
+      stageListEl.style.minHeight = `${measuredHeight}px`;
+    } else if (stageList.length === 0) {
+      stageListEl.style.removeProperty('min-height');
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- preserve the stage list container height while cards are re-rendered so the modal does not shrink before animations run
- update the measured height after rendering to keep the min-height aligned with the new card layout

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e904c41e9c83329d51a4fa30252b6d