### PR TITLE
Ensure main screen signs out when Drive refresh token is missing

### DIFF
--- a/src/modules/authUI.js
+++ b/src/modules/authUI.js
@@ -670,6 +670,27 @@ async function handleGoogleLogin(user) {
 }
 
 function handleAuthStateChange(buttons, user) {
+  if (user && !hasStoredDriveRefreshToken()) {
+    console.warn('User is logged in without a stored Drive refresh token; reverting to logged-out state.');
+    updateLoginButtonLabels(buttons, null);
+    setLoginUsernameText(getUsername() || '');
+    restoreUsernameModalDefaults();
+    hideRankSection();
+    showGuestPrompt();
+    if (!getUsername()) {
+      assignGuestNickname();
+    }
+    if (typeof firebase !== 'undefined' && firebase.auth) {
+      firebase
+        .auth()
+        .signOut()
+        .catch(err => {
+          console.warn('Failed to sign out after missing refresh token detection', err);
+        });
+    }
+    return;
+  }
+
   updateLoginButtonLabels(buttons, user);
   const nickname = getUsername() || '';
   setLoginUsernameText(nickname);


### PR DESCRIPTION
## Summary
- sign the user out on the main screen if Firebase reports a user but no Drive refresh token is stored
- immediately revert the UI to the logged-out state so the page behaves consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0e6fca4588332a0113f7bfc39def2