### PR TITLE
Fix mobile menu toggle shrinking grid

### DIFF
--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -146,8 +146,24 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
     const menuBar = document.getElementById('menuBar');
     if (menuBar) {
       const menuRect = menuBar.getBoundingClientRect();
+      const computedStyle = window.getComputedStyle(menuBar);
       const isVertical = menuRect.height > menuRect.width;
+
+      let ignoreMenuWidth = false;
       if (isVertical) {
+        const isFixed = computedStyle.position === 'fixed';
+        const top = parseFloat(computedStyle.top || '');
+        const right = parseFloat(computedStyle.right || '');
+        const left = parseFloat(computedStyle.left || '');
+        const isAnchoredToSide = Number.isFinite(right) ? Math.abs(right) < 0.5 : Number.isFinite(left) && Math.abs(left) < 0.5;
+        const isAnchoredToTop = Number.isFinite(top) && Math.abs(top) < 0.5;
+        ignoreMenuWidth = isFixed && isAnchoredToSide && isAnchoredToTop;
+      }
+
+      if (isVertical && ignoreMenuWidth) {
+        // On mobile layouts the vertical menu floats above the grid, so
+        // subtracting its width incorrectly shrinks the canvas.
+      } else if (isVertical) {
         availableWidth -= menuRect.width;
       } else {
         availableHeight -= menuRect.height;


### PR DESCRIPTION
## Summary
- avoid shrinking the canvas when the floating mobile menu is expanded by detecting fixed overlay menus
- keep the grid scale unchanged when the menu toggle button opens the menu on phones

## Testing
- Manual verification by running the app locally and expanding the mobile menu

------
https://chatgpt.com/codex/tasks/task_e_68e90edfcf688332b420855d88ba43da