### PR TITLE
Restore username modal for guest and Google login flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,16 @@
       <div class="loader"></div>
       <p id="loadingText">데이터 불러오는 중...</p>
     </div>
+    <div id="usernameModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <h2 id="loginTitle">로그인 또는 게스트 플레이</h2>
+        <button id="modalGoogleLoginBtn" class="btn-primary" style="margin-bottom:1rem;">Google 계정으로 로그인</button>
+        <p class="info-text" id="loginInfo">또는 닉네임을 입력하여 게스트로 플레이하세요.<br>닉네임은 랭킹에 표시되며 변경할 수 없습니다.</p>
+        <input type="text" id="usernameInput" placeholder="닉네임 입력" />
+        <div id="usernameError" style="color:red; margin-top:0.5rem;"></div>
+        <button id="usernameSubmit">게스트로 시작하기</button>
+      </div>
+    </div>
     <div id="mergeModal" class="modal" style="display:none;">
       <div class="modal-content">
         <h2 id="mergeTitle">진행 상황 병합</h2>

--- a/lang.js
+++ b/lang.js
@@ -1,6 +1,12 @@
 const translations = {
   ko: {
     loadingText: {text: "데이터 불러오는 중..."},
+    loginTitle: {text: "로그인 또는 게스트 플레이"},
+    modalGoogleLoginBtn: {text: "Google 계정으로 로그인"},
+    loginInfo: {html: "또는 닉네임을 입력하여 게스트로 플레이하세요.<br>닉네임은 랭킹에 표시되며 변경할 수 없습니다."},
+    loginInfoGoogle: {html: "이전에 사용하던 닉네임이 있는 경우 해당 닉네임을 입력하여 계속 플레이할 수 있습니다.<br>닉네임은 랭킹에 표시되며 변경할 수 없습니다."},
+    usernameInput: {placeholder: "닉네임 입력"},
+    usernameSubmit: {text: "게스트로 시작하기"},
     mergeTitle: {text: "진행 상황 병합"},
     mergeMessage: {text: "현재 로컬 진행 상황을 Google 계정과 병합하시겠습니까?"},
     mergeConfirmBtn: {text: "네"},
@@ -192,6 +198,12 @@ const translations = {
   },
   en: {
     loadingText: {text: "Loading data..."},
+    loginTitle: {text: "Login or play as guest"},
+    modalGoogleLoginBtn: {text: "Sign in with Google"},
+    loginInfo: {html: "Or enter a nickname to play as a guest.<br>The nickname appears in the ranking and cannot be changed."},
+    loginInfoGoogle: {html: "If you previously used a nickname, enter it to continue playing.<br>The nickname appears in the ranking and cannot be changed."},
+    usernameInput: {placeholder: "Enter nickname"},
+    usernameSubmit: {text: "Start as guest"},
     mergeTitle: {text: "Merge Progress"},
     mergeMessage: {text: "Merge local progress with your Google account?"},
     mergeConfirmBtn: {text: "Yes"},

--- a/src/main.js
+++ b/src/main.js
@@ -728,6 +728,13 @@ document.addEventListener("DOMContentLoaded", () => {
     fetchProgressSummary,
     ids: {
       googleLoginBtnId: 'googleLoginBtn',
+      modalGoogleLoginBtnId: 'modalGoogleLoginBtn',
+      usernameModalId: 'usernameModal',
+      usernameInputId: 'usernameInput',
+      usernameErrorId: 'usernameError',
+      usernameSubmitId: 'usernameSubmit',
+      usernameModalHeadingSelector: '#usernameModal h2',
+      loginInfoId: 'loginInfo',
       guestUsernameId: 'guestUsername',
       loginUsernameId: 'loginUsername',
       rankSectionId: 'rankSection',

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1395,6 +1395,58 @@ html, body {
     position: relative;
   }
 
+  /* ── Username Modal: input & button 디자인 ── */
+  #usernameModal .modal-content input#usernameInput {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    margin: 0.5rem 0 1rem;
+    box-sizing: border-box;
+    transition: border-color 0.2s ease;
+  }
+
+  #usernameModal .modal-content input#usernameInput:focus {
+    outline: none;
+    border-color: #6b8cff;
+  }
+
+  #usernameModal .modal-content button#usernameSubmit {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, #6B8CFF 0%, #88E0EF 100%);
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: transform 0.1s ease, box-shadow 0.2s ease;
+  }
+
+  #usernameModal .modal-content button#usernameSubmit:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  #usernameModal .modal-content button#usernameSubmit:active {
+    transform: translateY(0);
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
+  }
+
+  #usernameModal .modal-content button#usernameSubmit:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(107, 140, 255, 0.5);
+  }
+
+  #usernameModal .modal-content .info-text {
+    margin: 0.25rem 0;
+    font-size: 0.9rem;
+    color: #555;
+  }
+
   /* 랭킹 모달 전용 중앙정렬 오버라이드 */
   #rankingModal {
     position: fixed !important;


### PR DESCRIPTION
## Summary
- reintroduce the username modal markup, translations, and styling
- wire the modal elements back into auth initialisation and restore guest/Google nickname workflows
- ensure Google merge and claim flows prompt for nicknames and keep existing reservation handling intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb65e07274833282a2b9f26d9f26d1