### PR TITLE
Allow palette drops to replace occupied blocks

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -1899,23 +1899,65 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
               if (endB) endB.inputs = [...(endB.inputs || []), w.startBlockId];
             });
           }
-        } else if (!blockAt(cell) && !cellHasWire(cell)) {
-          const id = 'b' + Date.now();
-          circuit.blocks[id] = newBlock({
-            id,
-            type: state.draggingBlock.type,
-            name: state.draggingBlock.name,
-            pos: cell,
-          });
-          placed = true;
-          if (
-            state.draggingBlock.type === 'INPUT' ||
-            state.draggingBlock.type === 'OUTPUT'
-          ) {
-            hidePaletteItem(
-              state.draggingBlock.type,
-              state.draggingBlock.name
-            );
+        } else {
+          const occupyingBlock = blockAt(cell);
+          if (!occupyingBlock && !cellHasWire(cell)) {
+            const id = 'b' + Date.now();
+            circuit.blocks[id] = newBlock({
+              id,
+              type: state.draggingBlock.type,
+              name: state.draggingBlock.name,
+              pos: cell,
+            });
+            placed = true;
+            if (
+              state.draggingBlock.type === 'INPUT' ||
+              state.draggingBlock.type === 'OUTPUT'
+            ) {
+              hidePaletteItem(
+                state.draggingBlock.type,
+                state.draggingBlock.name
+              );
+            }
+          } else if (occupyingBlock && !occupyingBlock.fixed) {
+            if (
+              occupyingBlock.type === 'INPUT' ||
+              occupyingBlock.type === 'OUTPUT'
+            ) {
+              showPaletteItem(occupyingBlock.type, occupyingBlock.name);
+            }
+
+            const preservedInputs = Array.isArray(occupyingBlock.inputs)
+              ? [...occupyingBlock.inputs]
+              : undefined;
+            const replacement = newBlock({
+              id: occupyingBlock.id,
+              type: state.draggingBlock.type,
+              name: state.draggingBlock.name,
+              pos: { ...occupyingBlock.pos },
+              value:
+                state.draggingBlock.type === 'INPUT'
+                  ? Boolean(occupyingBlock.value)
+                  : false,
+              fixed: false,
+            });
+
+            if (preservedInputs) {
+              replacement.inputs = preservedInputs;
+            }
+
+            circuit.blocks[occupyingBlock.id] = replacement;
+            placed = true;
+
+            if (
+              state.draggingBlock.type === 'INPUT' ||
+              state.draggingBlock.type === 'OUTPUT'
+            ) {
+              hidePaletteItem(
+                state.draggingBlock.type,
+                state.draggingBlock.name
+              );
+            }
           }
         }
       } else if (


### PR DESCRIPTION
## Summary
- allow dragging a palette block onto an occupied grid cell to swap the existing block back into the palette
- preserve wire connections by reusing the occupying block and keeping its inputs while updating the type

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68f6184a361c8332adce39686b0a6bb6