### PR TITLE
Fix missing level title import

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,6 +107,7 @@ const {
   isLevelUnlocked,
   showIntroModal,
   getLevelDescription,
+  getLevelTitle,
   getLevelTitles,
   getLevelBlockSet,
   getLevelAnswer,
@@ -251,6 +252,7 @@ const clearedModalOptions = {
   closeButtonSelector: '.closeBtn',
   translate,
   loadClearedLevelsFromDb,
+  getLevelTitle,
   getLevelTitles,
   isLevelUnlocked,
   startLevel,
@@ -546,6 +548,7 @@ const { maybeStartTutorial = () => {} } = (initializeTutorials({
   lockOrientationLandscape,
   getStageDataPromise,
   startLevel,
+  getLevelTitle,
   getLevelTitles,
   getClearedLevels,
   elements: {


### PR DESCRIPTION
## Summary
- include the `getLevelTitle` helper when wiring level-related modules in `main.js`
- pass the new reference through to the modal and tutorial initializers that expect it so the stage map can render without runtime errors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5a6e643c83328425fb53ba12a4b1)