### PR TITLE
Embed login area in stage map info

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,28 @@
             <h1>🧠 Bitwiser</h1>
             <p class="tagline" id="mainTagline"></p>
           </div>
+          <div id="loginArea" class="stage-map-profile">
+            <h2 id="loginUsername"></h2>
+            <div id="rankSection" style="display:none;">
+              <table id="rankTable">
+                <tr>
+                  <td class="rank-cell">
+                    <p id="loginRankOverallLabel" class="rank-label"></p>
+                    <p id="overallRank" class="rank-value">#-</p>
+                  </td>
+                  <td class="rank-cell">
+                    <p id="loginRankClearedLabel" class="rank-label"></p>
+                    <p id="clearedCount" class="rank-value">0</p>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <div class="button-row">
+              <button id="googleLoginBtn" class="main-button"></button>
+              <button id="languageBtn" class="main-button"></button>
+            </div>
+            <p id="loginGuestPrompt" class="tagline"></p>
+          </div>
         </div>
         <div class="stage-detail-panel" id="stageDetailPanel">
           <p class="stage-detail-panel__chapter" id="stageDetailChapter"></p>
@@ -133,16 +155,6 @@
         </div>
       </div>
       <div class="stage-map-hud" aria-label="Stage map HUD">
-        <button
-          class="hud-button"
-          type="button"
-          data-panel-target="#loginPanel"
-          aria-controls="loginPanel"
-          aria-expanded="false"
-          aria-label="프로필"
-        >
-          👤
-        </button>
         <button class="hud-button" id="settingsBtn" type="button" aria-label="설정">
           ⚙️
         </button>
@@ -174,36 +186,6 @@
       </div>
       <div id="stagePanelBackdrop" class="stage-panel-backdrop" hidden></div>
       <div class="stage-map-panels">
-        <aside id="loginPanel" class="stage-panel" aria-hidden="true">
-          <div class="stage-panel__header">
-            <h2 id="loginPanelTitle">프로필 &amp; 로그인</h2>
-            <button class="stage-panel__close" type="button" data-panel-close aria-label="패널 닫기">×</button>
-          </div>
-          <div class="stage-panel__body">
-            <div id="loginArea">
-              <h2 id="loginUsername"></h2>
-              <div id="rankSection" style="display:none;">
-                <table id="rankTable">
-                  <tr>
-                    <td class="rank-cell">
-                      <p id="loginRankOverallLabel" class="rank-label"></p>
-                      <p id="overallRank" class="rank-value">#-</p>
-                    </td>
-                    <td class="rank-cell">
-                      <p id="loginRankClearedLabel" class="rank-label"></p>
-                      <p id="clearedCount" class="rank-value">0</p>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-              <div class="button-row">
-                <button id="googleLoginBtn" class="main-button"></button>
-                <button id="languageBtn" class="main-button"></button>
-              </div>
-              <p id="loginGuestPrompt" class="tagline"></p>
-            </div>
-          </div>
-        </aside>
         <aside id="rankingPanel" class="stage-panel" aria-hidden="true">
           <div class="stage-panel__header">
             <h2 id="rankingPanelTitle">🏆 전체 랭킹</h2>

--- a/style.css
+++ b/style.css
@@ -247,6 +247,27 @@ body.safe-mode .stage-map-connections path {
   gap: 0.75rem;
 }
 
+.stage-map-profile {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.02);
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stage-map-profile .button-row {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.stage-map-profile .main-button {
+  flex: 1 1 auto;
+}
+
 .stage-map-actions {
   display: flex;
   flex-wrap: wrap;
@@ -434,6 +455,11 @@ body.safe-mode .stage-panel {
   background: rgba(2, 6, 23, 0.94);
   color: #f8fafc;
   border: 1px solid rgba(248, 250, 252, 0.1);
+}
+
+body.safe-mode .stage-map-profile {
+  background: rgba(248, 250, 252, 0.06);
+  border-color: rgba(248, 250, 252, 0.25);
 }
 
 .problem-grid-container {
@@ -1502,8 +1528,7 @@ html, body {
   /* ── ② 비게임 화면에만 “흰 배경 + 블러” 오버레이 적용 ── */
   /* ── 비게임 화면에만 오버레이 적용 ── */
   body:not(.game-active) #mainScreen,
-  body:not(.game-active) #chapterStageScreen,
-  body:not(.game-active) #loginArea{
+  body:not(.game-active) #chapterStageScreen {
     background-color: rgba(255, 255, 255, 0.8);
     backdrop-filter: blur(8px);
     border-radius: 12px;
@@ -1802,8 +1827,7 @@ html, body {
     margin: 0 auto;
   }
 
-#mainScreen,
-#loginArea{
+#mainScreen {
   width: 320px;
 }
 
@@ -1821,7 +1845,8 @@ html, body {
   #loginArea {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 
   #loginArea #rankTable {


### PR DESCRIPTION
## Summary
- move the login/profile UI into the always-visible stage map info card and remove the profile HUD shortcut/panel
- add styling tweaks so the integrated login area aligns with the stage map aesthetic and keep safe-mode parity

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8cc9298c8332ba7f24a306c488dc)