### PR TITLE
feat: redraw stage map with lab-style circuit

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,14 +107,9 @@
     <!-- 스테이지 맵 화면 -->
     <section id="stageMapScreen" class="stage-map-screen" aria-label="Stage Map">
       <div class="stage-map-surface" id="stageMapSurface">
-        <div
-          class="stage-map-viewport"
-          id="stageMapViewport"
-          style="--map-scale: 1; --map-translate-x: 0px; --map-translate-y: 0px;"
-        >
-          <div class="stage-map-grid" aria-hidden="true"></div>
-          <svg id="stageMapConnections" class="stage-map-connections" role="presentation"></svg>
-          <div id="stageMapNodes" class="stage-map-nodes" role="list"></div>
+        <div class="stage-map-viewport" id="stageMapViewport">
+          <canvas id="stageMapCanvas" class="stage-map-canvas" role="presentation"></canvas>
+          <div id="stageMapNodes" class="stage-map-nodes" role="presentation"></div>
         </div>
         <div class="stage-map-info">
           <div class="stage-map-title">

--- a/src/modules/stageMap.js
+++ b/src/modules/stageMap.js
@@ -7,12 +7,44 @@ import {
 } from './navigation.js';
 import { openLabModeFromShortcut } from './labMode.js';
 import { STAGE_GRAPH, STAGE_TYPE_META } from './stageMapLayout.js';
+import { createCamera } from '../canvas/camera.js';
+import { drawGrid, drawWire, setupCanvas } from '../canvas/renderer.js';
+import { CELL, GAP } from '../canvas/model.js';
 
 const translate = typeof window !== 'undefined' && typeof window.t === 'function'
   ? window.t
   : key => key;
 
 const SPECIAL_NODE_KEY = 'stageMapSpecialClears';
