### PR TITLE
Make Solar Punch active blocks glow with gradient hover

### DIFF
--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -62,6 +62,7 @@ const BASE_BLOCK_STYLE = {
   strokeColor: null,
   strokeWidth: 0,
   activeFill: null,
+  activeHoverFill: null,
   activeTextColor: null,
   font: null
 };
@@ -216,6 +217,12 @@ function resolveBlockStyle(options = {}) {
   style.radius = CELL_CORNER_RADIUS;
   style.font = style.font || base.font || null;
   style.activeFill = style.activeFill || getThemeAccent(theme);
+  style.activeHoverFill =
+    style.activeHoverFill ??
+    base.activeHoverFill ??
+    style.activeFill ??
+    style.hoverFill ??
+    style.fill;
   style.activeTextColor = style.activeTextColor || '#ffffff';
   return style;
 }
@@ -538,11 +545,13 @@ export function drawBlock(
     block.value && ['INPUT', 'OUTPUT', 'JUNCTION'].includes(block.type)
   );
   const blockRadius = Math.max(0, style.radius * scale);
-  const fillSpec = isActive && style.activeFill
-    ? style.activeFill
-    : hovered && style.hoverFill
-    ? style.hoverFill
-    : style.fill;
+  let fillSpec;
+  if (hovered) {
+    fillSpec = isActive ? style.activeHoverFill : style.hoverFill;
+  }
+  if (!fillSpec) {
+    fillSpec = isActive && style.activeFill ? style.activeFill : style.fill;
+  }
   applyScaledShadow(ctx, hovered ? style.hoverShadow : style.shadow, scale);
   const fillStyle = createFillStyle(ctx, fillSpec, x, y, size, size) || fillSpec || '#f0f0ff';
   ctx.fillStyle = fillStyle;

--- a/src/themes.js
+++ b/src/themes.js
@@ -320,8 +320,9 @@ const THEMES = [
       fill: ['#fdba74', '#fb923c'],
       hoverFill: ['#fb923c', '#f97316'],
       textColor: '#7c2d12',
-      activeFill: '#f97316',
-      activeTextColor: '#fff7ed',
+      activeFill: ['#fef08a', '#fde047', '#facc15'],
+      activeHoverFill: ['#fef9c3', '#fde68a', '#fbbf24'],
+      activeTextColor: '#78350f',
       radius: 14,
       shadow: {
         color: 'rgba(249, 115, 22, 0.35)',


### PR DESCRIPTION
## Summary
- add active hover fill support to block rendering so active blocks can use gradient hover styles
- update the Solar Punch theme to use fluorescent yellow gradients and improved contrast for active inputs

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ee45bb309083328865a1255ae954f1