### PR TITLE
Add keyboard shortcuts for copy/paste and redesign tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,10 +265,10 @@
           <div class="edit-toolbar" role="toolbar" aria-label="회로 복사 및 붙여넣기" hidden>
             <button
               id="problemCopySelectionBtn"
-              class="toolbar__button"
+              class="toolbar__button has-tooltip"
               type="button"
-              title="선택 영역 복사"
-              aria-label="선택 영역 복사"
+              data-tooltip="선택 영역 복사 (C)"
+              aria-label="선택 영역 복사 (C)"
               hidden
               disabled
             >
@@ -276,10 +276,10 @@
             </button>
             <button
               id="problemPasteSelectionBtn"
-              class="toolbar__button"
+              class="toolbar__button has-tooltip"
               type="button"
-              title="선택 영역 붙여넣기"
-              aria-label="선택 영역 붙여넣기"
+              data-tooltip="선택 영역 붙여넣기 (V)"
+              aria-label="선택 영역 붙여넣기 (V)"
               hidden
               disabled
             >
@@ -369,44 +369,44 @@
           <div style="display:flex; justify-content:space-between; gap:1rem;">
             <div style="display:flex; flex-direction:column; align-items:center; gap:0.5rem; margin:auto;">
               <div class="status-toolbar" role="toolbar" aria-label="회로 편집 단축키 안내">
-                <button id="problemWireMoveInfo" class="status-toolbar__button" type="button"
-                  title="기본 상태" aria-label="기본 상태">
+                <button id="problemWireMoveInfo" class="status-toolbar__button has-tooltip" type="button"
+                  data-tooltip="기본 상태" aria-label="기본 상태">
                   <img src="assets/icon_move.svg" alt="" class="status-toolbar__icon">
                 </button>
-                <button id="problemWireStatusInfo" class="status-toolbar__button" type="button"
-                  title="Ctrl / Cmd - 도선 그리기" aria-label="Ctrl / Cmd - 도선 그리기">
+                <button id="problemWireStatusInfo" class="status-toolbar__button has-tooltip" type="button"
+                  data-tooltip="Ctrl / Cmd - 도선 그리기" aria-label="Ctrl / Cmd - 도선 그리기">
                   <img src="assets/icon_draw.svg" alt="" class="status-toolbar__icon">
                 </button>
-                <button id="problemWireDeleteInfo" class="status-toolbar__button" type="button"
-                  title="Shift - 도선/블록 삭제" aria-label="Shift - 도선/블록 삭제">
+                <button id="problemWireDeleteInfo" class="status-toolbar__button has-tooltip" type="button"
+                  data-tooltip="Shift - 도선/블록 삭제" aria-label="Shift - 도선/블록 삭제">
                   <img src="assets/icon_delete.svg" alt="" class="status-toolbar__icon">
                 </button>
-                <button id="problemWireSelectInfo" class="status-toolbar__button" type="button"
-                  title="마우스 오른쪽 - 선택" aria-label="마우스 오른쪽 - 선택">
+                <button id="problemWireSelectInfo" class="status-toolbar__button has-tooltip" type="button"
+                  data-tooltip="마우스 오른쪽 - 선택" aria-label="마우스 오른쪽 - 선택">
                   <img src="assets/icon_select.svg" alt="" class="status-toolbar__icon">
                 </button>
-                <button id="problemDeleteAllInfo" class="status-toolbar__button" type="button"
-                  title="R - 회로 초기화" aria-label="R - 회로 초기화">
+                <button id="problemDeleteAllInfo" class="status-toolbar__button has-tooltip" type="button"
+                  data-tooltip="R - 회로 초기화" aria-label="R - 회로 초기화">
                   <img src="assets/icon_reset.svg" alt="" class="status-toolbar__icon">
                 </button>
               </div>
               <div class="history-toolbar" role="group" aria-label="되돌리기 및 다시 실행">
                 <button
                   id="problemUndoBtn"
-                  class="status-toolbar__button"
+                  class="status-toolbar__button has-tooltip"
                   type="button"
-                  title="되돌리기 (Z)"
-                  aria-label="되돌리기"
+                  data-tooltip="되돌리기 (Z)"
+                  aria-label="되돌리기 (Z)"
                   disabled
                 >
                   <img src="assets/icon_undo.svg" alt="" class="status-toolbar__icon">
                 </button>
                 <button
                   id="problemRedoBtn"
-                  class="status-toolbar__button"
+                  class="status-toolbar__button has-tooltip"
                   type="button"
-                  title="다시 실행 (Y)"
-                  aria-label="다시 실행"
+                  data-tooltip="다시 실행 (Y)"
+                  aria-label="다시 실행 (Y)"
                   disabled
                 >
                   <img src="assets/icon_redo.svg" alt="" class="status-toolbar__icon">
@@ -616,10 +616,10 @@
           <div class="edit-toolbar" role="toolbar" aria-label="회로 복사 및 붙여넣기" hidden>
             <button
               id="copySelectionBtn"
-              class="toolbar__button"
+              class="toolbar__button has-tooltip"
               type="button"
-              title="선택 영역 복사"
-              aria-label="선택 영역 복사"
+              data-tooltip="선택 영역 복사 (C)"
+              aria-label="선택 영역 복사 (C)"
               hidden
               disabled
             >
@@ -627,10 +627,10 @@
             </button>
             <button
               id="pasteSelectionBtn"
-              class="toolbar__button"
+              class="toolbar__button has-tooltip"
               type="button"
-              title="선택 영역 붙여넣기"
-              aria-label="선택 영역 붙여넣기"
+              data-tooltip="선택 영역 붙여넣기 (V)"
+              aria-label="선택 영역 붙여넣기 (V)"
               hidden
               disabled
             >
