### PR TITLE
Improve lab mode panning performance

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -59,6 +59,15 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     ? externalCamera
     : null;
   const useCamera = Boolean(camera);
+  const requestFrame =
+    typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : callback => setTimeout(callback, 16);
+  const cancelFrame =
+    typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function'
+      ? window.cancelAnimationFrame.bind(window)
+      : handle => clearTimeout(handle);
+  let pendingCameraFrame = null;
   const MIN_CAMERA_SCALE = 0.2;
   const MAX_CAMERA_SCALE = 3;
   const ZOOM_SENSITIVITY = 0.0015;
@@ -284,10 +293,24 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     }
   }
 
-  if (useCamera) {
-    camera.setOnChange(() => {
+  function cancelPendingCameraRefresh() {
+    if (pendingCameraFrame == null) return;
+    cancelFrame(pendingCameraFrame);
+    pendingCameraFrame = null;
+  }
+
+  function scheduleCameraRefresh() {
+    if (pendingCameraFrame != null) return;
+    pendingCameraFrame = requestFrame(() => {
+      pendingCameraFrame = null;
       refreshBackground();
       refreshContent();
+    });
+  }
+
+  if (useCamera) {
+    camera.setOnChange(() => {
+      scheduleCameraRefresh();
     });
   }
 
@@ -323,6 +346,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
         gridWidth,
         gridHeight,
       });
+      cancelPendingCameraRefresh();
     }
     refreshBackground();
     refreshContent();
@@ -1154,6 +1178,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   function destroy() {
     stopEngine();
     removeBoundEvents();
+    cancelPendingCameraRefresh();
     if (keydownHandler) {
       document.removeEventListener('keydown', keydownHandler);
       keydownHandler = null;


### PR DESCRIPTION
## Summary
- schedule camera-triggered redraws via requestAnimationFrame to avoid repeated renders while panning
- cancel pending redraws when resizing or destroying the lab controller to prevent redundant work

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee4d20745c833293165851318487bc