### PR TITLE
Adjust mobile menu width scaling on mobile

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -2639,7 +2639,8 @@ html, body {
 
 @media (max-width: 1024px) {
   :root {
-    --menuBarWidth: 34vh;
+    --menuBarWidth: clamp(160px, 42vw, 280px);
+    --menuBarCollapsedWidth: clamp(48px, 12vw, 72px);
   }
 
   #menuBar {
@@ -2664,8 +2665,8 @@ html, body {
   #menuBar button:not(#menuToggleBtn) {
     width: 100%;
     word-break: keep-all;
-    font-size: 1.6vw;
-    height: 4vw;
+    font-size: clamp(12px, 1.6vw, 16px);
+    height: clamp(36px, 4vw, 48px);
     margin: 0;
     padding: 0;
     box-sizing: border-box;
@@ -2710,7 +2711,7 @@ html, body {
   }
 
   #menuBar.collapsed {
-    width: 6vh;
+    width: var(--menuBarCollapsedWidth, 6vh);
     height: auto;
     padding: 5px;
   }


### PR DESCRIPTION
## Summary
- adjust the mobile menu width variables to use viewport-width clamping
- clamp button sizing and collapsed width so expanding the menu no longer shrinks the canvas

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e90edfcf688332b420855d88ba43da