@@ -638,44 +638,44 @@
             </button>
           </div>
           <div class="status-toolbar" role="toolbar" aria-label="회로 편집 단축키 안내">
-            <button id="wireMoveInfo" class="status-toolbar__button" type="button"
-              title="기본 상태" aria-label="기본 상태">
+            <button id="wireMoveInfo" class="status-toolbar__button has-tooltip" type="button"
+              data-tooltip="기본 상태" aria-label="기본 상태">
               <img src="assets/icon_move.svg" alt="" class="status-toolbar__icon">
             </button>
-            <button id="wireStatusInfo" class="status-toolbar__button" type="button"
-              title="Ctrl / Cmd - 도선 그리기" aria-label="Ctrl / Cmd - 도선 그리기">
+            <button id="wireStatusInfo" class="status-toolbar__button has-tooltip" type="button"
+              data-tooltip="Ctrl / Cmd - 도선 그리기" aria-label="Ctrl / Cmd - 도선 그리기">
               <img src="assets/icon_draw.svg" alt="" class="status-toolbar__icon">
             </button>
-            <button id="wireDeleteInfo" class="status-toolbar__button" type="button"
-              title="Shift - 도선/블록 삭제" aria-label="Shift - 도선/블록 삭제">
+            <button id="wireDeleteInfo" class="status-toolbar__button has-tooltip" type="button"
+              data-tooltip="Shift - 도선/블록 삭제" aria-label="Shift - 도선/블록 삭제">
               <img src="assets/icon_delete.svg" alt="" class="status-toolbar__icon">
             </button>
-            <button id="wireSelectInfo" class="status-toolbar__button" type="button"
-              title="마우스 오른쪽 - 선택" aria-label="마우스 오른쪽 - 선택">
+            <button id="wireSelectInfo" class="status-toolbar__button has-tooltip" type="button"
+              data-tooltip="마우스 오른쪽 - 선택" aria-label="마우스 오른쪽 - 선택">
               <img src="assets/icon_select.svg" alt="" class="status-toolbar__icon">
             </button>
-            <button id="DeleteAllInfo" class="status-toolbar__button" type="button"
-              title="R - 회로 초기화" aria-label="R - 회로 초기화">
+            <button id="DeleteAllInfo" class="status-toolbar__button has-tooltip" type="button"
+              data-tooltip="R - 회로 초기화" aria-label="R - 회로 초기화">
               <img src="assets/icon_reset.svg" alt="" class="status-toolbar__icon">
             </button>
           </div>
           <div class="history-toolbar" role="group" aria-label="되돌리기 및 다시 실행">
             <button
               id="undoBtn"
-              class="status-toolbar__button"
+              class="status-toolbar__button has-tooltip"
               type="button"
-              title="되돌리기 (Z)"
-              aria-label="되돌리기"
+              data-tooltip="되돌리기 (Z)"
+              aria-label="되돌리기 (Z)"
               disabled
             >
               <img src="assets/icon_undo.svg" alt="" class="status-toolbar__icon">
             </button>
             <button
               id="redoBtn"
-              class="status-toolbar__button"
+              class="status-toolbar__button has-tooltip"
               type="button"
-              title="다시 실행 (Y)"
-              aria-label="다시 실행"
+              data-tooltip="다시 실행 (Y)"
+              aria-label="다시 실행 (Y)"
               disabled
             >
               <img src="assets/icon_redo.svg" alt="" class="status-toolbar__icon">

--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1366,6 +1366,22 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
       }
       const active = document.activeElement;
       if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) return;
+      if (key === 'c') {
+        if (state.copyPasteEnabled && state.selection) {
+          const copied = copySelection();
+          if (copied) {
+            e.preventDefault();
+            return;
+          }
+        }
+      }
+      if (key === 'v') {
+        if (state.copyPasteEnabled && state.clipboard) {
+          e.preventDefault();
+          togglePasteMode();
+          return;
+        }
+      }
       if (key === 'z') {
         e.preventDefault();
         undo();

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -582,6 +582,66 @@ html, body {
     pointer-events: none;
   }
 
+  .has-tooltip {
+    position: relative;
+  }
+
+  .has-tooltip::after,
+  .has-tooltip::before {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 20;
+  }
+
+  .has-tooltip::after {
+    content: attr(data-tooltip);
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, -6px);
+    background: rgba(30, 41, 59, 0.92);
+    color: #f8fafc;
+    padding: 6px 10px;
+    border-radius: 8px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.18);
+  }
+
+  .has-tooltip::before {
+    content: '';
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, -2px) scale(0.8);
+    border-width: 6px;
+    border-style: solid;
+    border-color: rgba(30, 41, 59, 0.92) transparent transparent transparent;
+  }
+
+  .has-tooltip:hover::after,
+  .has-tooltip:focus-visible::after {
+    opacity: 1;
+    transform: translate(-50%, -12px);
+  }
+
+  .has-tooltip:hover::before,
+  .has-tooltip:focus-visible::before {
+    opacity: 1;
+    transform: translate(-50%, -4px) scale(1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .has-tooltip::after,
+    .has-tooltip::before,
+    .has-tooltip:hover::after,
+    .has-tooltip:hover::before,
+    .has-tooltip:focus-visible::after,
+    .has-tooltip:focus-visible::before {
+      transition: none;
+    }
+  }
+
   #wireMoveInfo,
   #problemWireMoveInfo {
     cursor: default;


### PR DESCRIPTION
## Summary
- add dedicated C and V keyboard shortcuts for copying selections and toggling paste mode on the canvas
- replace native title attributes on toolbar buttons with consistent tooltip content that highlights shortcut keys
- introduce a custom tooltip style for toolbar buttons so shortcut help is easier to read

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6159656908332a0d9e82af25f4285