### PR TITLE
Avoid redundant circuit evaluations

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -8,7 +8,7 @@ import {
   roundRect,
   CELL_CORNER_RADIUS
 } from './renderer.js';
-import { evaluateCircuit, startEngine } from './engine.js';
+import { evaluateCircuit, markCircuitDirty, startEngine } from './engine.js';
 
 let keydownHandler = null;
 let keyupHandler = null;
@@ -395,6 +395,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
   }
 
   function notifyCircuitModified() {
+    markCircuitDirty(circuit);
     if (typeof onCircuitModified === 'function') {
       try {
         onCircuitModified();

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -1,4 +1,5 @@
 import { createCamera } from '../canvas/camera.js';
+import { markCircuitDirty } from '../canvas/engine.js';
 import { onThemeChange } from '../themes.js';
 
 const DEFAULT_GRID_SIZE = 6;
@@ -454,6 +455,22 @@ export function clearWires() {
 
 export function markCircuitModified(context) {
   const resolvedContext = resolveCircuitContext(context);
+  if (resolvedContext === CIRCUIT_CONTEXT.PLAY) {
+    if (playCircuit) {
+      markCircuitDirty(playCircuit);
+    }
+  } else if (resolvedContext === CIRCUIT_CONTEXT.PROBLEM) {
+    if (problemCircuit) {
+      markCircuitDirty(problemCircuit);
+    }
+  } else {
+    if (playCircuit) {
+      markCircuitDirty(playCircuit);
+    }
+    if (problemCircuit) {
+      markCircuitDirty(problemCircuit);
+    }
+  }
   notifyCircuitModified(resolvedContext);
   playController?.syncPaletteWithCircuit?.();
   problemController?.syncPaletteWithCircuit?.();


### PR DESCRIPTION
## Summary
- track circuit dirtiness so the engine only reevaluates when necessary
- flag circuits as dirty whenever controllers or grid helpers mutate them
- keep initial evaluation before the render loop to preserve existing behaviour

## Testing
- node tests/startEngine.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68f780bdf4448332b0ae36f0b5225348