### PR TITLE
Align canvas styling and theme preview

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -801,7 +801,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     const dr = Number.isFinite(offset?.dr) ? offset.dr : 0;
     const dc = Number.isFinite(offset?.dc) ? offset.dc : 0;
     overlayCtx.fillStyle = invalid ? 'rgba(255,0,0,0.35)' : 'rgba(0,128,255,0.3)';
-    const radius = Math.max(1, CELL_CORNER_RADIUS * getScale());
+    const radius = Math.max(0, CELL_CORNER_RADIUS * getScale());
     const fillRoundedCell = rect => {
       overlayCtx.beginPath();
       roundRect(overlayCtx, rect.x, rect.y, rect.w, rect.h, radius);

--- a/src/canvas/engine.js
+++ b/src/canvas/engine.js
@@ -113,7 +113,10 @@ export function startEngine(ctx, circuit, renderer) {
     const delta = time - lastTime;
     lastTime = time;
     // Advance the animation at a constant rate regardless of display refresh.
-    phase = (phase + (delta / 1000) * FLOW_SPEED) % 40;
+    phase += (delta / 1000) * FLOW_SPEED;
+    if (phase > 1e6) {
+      phase -= 1e6;
+    }
     renderer(ctx, circuit, phase);
     scheduleNext();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -80,7 +80,8 @@ import {
   setActiveTheme,
   getThemeById,
   onThemeChange,
-  getThemeText
+  getThemeText,
+  getThemeGridBackground
 } from './themes.js';
 import { drawGrid, renderContent, setupCanvas } from './canvas/renderer.js';
 import { CELL, GAP } from './canvas/model.js';
@@ -682,6 +683,18 @@ configureLevelModule({
   onLevelIntroComplete: () =>
     collapseMenuBarForMobile({ onAfterCollapse: updatePadding })
 });
+
+function syncGameAreaBackground(theme) {
+  const gameArea = document.getElementById('gameArea');
+  if (!gameArea) return;
+  const color = getThemeGridBackground(theme);
+  if (color) {
+    gameArea.style.backgroundColor = color;
+  } else {
+    gameArea.style.backgroundColor = '';
+  }
+}
+
 function setupSettings() {
   const btn = document.getElementById('settingsBtn');
   const modal = document.getElementById('settingsModal');
@@ -702,24 +715,17 @@ function setupSettings() {
     rows: previewConfig.rows,
     cols: previewConfig.cols,
     blocks: {
-      in1: {
-        id: 'preview_in1',
+      input: {
+        id: 'preview_in',
         type: 'INPUT',
-        name: 'IN1',
+        name: 'IN',
         pos: { r: 1, c: 0 },
-        value: true
-      },
-      gate: {
-        id: 'preview_gate',
-        type: 'NOT',
-        name: 'NOT',
-        pos: { r: 1, c: 1 },
         value: false
       },
-      out1: {
-        id: 'preview_out1',
+      output: {
+        id: 'preview_out',
         type: 'OUTPUT',
-        name: 'OUT1',
+        name: 'OUT',
         pos: { r: 1, c: 2 },
         value: false
       }
@@ -732,8 +738,8 @@ function setupSettings() {
           { r: 1, c: 1 },
           { r: 1, c: 2 }
         ],
-        startBlockId: 'preview_in1',
-        endBlockId: 'preview_out1'
+        startBlockId: 'preview_in',
+        endBlockId: 'preview_out'
       }
     }
   };
@@ -835,6 +841,7 @@ function setupSettings() {
   };
 
   const handleThemeChange = theme => {
+    syncGameAreaBackground(theme);
     if (!hasThemeUI || !theme) return;
     const lang = getCurrentLang();
     const name = getThemeText(theme, 'name', lang) || theme.id;
@@ -935,6 +942,8 @@ document.addEventListener("DOMContentLoaded", () => {
   setupKeyToggles();
   setupMenuToggle();
   setupSettings();
+  syncGameAreaBackground(getThemeById(getActiveThemeId()));
+  onThemeChange(syncGameAreaBackground);
   setupGameAreaPadding();
   Promise.all(initialTasks).then(() => {
     setupNavigation({

--- a/src/themes.js
+++ b/src/themes.js
@@ -513,3 +513,22 @@ export function getThemeAccentSoft(theme) {
   return theme.accentSoft || 'rgba(99, 102, 241, 0.2)';
 }
 
+export function getThemeGridBackground(theme) {
+  const sourceTheme = theme || getActiveTheme();
+  const background = sourceTheme?.grid?.background;
+  if (!background) return null;
+  if (typeof background === 'string') return background;
+  if (typeof background === 'object') {
+    if (typeof background.color === 'string') {
+      return background.color;
+    }
+    if (Array.isArray(background.stops)) {
+      const validStop = background.stops.find(stop => typeof stop?.color === 'string');
+      if (validStop?.color) {
+        return validStop.color;
+      }
+    }
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- unify canvas cell, block, wire, and selection corner radii around a 3px base while smoothing wire animation offsets and allowing block labels to scale with zoom
- refresh the settings preview to show an inactive IN—OUT circuit and ensure the game area background matches the selected theme
- expose a theme helper for retrieving grid background colors so other UI surfaces can stay in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed12aa3c3483329483df974886089a