### PR TITLE
Allow reusing reserved nicknames during merge

### DIFF
--- a/src/modules/authUI.js
+++ b/src/modules/authUI.js
@@ -338,7 +338,7 @@ function isRecordBetter(a, b) {
 }
 
 async function mergeProgress(oldName, newName) {
-  const finalName = await ensureUsernameRegistered(newName);
+  const finalName = await ensureUsernameRegistered(newName, { reuseExisting: true });
   const snap = await db.ref('rankings').once('value');
   const promises = [];
 


### PR DESCRIPTION
## Summary
- ensure nickname registration during merge reuses existing reservations tied to Google accounts
- prevent the merge flow from assigning a fresh guest nickname when the desired name already exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e997b2bbf0833291ee4a3fdbbc8e50