+const PITCH = CELL + GAP;
+const DEFAULT_CAMERA_SCALE = 0.75;
+const GRID_MARGIN_CELLS = 12;
+const STAGE_SPAN = STAGE_GRAPH.cellSpan ?? 3;
+const STAGE_WORLD_SIZE = STAGE_SPAN * PITCH - GAP;
+const GRID_STYLE = {
+  unbounded: true,
+  background: 'rgba(2, 6, 23, 0.95)',
+  gridFillA: 'rgba(15, 23, 42, 0.9)',
+  gridFillB: 'rgba(11, 16, 34, 0.9)',
+  gridStroke: 'rgba(148, 163, 184, 0.35)',
+  gridLineWidth: 1.1,
+  panelShadow: null,
+  borderColor: null
+};
+const INACTIVE_WIRE_STYLE = {
+  color: 'rgba(148, 163, 184, 0.5)',
+  width: 2.4,
+  dashPattern: [],
+  nodeFill: 'rgba(15, 23, 42, 0.85)',
+  nodeShadow: { color: 'rgba(15, 23, 42, 0.4)', blur: 6, offsetY: 2 }
+};
+const ACTIVE_WIRE_STYLE = {
+  color: '#fbbf24',
+  width: 3,
+  dashPattern: [],
+  nodeFill: '#fde68a',
+  nodeShadow: { color: 'rgba(251, 191, 36, 0.65)', blur: 12, offsetY: 4 }
+};
 
 function loadSpecialNodeClears() {
   if (typeof localStorage === 'undefined') return new Set();
@@ -44,6 +76,105 @@ function getTypeLabel(type) {
   return typeof text === 'string' ? text : '';
 }
 
+function gridToWorld(r, c) {
+  return {
+    x: GAP + c * PITCH,
+    y: GAP + r * PITCH
+  };
+}
+
+function getAnchorCell(node, anchor = 'E') {
+  if (!node?.gridPosition) return null;
+  const { r, c } = node.gridPosition;
+  const center = Math.floor(STAGE_SPAN / 2);
+  switch (anchor) {
+    case 'N':
+      return { r: r - 1, c: c + center };
+    case 'S':
+      return { r: r + STAGE_SPAN, c: c + center };
+    case 'W':
+      return { r: r + center, c: c - 1 };
+    case 'E':
+      return { r: r + center, c: c + STAGE_SPAN };
+    default:
+      return null;
+  }
+}
+
+function expandPathPoints(points) {
+  if (!Array.isArray(points) || points.length === 0) return [];
+  const expanded = [];
+  for (let i = 0; i < points.length; i += 1) {
+    const point = points[i];
+    if (!point) continue;
+    const current = { r: point.r, c: point.c };
+    if (i === 0) {
+      expanded.push(current);
+      continue;
+    }
+    const prev = expanded[expanded.length - 1];
+    if (prev.r !== current.r && prev.c !== current.c) {
+      console.warn('Stage map connection requires axis-aligned points', prev, current);
+      return expanded;
+    }
+    if (prev.r === current.r) {
+      const step = current.c >= prev.c ? 1 : -1;
+      for (let col = prev.c + step; col !== current.c + step; col += step) {
+        expanded.push({ r: current.r, c: col });
+      }
+    } else {
+      const step = current.r >= prev.r ? 1 : -1;
+      for (let row = prev.r + step; row !== current.r + step; row += step) {
+        expanded.push({ r: row, c: current.c });
+      }
+    }
+  }
+  return expanded;
+}
+
+function buildMapGeometry({ getLevelTitle } = {}) {
+  const nodes = STAGE_GRAPH.nodes.map(node => ({
+    ...node,
+    gridPosition: { ...node.gridPosition },
+    chapterName: getTypeLabel(node.type),
+    title: node.level ? (getLevelTitle?.(node.level) ?? node.label) : node.label
+  }));
+  const lookup = new Map(nodes.map(node => [node.id, node]));
+  let maxRow = 0;
+  let maxCol = 0;
+  nodes.forEach(node => {
+    maxRow = Math.max(maxRow, node.gridPosition.r + STAGE_SPAN);
+    maxCol = Math.max(maxCol, node.gridPosition.c + STAGE_SPAN);
+  });
+  const rawConnections = STAGE_GRAPH.connections ?? STAGE_GRAPH.edges ?? [];
+  const connections = rawConnections.map(conn => {
+    const fromNode = lookup.get(conn.from);
+    const toNode = lookup.get(conn.to);
+    if (!fromNode || !toNode) return null;
+    const start = getAnchorCell(fromNode, conn.startAnchor);
+    const end = getAnchorCell(toNode, conn.endAnchor);
+    if (!start || !end) return null;
+    const controls = Array.isArray(conn.path) ? conn.path.map(pt => ({ r: pt.r, c: pt.c })) : [];
+    const path = expandPathPoints([start, ...controls, end]);
+    path.forEach(pt => {
+      if (Number.isFinite(pt?.r)) maxRow = Math.max(maxRow, pt.r);
+      if (Number.isFinite(pt?.c)) maxCol = Math.max(maxCol, pt.c);
+    });
+    return {
+      id: `${conn.from}->${conn.to}`,
+      from: conn.from,
+      to: conn.to,
+      path,
+      active: false
+    };
+  }).filter(Boolean);
+  const gridRows = maxRow + STAGE_SPAN + GRID_MARGIN_CELLS;
+  const gridCols = maxCol + STAGE_SPAN + GRID_MARGIN_CELLS;
+  const worldWidth = GAP + gridCols * PITCH;
+  const worldHeight = GAP + gridRows * PITCH;
+  return { nodes, lookup, connections, gridRows, gridCols, worldWidth, worldHeight };
+}
+
 function createNodeElement(node) {
   const button = document.createElement('button');
   button.type = 'button';
@@ -52,41 +183,21 @@ function createNodeElement(node) {
   if (node.level) {
     button.dataset.stage = String(node.level);
   }
-  button.style.left = `${node.x}px`;
-  button.style.top = `${node.y}px`;
-  const icon = document.createElement('span');
-  icon.className = 'stage-node__icon';
-  icon.textContent = node.icon ?? STAGE_TYPE_META[node.type]?.icon ?? '';
-  const body = document.createElement('span');
-  body.className = 'stage-node__body';
-  body.innerHTML = `
-    <span class="stage-node__chapter">${node.chapterName}</span>
-    <span class="stage-node__title">${node.title}</span>
-    <span class="stage-node__status"></span>
+  button.setAttribute('aria-label', node.title || node.label);
+  const chip = document.createElement('span');
+  chip.className = 'stage-node__chip';
+  chip.innerHTML = `
+    <span class="stage-node__icon">${node.icon ?? STAGE_TYPE_META[node.type]?.icon ?? ''}</span>
+    <span class="stage-node__text">
+      <span class="stage-node__chapter">${node.chapterName ?? ''}</span>
+      <span class="stage-node__title">${node.title ?? ''}</span>
+    </span>
   `;
-  button.appendChild(icon);
-  button.appendChild(body);
-  button.setAttribute('aria-label', `${node.title}`);
+  const status = document.createElement('span');
+  status.className = 'stage-node__status';
+  button.appendChild(chip);
+  button.appendChild(status);
   return button;
-}
-
-function buildMapNodes({ getLevelTitle } = {}) {
-  const nodes = STAGE_GRAPH.nodes.map(node => {
-    const [x, y] = node.position;
-    const title = node.level
-      ? (getLevelTitle?.(node.level) ?? node.label)
-      : node.label;
-    return {
-      ...node,
-      x,
-      y,
-      title,
-      chapterName: getTypeLabel(node.type)
-    };
-  });
-  const width = Math.max(1400, Math.max(...nodes.map(node => node.x)) + 200);
-  const height = Math.max(900, Math.max(...nodes.map(node => node.y)) + 200);
-  return { nodes, mapSize: { width, height }, edges: [...STAGE_GRAPH.edges] };
 }
 
 function updatePanelState(panel, isOpen, backdrop) {
@@ -96,17 +207,6 @@ function updatePanelState(panel, isOpen, backdrop) {
   if (backdrop) {
     backdrop.hidden = !isOpen;
   }
-}
-
-function createConnectionPath(from, to) {
-  const dx = to.x - from.x;
-  const dy = to.y - from.y;
-  const midX = (from.x + to.x) / 2;
-  const midY = (from.y + to.y) / 2;
-  const bend = Math.min(160, Math.hypot(dx, dy) * 0.35);
-  const controlY = dy >= 0 ? midY - bend : midY + bend;
-  const controlX = midX + Math.sign(dx || 1) * Math.min(60, Math.abs(dy) * 0.25);
-  return `M ${from.x} ${from.y} Q ${controlX} ${controlY} ${to.x} ${to.y}`;
 }
 
 export function initializeStageMap({
@@ -119,7 +219,7 @@ export function initializeStageMap({
   const screenEl = document.getElementById('stageMapScreen');
   const viewport = document.getElementById('stageMapViewport');
   const nodesLayer = document.getElementById('stageMapNodes');
-  const connectionsSvg = document.getElementById('stageMapConnections');
+  const canvas = document.getElementById('stageMapCanvas');
   const zoomInBtn = document.getElementById('stageMapZoomIn');
   const zoomOutBtn = document.getElementById('stageMapZoomOut');
   const zoomResetBtn = document.getElementById('stageMapZoomReset');
@@ -129,31 +229,139 @@ export function initializeStageMap({
   const panelButtonByPanel = new Map();
   const panelBackdrop = document.getElementById('stagePanelBackdrop');
 
-  if (!screenEl || !viewport || !nodesLayer || !connectionsSvg) {
+  if (!screenEl || !viewport || !nodesLayer || !canvas) {
     return null;
   }
 
   const state = {
     nodes: [],
     nodeLookup: new Map(),
-    elements: new Map(),
-    edges: [],
     dependencies: new Map(),
     nodeStatus: new Map(),
-    scale: 1,
-    translateX: 0,
-    translateY: 0,
-    openPanel: null,
+    elements: new Map(),
+    wires: [],
+    scaleReadout: zoomResetBtn,
+    specialClears: loadSpecialNodeClears(),
+    camera: null,
+    ctx: null,
+    canvas,
+    viewport,
     pointerStart: null,
-    specialClears: loadSpecialNodeClears()
+    gridRows: 0,
+    gridCols: 0,
+    worldWidth: 0,
+    worldHeight: 0,
+    renderPending: false,
+    hasCentered: false,
+    resizeHandler: null,
+    openPanel: null
   };
 
-  function updateConnections() {
-    state.edges.forEach(edge => {
-      const status = state.nodeStatus.get(edge.from);
-      const active = Boolean(status?.progressCleared);
-      edge.element.classList.toggle('stage-connection--active', active);
+  function scheduleRender() {
+    if (state.renderPending) return;
+    state.renderPending = true;
+    const raf = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : cb => setTimeout(cb, 16);
+    raf(() => {
+      state.renderPending = false;
+      renderMap();
     });
+  }
+
+  function renderMap() {
+    if (!state.ctx || !state.camera) return;
+    drawGrid(state.ctx, state.gridRows, state.gridCols, 0, state.camera, GRID_STYLE);
+    state.wires.forEach(wire => {
+      drawWire(state.ctx, wire, 0, 0, state.camera, wire.active ? ACTIVE_WIRE_STYLE : INACTIVE_WIRE_STYLE);
+    });
+  }
+
+  function updateNodePositions() {
+    if (!state.camera) return;
+    const scale = state.camera.getScale();
+    state.nodes.forEach(node => {
+      const el = state.elements.get(node.id);
+      if (!el) return;
+      const topLeft = gridToWorld(node.gridPosition.r, node.gridPosition.c);
+      const screenPoint = state.camera.worldToScreen(topLeft.x, topLeft.y);
+      const size = STAGE_WORLD_SIZE * scale;
+      el.style.width = `${size}px`;
+      el.style.height = `${size}px`;
+      el.style.transform = `translate(${screenPoint.x}px, ${screenPoint.y}px)`;
+      el.style.setProperty('--stage-node-font-size', `${Math.max(12, 14 * scale)}px`);
+      el.style.setProperty('--stage-node-status-size', `${Math.max(10, 11 * scale)}px`);
+    });
+  }
+
+  function updateZoomDisplay() {
+    if (!state.scaleReadout || !state.camera) return;
+    const scale = state.camera.getScale();
+    state.scaleReadout.textContent = `${scale.toFixed(2)}×`;
+  }
+
+  function handleCameraChange() {
+    updateNodePositions();
+    updateZoomDisplay();
+    scheduleRender();
+  }
+
+  function resizeCanvas() {
+    if (!state.viewport || !state.canvas) return;
+    const rect = state.viewport.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    state.ctx = setupCanvas(state.canvas, rect.width, rect.height);
+    if (state.camera) {
+      state.camera.setViewport(rect.width, rect.height, { gridWidth: rect.width, gridHeight: rect.height });
+    }
+    updateNodePositions();
+    scheduleRender();
+  }
+
+  function centerCamera(force = false) {
+    if (!state.camera) return;
+    if (state.hasCentered && !force) return;
+    const camState = state.camera.getState();
+    const effectiveWidth = Math.max(0, (camState.viewportWidth ?? 0) - (camState.panelWidth ?? 0));
+    const effectiveHeight = Math.max(0, camState.viewportHeight ?? 0);
+    if (effectiveWidth === 0 || effectiveHeight === 0 || !Number.isFinite(camState.scale) || camState.scale <= 0) {
+      return;
+    }
+    const visibleWidth = effectiveWidth / camState.scale;
+    const visibleHeight = effectiveHeight / camState.scale;
+    const targetX = Math.max(0, (state.worldWidth - visibleWidth) / 2);
+    const targetY = Math.max(0, (state.worldHeight - visibleHeight) / 2);
+    const dx = (camState.originX - targetX) * camState.scale;
+    const dy = (camState.originY - targetY) * camState.scale;
+    state.camera.pan(dx, dy);
+    state.hasCentered = true;
+  }
+
+  function adjustZoom(factor, pivotX, pivotY) {
+    if (!state.camera || !Number.isFinite(factor)) return;
+    const current = state.camera.getScale();
+    const next = Math.max(0.45, Math.min(2.4, current * factor));
+    const pivot = state.viewport.getBoundingClientRect();
+    const px = pivotX ?? pivot.width / 2;
+    const py = pivotY ?? pivot.height / 2;
+    state.camera.setScale(next, px, py);
+  }
+
+  function resetView() {
+    if (!state.camera) return;
+    state.hasCentered = false;
+    state.camera.reset();
+    centerCamera(true);
+    updateZoomDisplay();
+    scheduleRender();
+  }
+
+  function updateConnections() {
+    state.wires.forEach(wire => {
+      const status = state.nodeStatus.get(wire.from);
+      wire.active = Boolean(status?.progressCleared);
+    });
+    scheduleRender();
   }
 
   function evaluateNodeStatus(node, memo, visiting, clearedLevels) {
@@ -184,7 +392,7 @@ export function initializeStageMap({
       const levelUnlocked = isLevelUnlocked?.(node.level) ?? true;
       unlocked = prerequisitesMet && levelUnlocked;
       locked = !unlocked;
-      displayCleared = (clearedLevels.has(node.level));
+      displayCleared = clearedLevels.has(node.level);
       progressCleared = displayCleared;
       statusKey = displayCleared
         ? 'stageDetailClearedMessage'
@@ -240,107 +448,41 @@ export function initializeStageMap({
   }
 
   function attachNodes() {
-    const { nodes, mapSize, edges } = buildMapNodes({ getLevelTitle });
-    state.nodes = nodes;
-    state.nodeLookup = new Map(nodes.map(node => [node.id, node]));
+    const geometry = buildMapGeometry({ getLevelTitle });
+    state.nodes = geometry.nodes;
+    state.nodeLookup = geometry.lookup;
     state.dependencies = new Map();
-    nodes.forEach(node => {
+    state.nodes.forEach(node => {
       state.dependencies.set(node.id, []);
     });
-    edges.forEach(edge => {
-      const deps = state.dependencies.get(edge.to);
-      if (deps) deps.push(edge.from);
+    geometry.connections.forEach(conn => {
+      const deps = state.dependencies.get(conn.to);
+      if (deps) deps.push(conn.from);
     });
-    viewport.style.setProperty('--map-width', `${mapSize.width}px`);
-    viewport.style.setProperty('--map-height', `${mapSize.height}px`);
+    state.wires = geometry.connections;
+    state.gridRows = geometry.gridRows;
+    state.gridCols = geometry.gridCols;
+    state.worldWidth = geometry.worldWidth;
+    state.worldHeight = geometry.worldHeight;
+
     nodesLayer.innerHTML = '';
-    connectionsSvg.innerHTML = '';
-    connectionsSvg.setAttribute('viewBox', `0 0 ${mapSize.width} ${mapSize.height}`);
-    connectionsSvg.setAttribute('width', mapSize.width);
-    connectionsSvg.setAttribute('height', mapSize.height);
     state.elements.clear();
-    state.edges = [];
-
-    edges.forEach(edge => {
-      const from = state.nodeLookup.get(edge.from);
-      const to = state.nodeLookup.get(edge.to);
-      if (!from || !to) return;
-      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-      path.setAttribute('d', createConnectionPath(from, to));
-      path.classList.add('stage-connection');
-      path.dataset.from = edge.from;
-      path.dataset.to = edge.to;
-      connectionsSvg.appendChild(path);
-      state.edges.push({ ...edge, element: path });
-    });
-
-    nodes.forEach(node => {
+    state.nodes.forEach(node => {
       const el = createNodeElement(node);
-      el.addEventListener('click', () => {
-        handleNodeActivation(node);
-      });
+      el.addEventListener('click', () => handleNodeActivation(node));
       nodesLayer.appendChild(el);
       state.elements.set(node.id, el);
     });
 
+    if (!state.camera) {
+      state.camera = createCamera({ panelWidth: 0, scale: DEFAULT_CAMERA_SCALE });
+      state.camera.setOnChange(handleCameraChange);
+    }
+    state.camera.setBounds(state.worldWidth, state.worldHeight, { clamp: true });
+    state.hasCentered = false;
+    resizeCanvas();
+    centerCamera(true);
     refreshNodeStates();
-  }
-
-  function updateViewport() {
-    viewport.style.setProperty('--map-scale', String(state.scale));
-    viewport.style.setProperty('--map-translate-x', `${state.translateX}px`);
-    viewport.style.setProperty('--map-translate-y', `${state.translateY}px`);
-  }
-
-  function handleZoom(delta) {
-    state.scale = Math.max(0.6, Math.min(1.6, state.scale + delta));
-    updateViewport();
-    if (zoomResetBtn) {
-      zoomResetBtn.textContent = `${state.scale.toFixed(1)}×`;
-    }
-  }
-
-  function resetView() {
-    state.scale = 1;
-    state.translateX = 0;
-    state.translateY = 0;
-    updateViewport();
-    if (zoomResetBtn) {
-      zoomResetBtn.textContent = '1×';
-    }
-  }
-
-  function attachPanHandlers() {
-    if (!surface) return;
-
-    surface.addEventListener('pointerdown', event => {
-      if (event.target.closest('.stage-panel') || event.target.closest('.hud-button') || event.target.closest('.stage-node')) {
-        return;
-      }
-      surface.setPointerCapture(event.pointerId);
-      state.pointerStart = {
-        x: event.clientX - state.translateX,
-        y: event.clientY - state.translateY
-      };
-    });
-
-    surface.addEventListener('pointermove', event => {
-      if (!state.pointerStart) return;
-      state.translateX = event.clientX - state.pointerStart.x;
-      state.translateY = event.clientY - state.pointerStart.y;
-      updateViewport();
-    });
-
-    surface.addEventListener('pointerup', () => {
-      state.pointerStart = null;
-    });
-
-    surface.addEventListener('wheel', event => {
-      if (!event.ctrlKey) {
-        event.preventDefault();
-        handleZoom(event.deltaY > 0 ? -0.05 : 0.05);
-      }
-    }, { passive: false });
   }
 
   function markModeNodeCleared(nodeId) {
@@ -413,6 +555,45 @@ export function initializeStageMap({
     showStageMapScreen();
   }
 
+  function attachPanHandlers() {
+    if (!surface) return;
+    surface.addEventListener('pointerdown', event => {
+      if (event.target.closest('.stage-panel') || event.target.closest('.hud-button') || event.target.closest('.stage-node')) {
+        return;
+      }
+      surface.setPointerCapture(event.pointerId);
+      state.pointerStart = { x: event.clientX, y: event.clientY };
+    });
+
+    surface.addEventListener('pointermove', event => {
+      if (!state.pointerStart || !state.camera) return;
+      const dx = event.clientX - state.pointerStart.x;
+      const dy = event.clientY - state.pointerStart.y;
+      if (dx === 0 && dy === 0) return;
+      state.camera.pan(dx, dy);
+      state.pointerStart = { x: event.clientX, y: event.clientY };
+      event.preventDefault();
+    }, { passive: false });
+
+    const releasePointer = () => {
+      state.pointerStart = null;
+    };
+    surface.addEventListener('pointerup', releasePointer);
+    surface.addEventListener('pointercancel', releasePointer);
+
+    surface.addEventListener('wheel', event => {
+      if (!state.camera) return;
+      if (!event.ctrlKey) {
+        event.preventDefault();
+        const rect = state.viewport.getBoundingClientRect();
+        const pivotX = event.clientX - rect.left;
+        const pivotY = event.clientY - rect.top;
+        const factor = event.deltaY < 0 ? 1.1 : 0.9;
+        adjustZoom(factor, pivotX, pivotY);
+      }
+    }, { passive: false });
+  }
+
   function setupPanels() {
     panels.forEach(panel => {
       panel.setAttribute('aria-hidden', 'true');
@@ -445,13 +626,20 @@ export function initializeStageMap({
     });
   }
 
-  if (zoomInBtn) zoomInBtn.addEventListener('click', () => handleZoom(0.1));
-  if (zoomOutBtn) zoomOutBtn.addEventListener('click', () => handleZoom(-0.1));
+  if (zoomInBtn) zoomInBtn.addEventListener('click', () => adjustZoom(1.15));
+  if (zoomOutBtn) zoomOutBtn.addEventListener('click', () => adjustZoom(0.87));
   if (zoomResetBtn) zoomResetBtn.addEventListener('click', resetView);
 
   attachNodes();
   attachPanHandlers();
   setupPanels();
+
+  const handleResize = () => {
+    resizeCanvas();
+    centerCamera();
+  };
+  state.resizeHandler = handleResize;
+  window.addEventListener('resize', state.resizeHandler);
 
   document.addEventListener('stageMap:progressUpdated', refreshNodeStates);
   document.addEventListener('stageMap:closePanels', closeOpenPanel);

--- a/src/modules/stageMapLayout.js
+++ b/src/modules/stageMapLayout.js
@@ -1,5 +1,4 @@
-const BASE_OFFSET_X = 120;
-const BASE_OFFSET_Y = 120;
+const BASE_STAGE_SPAN = 3;
 
 export const STAGE_TYPE_META = {
   primitive_gate: {
@@ -29,88 +28,260 @@ export const STAGE_TYPE_META = {
   }
 };
 
-function nodePosition(x, y) {
-  return [BASE_OFFSET_X + x, BASE_OFFSET_Y + y];
+function stage(id, options) {
+  return {
+    id,
+    type: 'primitive_gate',
+    label: id,
+    gridPosition: { r: 0, c: 0 },
+    ...options
+  };
 }
 
+const STAGE_NODES = [
+  stage('UserCreated', {
+    label: 'User Created',
+    type: 'mode',
+    gridPosition: { r: 0, c: 12 },
+    icon: '🧩',
+    mode: 'userProblems'
+  }),
+  stage('Lab', {
+    label: 'Lab',
+    type: 'mode',
+    gridPosition: { r: 0, c: 18 },
+    icon: '🔬',
+    mode: 'lab'
+  }),
+  stage('BitWiser', {
+    label: 'Bit Wiser',
+    type: 'title',
+    icon: '🧠',
+    gridPosition: { r: 12, c: 18 },
+    autoClear: true
+  }),
+
+  stage('NOT', { label: 'NOT', level: 1, gridPosition: { r: 6, c: 0 } }),
+  stage('OR', { label: 'OR', level: 2, gridPosition: { r: 6, c: 6 } }),
+  stage('AND', { label: 'AND', level: 3, gridPosition: { r: 6, c: 12 } }),
+  stage('XOR', { label: 'XOR', level: 6, gridPosition: { r: 6, c: 18 } }),
+  stage('FixedXOR', {
+    label: 'Fixed XOR',
+    gridPosition: { r: 6, c: 24 },
+    comingSoon: true,
+    autoClear: true
+  }),
+  stage('NOR', { label: 'NOR', level: 4, gridPosition: { r: 12, c: 6 } }),
+  stage('NAND', { label: 'NAND', level: 5, gridPosition: { r: 12, c: 12 } }),
+
+  stage('MajorityGate', {
+    label: 'Majority Gate',
+    type: 'logic_stage',
+    level: 7,
+    gridPosition: { r: 12, c: 24 }
+  }),
+  stage('ParityChecker', {
+    label: 'Parity Checker',
+    type: 'logic_stage',
+    level: 8,
+    gridPosition: { r: 12, c: 30 }
+  }),
+  stage('Decoder2to4', {
+    label: '2-to-4 Decoder',
+    type: 'logic_stage',
+    level: 11,
+    gridPosition: { r: 12, c: 36 }
+  }),
+  stage('FixedDecoder', {
+    label: 'Fixed Decoder',
+    type: 'logic_stage',
+    gridPosition: { r: 18, c: 36 },
+    comingSoon: true,
+    autoClear: true
+  }),
+  stage('MaxSelector2bit', {
+    label: '2-bit Max Selector',
+    type: 'logic_stage',
+    level: 16,
+    gridPosition: { r: 12, c: 42 }
+  }),
+  stage('Shifter3bit', {
+    label: '3-bit Shifter',
+    type: 'logic_stage',
+    gridPosition: { r: 18, c: 30 },
+    comingSoon: true,
+    autoClear: true
+  }),
+  stage('Crossroad', {
+    label: 'Crossroad',
+    type: 'logic_stage',
+    gridPosition: { r: 18, c: 42 },
+    comingSoon: true,
+    autoClear: true
+  }),
+  stage('MUX4to1', {
+    label: '4-to-1 MUX',
+    type: 'logic_stage',
+    level: 12,
+    gridPosition: { r: 12, c: 48 }
+  }),
+  stage('AbsoluteValue', {
+    label: 'Absolute Value',
+    type: 'logic_stage',
+    gridPosition: { r: 12, c: 54 },
+    comingSoon: true,
+    autoClear: true
+  }),
+
+  stage('HalfAdder', {
+    label: 'Half Adder',
+    type: 'arith_stage',
+    level: 9,
+    gridPosition: { r: 18, c: 18 }
+  }),
+  stage('FullAdder', {
+    label: 'Full Adder',
+    type: 'arith_stage',
+    level: 10,
+    gridPosition: { r: 24, c: 18 }
+  }),
+  stage('OverflowDetector', {
+    label: 'Overflow Detector',
+    type: 'arith_stage',
+    gridPosition: { r: 30, c: 18 },
+    comingSoon: true,
+    autoClear: true
+  }),
+  stage('Comparator2bit', {
+    label: '2-bit Comparator',
+    type: 'arith_stage',
+    level: 13,
+    gridPosition: { r: 30, c: 30 }
+  }),
+  stage('Adder2bit', {
+    label: '2-bit Adder',
+    type: 'arith_stage',
+    level: 14,
+    gridPosition: { r: 36, c: 30 }
+  }),
+  stage('TwosComplement', {
+    label: "2's Complement",
+    type: 'arith_stage',
+    gridPosition: { r: 36, c: 42 },
+    comingSoon: true,
+    autoClear: true
+  }),
+  stage('Subtractor2bit', {
+    label: '2-bit Subtractor',
+    type: 'arith_stage',
+    level: 15,
+    gridPosition: { r: 42, c: 42 }
+  }),
+  stage('Multiplier2bit', {
+    label: '2-bit Multiplier',
+    type: 'arith_stage',
+    level: 17,
+    gridPosition: { r: 36, c: 54 }
+  }),
+  stage('Mod3Remainder', {
+    label: 'Mod 3 Remainder',
+    type: 'arith_stage',
+    level: 18,
+    gridPosition: { r: 48, c: 42 }
+  }),
+
+  stage('BitMaster', {
+    label: 'Bit Master',
+    type: 'title',
+    icon: '🏆',
+    gridPosition: { r: 36, c: 60 },
+    autoClear: true
+  })
+];
+
+const STAGE_CONNECTIONS = [
+  { from: 'NOT', to: 'OR', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'OR', to: 'AND', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'AND', to: 'XOR', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'OR', to: 'NOR', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'AND', to: 'NAND', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'XOR', to: 'FixedXOR', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'XOR', to: 'BitWiser', startAnchor: 'S', endAnchor: 'N' },
+  {
+    from: 'UserCreated',
+    to: 'BitWiser',
+    startAnchor: 'S',
+    endAnchor: 'W',
+    path: [
+      { r: 8, c: 13 },
+      { r: 8, c: 17 }
+    ]
+  },
+  {
+    from: 'Lab',
+    to: 'BitWiser',
+    startAnchor: 'S',
+    endAnchor: 'E',
+    path: [
+      { r: 8, c: 19 },
+      { r: 8, c: 21 }
+    ]
+  },
+  { from: 'BitWiser', to: 'MajorityGate', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'BitWiser', to: 'HalfAdder', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'MajorityGate', to: 'ParityChecker', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'ParityChecker', to: 'Decoder2to4', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'ParityChecker', to: 'Shifter3bit', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'Decoder2to4', to: 'FixedDecoder', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'Decoder2to4', to: 'MaxSelector2bit', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'MaxSelector2bit', to: 'MUX4to1', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'MaxSelector2bit', to: 'Crossroad', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'Shifter3bit', to: 'Crossroad', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'Crossroad', to: 'TwosComplement', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'MUX4to1', to: 'AbsoluteValue', startAnchor: 'E', endAnchor: 'W' },
+  {
+    from: 'AbsoluteValue',
+    to: 'BitMaster',
+    startAnchor: 'S',
+    endAnchor: 'N',
+    path: [
+      { r: 28, c: 55 },
+      { r: 28, c: 61 }
+    ]
+  },
+  { from: 'HalfAdder', to: 'FullAdder', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'FullAdder', to: 'OverflowDetector', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'OverflowDetector', to: 'Comparator2bit', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'Comparator2bit', to: 'Adder2bit', startAnchor: 'S', endAnchor: 'N' },
+  {
+    from: 'Adder2bit',
+    to: 'Multiplier2bit',
+    startAnchor: 'E',
+    endAnchor: 'W',
+    path: [
+      { r: 40, c: 33 },
+      { r: 40, c: 53 }
+    ]
+  },
+  { from: 'Adder2bit', to: 'TwosComplement', startAnchor: 'E', endAnchor: 'W' },
+  { from: 'TwosComplement', to: 'Subtractor2bit', startAnchor: 'S', endAnchor: 'N' },
+  { from: 'Subtractor2bit', to: 'Mod3Remainder', startAnchor: 'S', endAnchor: 'N' },
+  {
+    from: 'Mod3Remainder',
+    to: 'BitMaster',
+    startAnchor: 'E',
+    endAnchor: 'S',
+    path: [
+      { r: 39, c: 45 },
+      { r: 39, c: 61 }
+    ]
+  },
+  { from: 'Multiplier2bit', to: 'BitMaster', startAnchor: 'E', endAnchor: 'W' }
+];
+
 export const STAGE_GRAPH = {
-  nodes: [
-    { id: 'UserCreated', label: 'User Created', type: 'mode', position: nodePosition(280, 0), icon: '🧩', mode: 'userProblems' },
-    { id: 'Lab', label: 'Lab', type: 'mode', position: nodePosition(420, 0), icon: '🔬', mode: 'lab' },
-    { id: 'BitWiser', label: 'Bit Wiser', type: 'title', position: nodePosition(600, 0), icon: '🧠', autoClear: true },
-
-    { id: 'NOT', label: 'NOT', type: 'primitive_gate', level: 1, position: nodePosition(0, 200), icon: '¬' },
-    { id: 'OR', label: 'OR', type: 'primitive_gate', level: 2, position: nodePosition(160, 200) },
-    { id: 'AND', label: 'AND', type: 'primitive_gate', level: 3, position: nodePosition(320, 200) },
-    { id: 'XOR', label: 'XOR', type: 'primitive_gate', level: 6, position: nodePosition(480, 200) },
-    { id: 'FixedXOR', label: 'Fixed XOR', type: 'primitive_gate', position: nodePosition(640, 200), comingSoon: true, autoClear: true },
-    { id: 'NOR', label: 'NOR', type: 'primitive_gate', level: 4, position: nodePosition(160, 360) },
-    { id: 'NAND', label: 'NAND', type: 'primitive_gate', level: 5, position: nodePosition(320, 360) },
-
-    { id: 'MajorityGate', label: 'Majority Gate', type: 'logic_stage', level: 7, position: nodePosition(600, 360) },
-    { id: 'ParityChecker', label: 'Parity Checker', type: 'logic_stage', level: 8, position: nodePosition(760, 360) },
-    { id: 'Decoder2to4', label: '2-to-4 Decoder', type: 'logic_stage', level: 11, position: nodePosition(920, 360) },
-    { id: 'FixedDecoder', label: 'Fixed Decoder', type: 'logic_stage', position: nodePosition(920, 520), comingSoon: true, autoClear: true },
-    { id: 'MaxSelector2bit', label: '2-bit Max Selector', type: 'logic_stage', level: 16, position: nodePosition(1080, 360) },
-    { id: 'Shifter3bit', label: '3-bit Shifter', type: 'logic_stage', position: nodePosition(760, 520), comingSoon: true, autoClear: true },
-    { id: 'Crossroad', label: 'Crossroad', type: 'logic_stage', position: nodePosition(1080, 520), comingSoon: true, autoClear: true },
-    { id: 'MUX4to1', label: '4-to-1 MUX', type: 'logic_stage', level: 12, position: nodePosition(1240, 360) },
-    { id: 'AbsoluteValue', label: 'Absolute Value', type: 'logic_stage', position: nodePosition(1400, 360), comingSoon: true, autoClear: true },
-
-    { id: 'HalfAdder', label: 'Half Adder', type: 'arith_stage', level: 9, position: nodePosition(600, 520) },
-    { id: 'FullAdder', label: 'Full Adder', type: 'arith_stage', level: 10, position: nodePosition(600, 680) },
-    { id: 'OverflowDetector', label: 'Overflow Detector', type: 'arith_stage', position: nodePosition(760, 680), comingSoon: true, autoClear: true },
-    { id: 'Comparator2bit', label: '2-bit Comparator', type: 'arith_stage', level: 13, position: nodePosition(920, 680) },
-    { id: 'Adder2bit', label: '2-bit Adder', type: 'arith_stage', level: 14, position: nodePosition(1080, 680) },
-    { id: 'TwosComplement', label: "2's Complement", type: 'arith_stage', position: nodePosition(1240, 680), comingSoon: true, autoClear: true },
-    { id: 'Subtractor2bit', label: '2-bit Subtractor', type: 'arith_stage', level: 15, position: nodePosition(1400, 680) },
-    { id: 'Multiplier2bit', label: '2-bit Multiplier', type: 'arith_stage', level: 17, position: nodePosition(1240, 520) },
-    { id: 'Mod3Remainder', label: 'Mod 3 Remainder', type: 'arith_stage', level: 18, position: nodePosition(1560, 680) },
-
-    { id: 'BitMaster', label: 'Bit Master', type: 'title', position: nodePosition(1560, 520), icon: '🏆', autoClear: true }
-  ],
-  edges: [
-    { from: 'NOT', to: 'OR' },
-    { from: 'OR', to: 'AND' },
-    { from: 'AND', to: 'XOR' },
-    { from: 'OR', to: 'NOR' },
-    { from: 'AND', to: 'NAND' },
-    { from: 'XOR', to: 'FixedXOR' },
-    { from: 'XOR', to: 'BitWiser' },
-
-    { from: 'UserCreated', to: 'BitWiser' },
-    { from: 'Lab', to: 'BitWiser' },
-
-    { from: 'BitWiser', to: 'MajorityGate' },
-    { from: 'BitWiser', to: 'HalfAdder' },
-
-    { from: 'MajorityGate', to: 'ParityChecker' },
-    { from: 'ParityChecker', to: 'Decoder2to4' },
-    { from: 'ParityChecker', to: 'Shifter3bit' },
-
-    { from: 'Decoder2to4', to: 'FixedDecoder' },
-    { from: 'Decoder2to4', to: 'MaxSelector2bit' },
-    { from: 'MaxSelector2bit', to: 'MUX4to1' },
-    { from: 'MaxSelector2bit', to: 'Crossroad' },
-
-    { from: 'Shifter3bit', to: 'Crossroad' },
-    { from: 'Crossroad', to: 'TwosComplement' },
-
-    { from: 'MUX4to1', to: 'AbsoluteValue' },
-    { from: 'AbsoluteValue', to: 'BitMaster' },
-
-    { from: 'HalfAdder', to: 'FullAdder' },
-    { from: 'FullAdder', to: 'OverflowDetector' },
-    { from: 'OverflowDetector', to: 'Comparator2bit' },
-
-    { from: 'Comparator2bit', to: 'Adder2bit' },
-    { from: 'Adder2bit', to: 'Multiplier2bit' },
-    { from: 'Adder2bit', to: 'TwosComplement' },
-
-    { from: 'TwosComplement', to: 'Subtractor2bit' },
-    { from: 'Subtractor2bit', to: 'Mod3Remainder' },
-
-    { from: 'Mod3Remainder', to: 'BitMaster' },
-    { from: 'Multiplier2bit', to: 'BitMaster' }
-  ]
+  cellSpan: BASE_STAGE_SPAN,
+  nodes: STAGE_NODES,
+  connections: STAGE_CONNECTIONS,
+  edges: STAGE_CONNECTIONS
 };

--- a/style.css
+++ b/style.css
@@ -51,61 +51,22 @@ body.safe-mode .stage-map-surface {
 
 .stage-map-viewport {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: var(--map-width, 1800px);
-  height: var(--map-height, 1100px);
-  transform-origin: center;
-  transform: translate3d(calc(-50% + var(--map-translate-x, 0px)), calc(-50% + var(--map-translate-y, 0px)), 0)
-    scale(var(--map-scale, 1));
-  transition: transform 0.15s ease-out;
+  inset: 0;
+  overflow: hidden;
 }
 
-.stage-map-grid,
-.stage-map-connections,
-.stage-map-nodes {
+.stage-map-canvas {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-}
-
-.stage-map-grid {
-  background-image: linear-gradient(rgba(148, 163, 184, 0.12) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
-  background-size: 120px 120px;
-  filter: drop-shadow(0 0 16px rgba(15, 23, 42, 0.6));
-}
-
-body.safe-mode .stage-map-grid {
-  background-image: linear-gradient(rgba(248, 250, 252, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(248, 250, 252, 0.08) 1px, transparent 1px);
-}
-
-.stage-map-connections {
+  display: block;
   pointer-events: none;
 }
 
-.stage-map-connections path {
-  stroke: rgba(100, 116, 139, 0.65);
-  stroke-width: 3.5;
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0.5;
-}
-
-body.safe-mode .stage-map-connections path {
-  stroke: rgba(248, 250, 252, 0.4);
-}
-
-.stage-connection--active {
-  stroke: #fbbf24;
-  opacity: 0.95;
-  filter: drop-shadow(0 0 18px rgba(251, 191, 36, 0.5));
-}
-
 .stage-map-nodes {
+  position: absolute;
+  inset: 0;
   pointer-events: none;
 }
 
@@ -115,64 +76,87 @@ body.safe-mode .stage-map-connections path {
 
 .stage-node {
   position: absolute;
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  min-width: 210px;
-  padding: 0.85rem 1.1rem;
-  border-radius: 20px;
+  box-sizing: border-box;
+  padding: 0.65rem;
+  border-radius: 18px;
   border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(248, 250, 252, 0.95);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.98), rgba(226, 232, 240, 0.9));
   color: #0f172a;
-  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.4rem;
   cursor: pointer;
-  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.4);
+  transform-origin: top left;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.stage-node::before {
+  content: '';
+  position: absolute;
+  inset: 0.35rem;
+  border-radius: 14px;
+  background-image:
+    linear-gradient(90deg, rgba(148, 163, 184, 0.35) 1px, transparent 1px),
+    linear-gradient(rgba(148, 163, 184, 0.35) 1px, transparent 1px);
+  background-size: calc((100% - 0.7rem) / 3) 100%, 100% calc((100% - 0.7rem) / 3);
+  mix-blend-mode: overlay;
+  pointer-events: none;
 }
 
 .stage-node:hover {
-  transform: translate(-50%, -50%) scale(1.05);
   box-shadow: 0 24px 55px rgba(15, 23, 42, 0.45);
 }
 
 .stage-node:focus-visible {
   outline: 3px solid #38bdf8;
-  outline-offset: 4px;
+  outline-offset: 3px;
+}
+
+.stage-node__chip {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  z-index: 1;
 }
 
 .stage-node__icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
   background: rgba(15, 23, 42, 0.08);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
-.stage-node__body {
+.stage-node__text {
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
+  gap: 0.15rem;
   text-align: left;
 }
 
 .stage-node__chapter {
-  font-size: 0.72rem;
+  font-size: clamp(0.6rem, 0.55rem + 0.2vw, 0.75rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #64748b;
 }
 
 .stage-node__title {
-  font-size: 1.05rem;
+  font-size: var(--stage-node-font-size, 1rem);
   font-weight: 700;
+  line-height: 1.1;
 }
 
 .stage-node__status {
-  font-size: 0.8rem;
+  font-size: var(--stage-node-status-size, 0.75rem);
   color: #475569;
+  z-index: 1;
 }
 
 .stage-node--primitive {
@@ -188,21 +172,21 @@ body.safe-mode .stage-map-connections path {
 }
 
 .stage-node--mode {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.15), rgba(251, 191, 36, 0.25));
-  border-color: rgba(56, 189, 248, 0.65);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(251, 191, 36, 0.3));
+  border-color: rgba(56, 189, 248, 0.7);
 }
 
 .stage-node--title {
-  background: linear-gradient(135deg, rgba(253, 224, 71, 0.85), rgba(234, 179, 8, 0.95));
+  background: linear-gradient(135deg, rgba(253, 224, 71, 0.9), rgba(234, 179, 8, 0.95));
   color: #422006;
   border-color: rgba(217, 119, 6, 0.9);
-  box-shadow: 0 20px 45px rgba(234, 179, 8, 0.45);
+  box-shadow: 0 22px 50px rgba(234, 179, 8, 0.45);
 }
 
 .stage-node--locked {
-  background: rgba(15, 23, 42, 0.75);
+  background: rgba(15, 23, 42, 0.82);
   color: #cbd5f5;
-  border-color: rgba(148, 163, 184, 0.3);
+  border-color: rgba(148, 163, 184, 0.35);
   cursor: not-allowed;
   box-shadow: none;
 }
@@ -212,25 +196,23 @@ body.safe-mode .stage-map-connections path {
 }
 
 .stage-node--cleared {
-  border-color: rgba(34, 197, 94, 0.7);
+  border-color: rgba(34, 197, 94, 0.75);
   box-shadow: 0 22px 50px rgba(34, 197, 94, 0.35);
 }
 
 .stage-node--preview {
   border-style: dashed;
-  opacity: 0.85;
+  opacity: 0.9;
 }
 
 .stage-node--locked-feedback {
-  animation: stage-node-shake 0.4s ease;
+  animation: stage-node-pulse 0.35s ease;
 }
 
-@keyframes stage-node-shake {
-  0% { transform: translateX(0); }
-  25% { transform: translateX(-4px); }
-  50% { transform: translateX(4px); }
-  75% { transform: translateX(-2px); }
-  100% { transform: translateX(0); }
+@keyframes stage-node-pulse {
+  0% { box-shadow: 0 18px 40px rgba(248, 113, 113, 0.25); }
+  50% { box-shadow: 0 18px 40px rgba(248, 113, 113, 0.65); }
+  100% { box-shadow: 0 18px 40px rgba(248, 113, 113, 0.25); }
 }
 
 .stage-map-info {
@@ -405,13 +387,27 @@ body.safe-mode .stage-map-connections path {
 }
 
 body.safe-mode .stage-node {
-  background: rgba(2, 6, 23, 0.9);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.8));
   color: #f8fafc;
-  border-color: rgba(248, 250, 252, 0.2);
+  border-color: rgba(248, 250, 252, 0.25);
+}
+
+body.safe-mode .stage-node::before {
+  background-image:
+    linear-gradient(90deg, rgba(148, 163, 184, 0.4) 1px, transparent 1px),
+    linear-gradient(rgba(148, 163, 184, 0.4) 1px, transparent 1px);
 }
 
 body.safe-mode .stage-node__icon {
   background: rgba(248, 250, 252, 0.12);
+}
+
+body.safe-mode .stage-node__chapter {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+body.safe-mode .stage-node__status {
+  color: rgba(226, 232, 240, 0.85);
 }
 
 body.safe-mode .hud-button {


### PR DESCRIPTION
## Summary
- replace the stage map layout with a grid-based lab coordinate system and explicit wire routes for every connection
- rebuild the stage map renderer to reuse the lab camera/canvas, draw real wires, and display each stage as a 3×3 block that tracks zoom/pan
- restyle the stage map viewport, node buttons, and markup to host the new canvas-driven presentation

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd674e76883329df9a3357a358e7c)