### PR TITLE
Add neon gradient styling for active blocks

### DIFF
--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -62,6 +62,7 @@ const BASE_BLOCK_STYLE = {
   strokeColor: null,
   strokeWidth: 0,
   activeFill: null,
+  activeHoverFill: null,
   activeTextColor: null,
   font: null
 };
@@ -216,6 +217,7 @@ function resolveBlockStyle(options = {}) {
   style.radius = CELL_CORNER_RADIUS;
   style.font = style.font || base.font || null;
   style.activeFill = style.activeFill || getThemeAccent(theme);
+  style.activeHoverFill = style.activeHoverFill || style.hoverFill;
   style.activeTextColor = style.activeTextColor || '#ffffff';
   return style;
 }
@@ -538,8 +540,8 @@ export function drawBlock(
     block.value && ['INPUT', 'OUTPUT', 'JUNCTION'].includes(block.type)
   );
   const blockRadius = Math.max(0, style.radius * scale);
-  const fillSpec = isActive && style.activeFill
-    ? style.activeFill
+  const fillSpec = isActive
+    ? (hovered && (style.activeHoverFill || style.hoverFill)) || style.activeFill
     : hovered && style.hoverFill
     ? style.hoverFill
     : style.fill;

--- a/src/themes.js
+++ b/src/themes.js
@@ -82,8 +82,25 @@ const THEMES = [
       fill: ['#d7dbff', '#b9c1ff'],
       hoverFill: ['#c7cffb', '#a3b1ff'],
       textColor: '#111827',
-      activeFill: '#4f46e5',
-      activeTextColor: '#eef2ff',
+      activeFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef3c7' },
+          { offset: 0.55, color: '#fde047' },
+          { offset: 1, color: '#facc15' }
+        ]
+      },
+      activeHoverFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef9c3' },
+          { offset: 0.5, color: '#fde68a' },
+          { offset: 1, color: '#fbbf24' }
+        ]
+      },
+      activeTextColor: '#422006',
       radius: 12,
       shadow: {
         color: 'rgba(79, 70, 229, 0.18)',
@@ -152,8 +169,25 @@ const THEMES = [
       fill: '#dce3ef',
       hoverFill: '#cfd8e6',
       textColor: '#1f2937',
-      activeFill: '#475569',
-      activeTextColor: '#f8fafc',
+      activeFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef3c7' },
+          { offset: 0.55, color: '#fde047' },
+          { offset: 1, color: '#facc15' }
+        ]
+      },
+      activeHoverFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef9c3' },
+          { offset: 0.5, color: '#fde68a' },
+          { offset: 1, color: '#fbbf24' }
+        ]
+      },
+      activeTextColor: '#422006',
       radius: 12,
       shadow: {
         color: 'rgba(15, 23, 42, 0.18)',
@@ -236,8 +270,25 @@ const THEMES = [
       fill: ['#0ea5e9', '#38bdf8'],
       hoverFill: ['#38bdf8', '#67e8f9'],
       textColor: '#f8fafc',
-      activeFill: '#38bdf8',
-      activeTextColor: '#0f172a',
+      activeFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef3c7' },
+          { offset: 0.55, color: '#fde047' },
+          { offset: 1, color: '#facc15' }
+        ]
+      },
+      activeHoverFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef9c3' },
+          { offset: 0.5, color: '#fde68a' },
+          { offset: 1, color: '#fbbf24' }
+        ]
+      },
+      activeTextColor: '#1f2937',
       radius: 12,
       shadow: {
         color: 'rgba(56, 189, 248, 0.35)',
@@ -320,8 +371,25 @@ const THEMES = [
       fill: ['#fdba74', '#fb923c'],
       hoverFill: ['#fb923c', '#f97316'],
       textColor: '#7c2d12',
-      activeFill: '#f97316',
-      activeTextColor: '#fff7ed',
+      activeFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef3c7' },
+          { offset: 0.55, color: '#fde047' },
+          { offset: 1, color: '#facc15' }
+        ]
+      },
+      activeHoverFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef9c3' },
+          { offset: 0.5, color: '#fde68a' },
+          { offset: 1, color: '#fbbf24' }
+        ]
+      },
+      activeTextColor: '#422006',
       radius: 14,
       shadow: {
         color: 'rgba(249, 115, 22, 0.35)',
@@ -404,8 +472,25 @@ const THEMES = [
       fill: ['#a7f3d0', '#6ee7b7'],
       hoverFill: ['#6ee7b7', '#34d399'],
       textColor: '#064e3b',
-      activeFill: '#14b8a6',
-      activeTextColor: '#ecfdf5',
+      activeFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef3c7' },
+          { offset: 0.55, color: '#fde047' },
+          { offset: 1, color: '#facc15' }
+        ]
+      },
+      activeHoverFill: {
+        type: 'linear',
+        angle: 90,
+        stops: [
+          { offset: 0, color: '#fef9c3' },
+          { offset: 0.5, color: '#fde68a' },
+          { offset: 1, color: '#fbbf24' }
+        ]
+      },
+      activeTextColor: '#14532d',
       radius: 14,
       shadow: {
         color: 'rgba(16, 185, 129, 0.35)',


### PR DESCRIPTION
## Summary
- give active circuit blocks a fluorescent yellow gradient with hover feedback
- update theme palettes so active text colors stay legible across all themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ee45bb309083328865a1255ae954f1