### PR TITLE
Temporarily disable auto tutorial popup

### DIFF
--- a/src/modules/tutorials.js
+++ b/src/modules/tutorials.js
@@ -174,7 +174,12 @@ export function initializeTutorials({
     }
   };
 
+  const autoTutorialEnabled = false;
+
   const maybeStartTutorial = () => {
+    if (!autoTutorialEnabled) {
+      return;
+    }
     if (!storage || storage.getItem('tutorialCompleted')) {
       return;
     }


### PR DESCRIPTION
## Summary
- add a flag to short-circuit tutorial auto-start logic so the modal no longer appears on initial load

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c89cd0e7c83329971e62135814bab)