### PR TITLE
Allow deeper zoom out on infinite grid

### DIFF
--- a/src/canvas/controller.js
+++ b/src/canvas/controller.js
@@ -115,7 +115,7 @@ export function createController(canvasSet, circuit, ui = {}, options = {}) {
     ? externalCamera
     : null;
   const useCamera = Boolean(camera);
-  const MIN_CAMERA_SCALE = 0.2;
+  const MIN_CAMERA_SCALE = unboundedGrid ? 0.05 : 0.2;
   const MAX_CAMERA_SCALE = 3;
   const ZOOM_SENSITIVITY = 0.0015;
   const gap = 10;

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -222,7 +222,7 @@ export function adjustGridZoom(containerId = 'canvasContainer') {
   const camera = isProblemContainer ? problemCamera : playCamera;
 
   if (camera && typeof controller?.resizeCanvas === 'function') {
-    const MIN_CAMERA_SCALE = 0.1;
+    const MIN_CAMERA_SCALE = 0.05;
     const resolvedPanelWidth = Number.isFinite(panelWidth)
       ? panelWidth
       : Math.max(0, baseWidth - (Number.isFinite(baseGridWidth) ? baseGridWidth : 0));


### PR DESCRIPTION
## Summary
- lower the minimum camera scale applied during grid resize so the canvas can shrink further
- allow controllers in unbounded grid contexts to zoom out to a 0.05 scale

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f78a1bb3688332b8e72a5adfd0eb68