### PR TITLE
feat: render stage map with lab-style circuit

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,14 +107,12 @@
     <!-- 스테이지 맵 화면 -->
     <section id="stageMapScreen" class="stage-map-screen" aria-label="Stage Map">
       <div class="stage-map-surface" id="stageMapSurface">
-        <div
-          class="stage-map-viewport"
-          id="stageMapViewport"
-          style="--map-scale: 1; --map-translate-x: 0px; --map-translate-y: 0px;"
-        >
-          <div class="stage-map-grid" aria-hidden="true"></div>
-          <svg id="stageMapConnections" class="stage-map-connections" role="presentation"></svg>
-          <div id="stageMapNodes" class="stage-map-nodes" role="list"></div>
+        <div class="stage-map-viewport" id="stageMapViewport">
+          <div class="stage-map-canvas-stack" id="stageMapCanvasStack">
+            <canvas id="stageMapBgCanvas"></canvas>
+            <canvas id="stageMapContentCanvas"></canvas>
+            <canvas id="stageMapOverlayCanvas"></canvas>
+          </div>
         </div>
         <div class="stage-map-info">
           <div class="stage-map-title">

--- a/src/canvas/renderer.js
+++ b/src/canvas/renderer.js
@@ -47,6 +47,9 @@ const BASE_BLOCK_STYLE = {
   fill: ['#f0f0ff', '#d0d0ff'],
   hoverFill: ['#fdfdff', '#c8c8ff'],
   textColor: '#000',
+  subtitleColor: '#475569',
+  subtitleSize: 13,
+  subtitleFont: null,
   radius: CELL_CORNER_RADIUS,
   shadow: {
     color: 'rgba(0,0,0,0.18)',
@@ -217,6 +220,9 @@ function resolveBlockStyle(options = {}) {
   style.hoverShadow = mergeShadow(mergeShadow(BASE_BLOCK_STYLE.hoverShadow, themeBlock.hoverShadow), hoverShadow);
   style.radius = CELL_CORNER_RADIUS;
   style.font = style.font || base.font || null;
+  style.subtitleFont = style.subtitleFont || base.subtitleFont || null;
+  style.subtitleSize = style.subtitleSize ?? base.subtitleSize ?? 13;
+  style.subtitleColor = style.subtitleColor || base.subtitleColor || '#475569';
   style.activeFill = style.activeFill || getThemeAccent(theme);
   style.activeHoverFill = style.activeHoverFill || style.hoverFill;
   style.activeTextColor = style.activeTextColor || 'hsl(170, 25%, 20%)';
@@ -347,17 +353,30 @@ function rectIntersects(bounds, rect) {
   );
 }
 
+function resolveBlockSpan(block) {
+  if (!block) {
+    return { rows: 1, cols: 1 };
+  }
+  const span = block.span;
+  const rows = Math.max(1, Math.round(span?.rows ?? span?.h ?? span?.height ?? span ?? 1));
+  const cols = Math.max(1, Math.round(span?.cols ?? span?.w ?? span?.width ?? span ?? 1));
+  return { rows, cols };
+}
+
 function blockWorldRect(block) {
   if (!block || !block.pos) return null;
   const { r, c } = block.pos;
   if (!Number.isFinite(r) || !Number.isFinite(c)) return null;
+  const { rows, cols } = resolveBlockSpan(block);
+  const width = cols * CELL + Math.max(0, cols - 1) * GAP;
+  const height = rows * CELL + Math.max(0, rows - 1) * GAP;
   const x = GAP + c * PITCH;
   const y = GAP + r * PITCH;
   return {
     minX: x,
     minY: y,
-    maxX: x + CELL,
-    maxY: y + CELL
+    maxX: x + width,
+    maxY: y + height
   };
 }
 
@@ -732,6 +751,19 @@ export function drawGrid(ctx, rows, cols, offsetX = 0, camera = null, options = 
   ctx.restore();
 }
 
+function resolveFontSpec(font, scale = 1, { fallbackSize = 16, fallbackWeight = 'bold' } = {}) {
+  const defaultFont = `${fallbackWeight} ${fallbackSize}px "Noto Sans KR", sans-serif`;
+  const baseFont = font || defaultFont;
+  const fontMatch = baseFont.match(/(\d+(?:\.\d+)?)px/);
+  if (fontMatch) {
+    const px = parseFloat(fontMatch[1]);
+    const scaled = Math.max(0, px * scale);
+    return baseFont.replace(fontMatch[0], `${scaled}px`);
+  }
+  const fallback = Math.max(0, fallbackSize * scale);
+  return `${fallbackWeight} ${fallback}px "Noto Sans KR", sans-serif`;
+}
+
 // Blocks are drawn as rounded rectangles with text labels
 export function drawBlock(
   ctx,
@@ -743,18 +775,27 @@ export function drawBlock(
 ) {
   const style = resolveBlockStyle(options);
   const { r, c } = block.pos;
+  const scale = camera ? camera.getScale() : 1;
+  const { rows, cols } = resolveBlockSpan(block);
+  const widthWorld = cols * CELL + Math.max(0, cols - 1) * GAP;
+  const heightWorld = rows * CELL + Math.max(0, rows - 1) * GAP;
+  const baseX = GAP + c * PITCH;
+  const baseY = GAP + r * PITCH;
   let x;
   let y;
-  let size = CELL;
-  const scale = camera ? camera.getScale() : 1;
+  let width;
+  let height;
   if (camera) {
-    const point = camera.cellToScreenCell({ r, c });
+    const point = camera.worldToScreen(baseX, baseY);
     x = point.x;
     y = point.y;
-    size = CELL * scale;
+    width = widthWorld * scale;
+    height = heightWorld * scale;
   } else {
-    x = offsetX + GAP + c * PITCH;
-    y = GAP + r * PITCH;
+    x = offsetX + baseX;
+    y = baseY;
+    width = widthWorld;
+    height = heightWorld;
   }
   ctx.save();
 
@@ -772,29 +813,29 @@ export function drawBlock(
     applyScaledShadow(ctx, haloShadow, scale);
     const baseGlowColor = 'rgba(255, 246, 225, 0.96)';
     ctx.fillStyle = baseGlowColor;
-    roundRect(ctx, x, y, size, size, blockRadius);
+    roundRect(ctx, x, y, width, height, blockRadius);
     ctx.fill();
 
     ctx.shadowColor = 'transparent';
-    const cx = x + size * 0.42;
-    const cy = y + size * 0.38;
-    const innerRadius = Math.max(size * 0.06, 0);
-    const outerRadius = Math.max(size * 0.9, innerRadius + 0.1);
+    const cx = x + width * 0.42;
+    const cy = y + height * 0.38;
+    const innerRadius = Math.max(Math.min(width, height) * 0.06, 0);
+    const outerRadius = Math.max(Math.min(width, height) * 0.9, innerRadius + 0.1);
     const glowGradient = ctx.createRadialGradient(cx, cy, innerRadius, cx, cy, outerRadius);
     glowGradient.addColorStop(0, 'rgba(255, 255, 235, 0.25)');
     glowGradient.addColorStop(0.58, 'rgba(255, 235, 160, 0.18)');
     glowGradient.addColorStop(1, 'rgba(255, 200, 100, 0)');
     ctx.globalCompositeOperation = 'lighter';
     ctx.fillStyle = glowGradient;
-    roundRect(ctx, x, y, size, size, blockRadius);
+    roundRect(ctx, x, y, width, height, blockRadius);
     ctx.fill();
     ctx.globalCompositeOperation = 'source-over';
   } else {
     const fillSpec = hovered && style.hoverFill ? style.hoverFill : style.fill;
     applyScaledShadow(ctx, hovered ? style.hoverShadow : style.shadow, scale);
-    const fillStyle = createFillStyle(ctx, fillSpec, x, y, size, size) || fillSpec || '#f0f0ff';
+    const fillStyle = createFillStyle(ctx, fillSpec, x, y, width, height) || fillSpec || '#f0f0ff';
     ctx.fillStyle = fillStyle;
-    roundRect(ctx, x, y, size, size, blockRadius);
+    roundRect(ctx, x, y, width, height, blockRadius);
     ctx.fill();
   }
 
@@ -802,29 +843,37 @@ export function drawBlock(
     ctx.shadowColor = 'transparent';
     ctx.lineWidth = Math.max(style.strokeWidth * scale, 0.6);
     ctx.strokeStyle = style.strokeColor;
-    roundRect(ctx, x, y, size, size, blockRadius);
+    roundRect(ctx, x, y, width, height, blockRadius);
     ctx.stroke();
   }
 
   ctx.shadowColor = 'transparent';
 
-  const baseFont = style.font || `bold 16px "Noto Sans KR", sans-serif`;
-  const fontMatch = baseFont.match(/(\d+(?:\.\d+)?)px/);
-  let resolvedFont;
-  if (fontMatch) {
-    const px = parseFloat(fontMatch[1]);
-    const scaled = Math.max(0, px * scale);
-    resolvedFont = baseFont.replace(fontMatch[0], `${scaled}px`);
-  } else {
-    const fallbackSize = Math.max(0, 16 * scale);
-    resolvedFont = `bold ${fallbackSize}px "Noto Sans KR", sans-serif`;
-  }
+  const mainFont = resolveFontSpec(style.font, scale, { fallbackSize: 16, fallbackWeight: 'bold' });
   const textColor = isActive && style.activeTextColor ? style.activeTextColor : style.textColor;
   ctx.fillStyle = textColor || '#000';
-  ctx.font = resolvedFont;
+  ctx.font = mainFont;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(block.name || block.type, x + size / 2, y + size / 2);
+  const centerX = x + width / 2;
+  const centerY = y + height / 2;
+  const subtitle = block.subtitle && block.subtitle.trim().length ? block.subtitle : null;
+  if (subtitle) {
+    const gap = Math.max(height * 0.08, 10 * scale);
+    ctx.fillText(block.name || block.type, centerX, centerY - gap / 2);
+    const subtitleFont = resolveFontSpec(
+      style.subtitleFont || `600 ${style.subtitleSize || 13}px "Noto Sans KR", sans-serif`,
+      scale,
+      { fallbackSize: style.subtitleSize || 13, fallbackWeight: '600' }
+    );
+    ctx.font = subtitleFont;
+    ctx.fillStyle = style.subtitleColor || textColor || '#475569';
+    ctx.globalAlpha = 0.95;
+    ctx.fillText(subtitle, centerX, centerY + gap / 2);
+    ctx.globalAlpha = 1;
+  } else {
+    ctx.fillText(block.name || block.type, centerX, centerY);
+  }
   ctx.restore();
 }
 
@@ -934,8 +983,14 @@ export function renderContent(
   const blocks = contentBounds
     ? Object.values(circuit.blocks).filter(b => rectIntersects(contentBounds, blockWorldRect(b)))
     : Object.values(circuit.blocks);
-  wires.forEach(w => drawWire(ctx, w, phase, offsetX, camera, styleOptions));
-  blocks.forEach(b => drawBlock(ctx, b, offsetX, b.id === hoverId, camera, styleOptions));
+  wires.forEach(w => {
+    const wireOptions = w.style ? { ...styleOptions, ...w.style } : styleOptions;
+    drawWire(ctx, w, phase, offsetX, camera, wireOptions);
+  });
+  blocks.forEach(b => {
+    const blockOptions = b.style ? { ...styleOptions, ...b.style } : styleOptions;
+    drawBlock(ctx, b, offsetX, b.id === hoverId, camera, blockOptions);
+  });
   ctx.restore();
 }
 

--- a/src/modules/stageMapLayout.js
+++ b/src/modules/stageMapLayout.js
@@ -1,5 +1,112 @@
-const BASE_OFFSET_X = 120;
-const BASE_OFFSET_Y = 120;
+const STAGE_NODE_BLOCKS = {
+  NOT: { x: 4, y: 0, w: 3, h: 3 },
+  OR: { x: 4, y: 4, w: 3, h: 3 },
+  AND: { x: 4, y: 8, w: 3, h: 3 },
+  XOR: { x: 4, y: 12, w: 3, h: 3 },
+  NAND: { x: 0, y: 16, w: 3, h: 3 },
+  FixedXOR: { x: 4, y: 16, w: 3, h: 3 },
+  NOR: { x: 8, y: 16, w: 3, h: 3 },
+  MajorityGate: { x: 0, y: 24, w: 3, h: 3 },
+  ParityChecker: { x: 0, y: 28, w: 3, h: 3 },
+  Decoder2to4: { x: 0, y: 32, w: 3, h: 3 },
+  Shifter3bit: { x: 0, y: 36, w: 3, h: 3 },
+  FixedDecoder: { x: 0, y: 40, w: 3, h: 3 },
+  MaxSelector2bit: { x: 4, y: 40, w: 3, h: 3 },
+  Crossroad: { x: 4, y: 44, w: 3, h: 3 },
+  MUX4to1: { x: 0, y: 48, w: 3, h: 3 },
+  AbsoluteValue: { x: 0, y: 56, w: 3, h: 3 },
+  HalfAdder: { x: 8, y: 24, w: 3, h: 3 },
+  FullAdder: { x: 8, y: 28, w: 3, h: 3 },
+  OverflowDetector: { x: 8, y: 32, w: 3, h: 3 },
+  Comparator2bit: { x: 8, y: 36, w: 3, h: 3 },
+  Adder2bit: { x: 8, y: 40, w: 3, h: 3 },
+  TwosComplement: { x: 4, y: 48, w: 3, h: 3 },
+  Subtractor2bit: { x: 4, y: 52, w: 3, h: 3 },
+  Mod3Remainder: { x: 4, y: 56, w: 3, h: 3 },
+  Multiplier2bit: { x: 8, y: 48, w: 3, h: 3 },
+  BitWiser: { x: 4, y: 20, w: 3, h: 3 },
+  BitMaster: { x: 4, y: 60, w: 3, h: 3 },
+  UserCreated: { x: 0, y: 20, w: 3, h: 3 },
+  Lab: { x: 8, y: 20, w: 3, h: 3 }
+};
+
+const STAGE_MAP_WIRES = [
+  { id: 'w_NOT_OR', from: 'NOT', to: 'OR', path: [{ x: 5, y: 1 }, { x: 5, y: 5 }] },
+  { id: 'w_OR_AND', from: 'OR', to: 'AND', path: [{ x: 5, y: 5 }, { x: 5, y: 9 }] },
+  { id: 'w_AND_XOR', from: 'AND', to: 'XOR', path: [{ x: 5, y: 9 }, { x: 5, y: 13 }] },
+  { id: 'w_OR_NOR', from: 'OR', to: 'NOR', path: [{ x: 5, y: 5 }, { x: 5, y: 17 }, { x: 9, y: 17 }] },
+  { id: 'w_AND_NAND', from: 'AND', to: 'NAND', path: [{ x: 5, y: 9 }, { x: 5, y: 17 }, { x: 1, y: 17 }] },
+  { id: 'w_XOR_FixedXOR', from: 'XOR', to: 'FixedXOR', path: [{ x: 5, y: 13 }, { x: 5, y: 17 }] },
+  { id: 'w_XOR_BitWiser', from: 'XOR', to: 'BitWiser', path: [{ x: 5, y: 13 }, { x: 5, y: 21 }] },
+  { id: 'w_UserCreated_BitWiser', from: 'UserCreated', to: 'BitWiser', path: [{ x: 1, y: 21 }, { x: 5, y: 21 }] },
+  { id: 'w_Lab_BitWiser', from: 'Lab', to: 'BitWiser', path: [{ x: 9, y: 21 }, { x: 5, y: 21 }] },
+  { id: 'w_BitWiser_Majority', from: 'BitWiser', to: 'MajorityGate', path: [{ x: 5, y: 21 }, { x: 5, y: 25 }, { x: 1, y: 25 }] },
+  { id: 'w_BitWiser_HalfAdder', from: 'BitWiser', to: 'HalfAdder', path: [{ x: 5, y: 21 }, { x: 5, y: 25 }, { x: 9, y: 25 }] },
+  { id: 'w_Majority_Parity', from: 'MajorityGate', to: 'ParityChecker', path: [{ x: 1, y: 25 }, { x: 1, y: 29 }] },
+  { id: 'w_Parity_Decoder', from: 'ParityChecker', to: 'Decoder2to4', path: [{ x: 1, y: 29 }, { x: 1, y: 33 }] },
+  { id: 'w_Parity_Shifter', from: 'ParityChecker', to: 'Shifter3bit', path: [{ x: 1, y: 29 }, { x: 1, y: 37 }] },
+  { id: 'w_Decoder_FixedDecoder', from: 'Decoder2to4', to: 'FixedDecoder', path: [{ x: 1, y: 33 }, { x: 1, y: 41 }] },
+  { id: 'w_Decoder_MaxSelector', from: 'Decoder2to4', to: 'MaxSelector2bit', path: [{ x: 1, y: 33 }, { x: 1, y: 41 }, { x: 5, y: 41 }] },
+  { id: 'w_MaxSelector_MUX', from: 'MaxSelector2bit', to: 'MUX4to1', path: [{ x: 5, y: 41 }, { x: 5, y: 49 }, { x: 1, y: 49 }] },
+  { id: 'w_MaxSelector_Cross', from: 'MaxSelector2bit', to: 'Crossroad', path: [{ x: 5, y: 41 }, { x: 5, y: 45 }] },
+  { id: 'w_Shifter_Cross', from: 'Shifter3bit', to: 'Crossroad', path: [{ x: 1, y: 37 }, { x: 1, y: 45 }, { x: 5, y: 45 }] },
+  { id: 'w_Cross_TwosComp', from: 'Crossroad', to: 'TwosComplement', path: [{ x: 5, y: 45 }, { x: 5, y: 49 }] },
+  { id: 'w_MUX_Absolute', from: 'MUX4to1', to: 'AbsoluteValue', path: [{ x: 1, y: 49 }, { x: 1, y: 57 }] },
+  { id: 'w_Absolute_BitMaster', from: 'AbsoluteValue', to: 'BitMaster', path: [{ x: 1, y: 57 }, { x: 1, y: 61 }, { x: 5, y: 61 }] },
+  { id: 'w_Half_Full', from: 'HalfAdder', to: 'FullAdder', path: [{ x: 9, y: 25 }, { x: 9, y: 29 }] },
+  { id: 'w_Full_Overflow', from: 'FullAdder', to: 'OverflowDetector', path: [{ x: 9, y: 29 }, { x: 9, y: 33 }] },
+  { id: 'w_Overflow_Comparator', from: 'OverflowDetector', to: 'Comparator2bit', path: [{ x: 9, y: 33 }, { x: 9, y: 37 }] },
+  { id: 'w_Comparator_Adder', from: 'Comparator2bit', to: 'Adder2bit', path: [{ x: 9, y: 37 }, { x: 9, y: 41 }] },
+  { id: 'w_Adder_Multiplier', from: 'Adder2bit', to: 'Multiplier2bit', path: [{ x: 9, y: 41 }, { x: 9, y: 49 }] },
+  { id: 'w_Adder_TwosComp', from: 'Adder2bit', to: 'TwosComplement', path: [{ x: 9, y: 41 }, { x: 9, y: 49 }, { x: 5, y: 49 }] },
+  { id: 'w_TwosComp_Sub', from: 'TwosComplement', to: 'Subtractor2bit', path: [{ x: 5, y: 49 }, { x: 5, y: 53 }] },
+  { id: 'w_Sub_Mod3', from: 'Subtractor2bit', to: 'Mod3Remainder', path: [{ x: 5, y: 53 }, { x: 5, y: 57 }] },
+  { id: 'w_Mod3_BitMaster', from: 'Mod3Remainder', to: 'BitMaster', path: [{ x: 5, y: 57 }, { x: 5, y: 61 }] },
+  { id: 'w_Multiplier_BitMaster', from: 'Multiplier2bit', to: 'BitMaster', path: [{ x: 9, y: 49 }, { x: 9, y: 61 }, { x: 5, y: 61 }] }
+];
+
+const BASE_NODES = [
+  { id: 'UserCreated', label: 'User Created', type: 'mode', icon: '🧩', mode: 'userProblems' },
+  { id: 'Lab', label: 'Lab', type: 'mode', icon: '🔬', mode: 'lab' },
+  { id: 'BitWiser', label: 'Bit Wiser', type: 'title', icon: '🧠', autoClear: true },
+  { id: 'NOT', label: 'NOT', type: 'primitive_gate', level: 1, icon: '¬' },
+  { id: 'OR', label: 'OR', type: 'primitive_gate', level: 2 },
+  { id: 'AND', label: 'AND', type: 'primitive_gate', level: 3 },
+  { id: 'XOR', label: 'XOR', type: 'primitive_gate', level: 6 },
+  { id: 'FixedXOR', label: 'Fixed XOR', type: 'primitive_gate', comingSoon: true, autoClear: true },
+  { id: 'NOR', label: 'NOR', type: 'primitive_gate', level: 4 },
+  { id: 'NAND', label: 'NAND', type: 'primitive_gate', level: 5 },
+  { id: 'MajorityGate', label: 'Majority Gate', type: 'logic_stage', level: 7 },
+  { id: 'ParityChecker', label: 'Parity Checker', type: 'logic_stage', level: 8 },
+  { id: 'Decoder2to4', label: '2-to-4 Decoder', type: 'logic_stage', level: 11 },
+  { id: 'FixedDecoder', label: 'Fixed Decoder', type: 'logic_stage', comingSoon: true, autoClear: true },
+  { id: 'MaxSelector2bit', label: '2-bit Max Selector', type: 'logic_stage', level: 16 },
+  { id: 'Shifter3bit', label: '3-bit Shifter', type: 'logic_stage', comingSoon: true, autoClear: true },
+  { id: 'Crossroad', label: 'Crossroad', type: 'logic_stage', comingSoon: true, autoClear: true },
+  { id: 'MUX4to1', label: '4-to-1 MUX', type: 'logic_stage', level: 12 },
+  { id: 'AbsoluteValue', label: 'Absolute Value', type: 'logic_stage', comingSoon: true, autoClear: true },
+  { id: 'HalfAdder', label: 'Half Adder', type: 'arith_stage', level: 9 },
+  { id: 'FullAdder', label: 'Full Adder', type: 'arith_stage', level: 10 },
+  { id: 'OverflowDetector', label: 'Overflow Detector', type: 'arith_stage', comingSoon: true, autoClear: true },
+  { id: 'Comparator2bit', label: '2-bit Comparator', type: 'arith_stage', level: 13 },
+  { id: 'Adder2bit', label: '2-bit Adder', type: 'arith_stage', level: 14 },
+  { id: 'TwosComplement', label: "2's Complement", type: 'arith_stage', comingSoon: true, autoClear: true },
+  { id: 'Subtractor2bit', label: '2-bit Subtractor', type: 'arith_stage', level: 15 },
+  { id: 'Mod3Remainder', label: 'Mod 3 Remainder', type: 'arith_stage', level: 18 },
+  { id: 'Multiplier2bit', label: '2-bit Multiplier', type: 'arith_stage', level: 17 },
+  { id: 'BitMaster', label: 'Bit Master', type: 'title', icon: '🏆', autoClear: true }
+].map(node => ({
+  ...node,
+  block: STAGE_NODE_BLOCKS[node.id] || null
+}));
+
+const edgeMap = new Map();
+STAGE_MAP_WIRES.forEach(wire => {
+  const key = `${wire.from}->${wire.to}`;
+  if (!edgeMap.has(key)) {
+    edgeMap.set(key, { from: wire.from, to: wire.to });
+  }
+});
 
 export const STAGE_TYPE_META = {
   primitive_gate: {
@@ -29,88 +136,18 @@ export const STAGE_TYPE_META = {
   }
 };
 
-function nodePosition(x, y) {
-  return [BASE_OFFSET_X + x, BASE_OFFSET_Y + y];
-}
-
 export const STAGE_GRAPH = {
-  nodes: [
-    { id: 'UserCreated', label: 'User Created', type: 'mode', position: nodePosition(280, 0), icon: '🧩', mode: 'userProblems' },
-    { id: 'Lab', label: 'Lab', type: 'mode', position: nodePosition(420, 0), icon: '🔬', mode: 'lab' },
-    { id: 'BitWiser', label: 'Bit Wiser', type: 'title', position: nodePosition(600, 0), icon: '🧠', autoClear: true },
+  nodes: BASE_NODES,
+  edges: Array.from(edgeMap.values())
+};
 
-    { id: 'NOT', label: 'NOT', type: 'primitive_gate', level: 1, position: nodePosition(0, 200), icon: '¬' },
-    { id: 'OR', label: 'OR', type: 'primitive_gate', level: 2, position: nodePosition(160, 200) },
-    { id: 'AND', label: 'AND', type: 'primitive_gate', level: 3, position: nodePosition(320, 200) },
-    { id: 'XOR', label: 'XOR', type: 'primitive_gate', level: 6, position: nodePosition(480, 200) },
-    { id: 'FixedXOR', label: 'Fixed XOR', type: 'primitive_gate', position: nodePosition(640, 200), comingSoon: true, autoClear: true },
-    { id: 'NOR', label: 'NOR', type: 'primitive_gate', level: 4, position: nodePosition(160, 360) },
-    { id: 'NAND', label: 'NAND', type: 'primitive_gate', level: 5, position: nodePosition(320, 360) },
-
-    { id: 'MajorityGate', label: 'Majority Gate', type: 'logic_stage', level: 7, position: nodePosition(600, 360) },
-    { id: 'ParityChecker', label: 'Parity Checker', type: 'logic_stage', level: 8, position: nodePosition(760, 360) },
-    { id: 'Decoder2to4', label: '2-to-4 Decoder', type: 'logic_stage', level: 11, position: nodePosition(920, 360) },
-    { id: 'FixedDecoder', label: 'Fixed Decoder', type: 'logic_stage', position: nodePosition(920, 520), comingSoon: true, autoClear: true },
-    { id: 'MaxSelector2bit', label: '2-bit Max Selector', type: 'logic_stage', level: 16, position: nodePosition(1080, 360) },
-    { id: 'Shifter3bit', label: '3-bit Shifter', type: 'logic_stage', position: nodePosition(760, 520), comingSoon: true, autoClear: true },
-    { id: 'Crossroad', label: 'Crossroad', type: 'logic_stage', position: nodePosition(1080, 520), comingSoon: true, autoClear: true },
-    { id: 'MUX4to1', label: '4-to-1 MUX', type: 'logic_stage', level: 12, position: nodePosition(1240, 360) },
-    { id: 'AbsoluteValue', label: 'Absolute Value', type: 'logic_stage', position: nodePosition(1400, 360), comingSoon: true, autoClear: true },
-
-    { id: 'HalfAdder', label: 'Half Adder', type: 'arith_stage', level: 9, position: nodePosition(600, 520) },
-    { id: 'FullAdder', label: 'Full Adder', type: 'arith_stage', level: 10, position: nodePosition(600, 680) },
-    { id: 'OverflowDetector', label: 'Overflow Detector', type: 'arith_stage', position: nodePosition(760, 680), comingSoon: true, autoClear: true },
-    { id: 'Comparator2bit', label: '2-bit Comparator', type: 'arith_stage', level: 13, position: nodePosition(920, 680) },
-    { id: 'Adder2bit', label: '2-bit Adder', type: 'arith_stage', level: 14, position: nodePosition(1080, 680) },
-    { id: 'TwosComplement', label: "2's Complement", type: 'arith_stage', position: nodePosition(1240, 680), comingSoon: true, autoClear: true },
-    { id: 'Subtractor2bit', label: '2-bit Subtractor', type: 'arith_stage', level: 15, position: nodePosition(1400, 680) },
-    { id: 'Multiplier2bit', label: '2-bit Multiplier', type: 'arith_stage', level: 17, position: nodePosition(1240, 520) },
-    { id: 'Mod3Remainder', label: 'Mod 3 Remainder', type: 'arith_stage', level: 18, position: nodePosition(1560, 680) },
-
-    { id: 'BitMaster', label: 'Bit Master', type: 'title', position: nodePosition(1560, 520), icon: '🏆', autoClear: true }
-  ],
-  edges: [
-    { from: 'NOT', to: 'OR' },
-    { from: 'OR', to: 'AND' },
-    { from: 'AND', to: 'XOR' },
-    { from: 'OR', to: 'NOR' },
-    { from: 'AND', to: 'NAND' },
-    { from: 'XOR', to: 'FixedXOR' },
-    { from: 'XOR', to: 'BitWiser' },
-
-    { from: 'UserCreated', to: 'BitWiser' },
-    { from: 'Lab', to: 'BitWiser' },
-
-    { from: 'BitWiser', to: 'MajorityGate' },
-    { from: 'BitWiser', to: 'HalfAdder' },
-
-    { from: 'MajorityGate', to: 'ParityChecker' },
-    { from: 'ParityChecker', to: 'Decoder2to4' },
-    { from: 'ParityChecker', to: 'Shifter3bit' },
-
-    { from: 'Decoder2to4', to: 'FixedDecoder' },
-    { from: 'Decoder2to4', to: 'MaxSelector2bit' },
-    { from: 'MaxSelector2bit', to: 'MUX4to1' },
-    { from: 'MaxSelector2bit', to: 'Crossroad' },
-
-    { from: 'Shifter3bit', to: 'Crossroad' },
-    { from: 'Crossroad', to: 'TwosComplement' },
-
-    { from: 'MUX4to1', to: 'AbsoluteValue' },
-    { from: 'AbsoluteValue', to: 'BitMaster' },
-
-    { from: 'HalfAdder', to: 'FullAdder' },
-    { from: 'FullAdder', to: 'OverflowDetector' },
-    { from: 'OverflowDetector', to: 'Comparator2bit' },
-
-    { from: 'Comparator2bit', to: 'Adder2bit' },
-    { from: 'Adder2bit', to: 'Multiplier2bit' },
-    { from: 'Adder2bit', to: 'TwosComplement' },
-
-    { from: 'TwosComplement', to: 'Subtractor2bit' },
-    { from: 'Subtractor2bit', to: 'Mod3Remainder' },
-
-    { from: 'Mod3Remainder', to: 'BitMaster' },
-    { from: 'Multiplier2bit', to: 'BitMaster' }
-  ]
+export const STAGE_MAP_BLUEPRINT = {
+  grid: { cellSize: 1, stageBlockSize: 3 },
+  nodes: BASE_NODES.map(node => ({
+    id: node.id,
+    label: node.label,
+    type: node.type,
+    block: node.block
+  })),
+  wires: STAGE_MAP_WIRES
 };

--- a/style.css
+++ b/style.css
@@ -51,93 +51,35 @@ body.safe-mode .stage-map-surface {
 
 .stage-map-viewport {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: var(--map-width, 1800px);
-  height: var(--map-height, 1100px);
-  transform-origin: center;
-  transform: translate3d(calc(-50% + var(--map-translate-x, 0px)), calc(-50% + var(--map-translate-y, 0px)), 0)
-    scale(var(--map-scale, 1));
-  transition: transform 0.15s ease-out;
+  inset: 0;
+  overflow: hidden;
+  z-index: 1;
 }
 
-.stage-map-grid,
-.stage-map-connections,
-.stage-map-nodes {
+.stage-map-canvas-stack {
+  position: absolute;
+  inset: 0;
+}
+
+.stage-map-canvas-stack canvas {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
 }
 
-.stage-map-grid {
-  background-image: linear-gradient(rgba(148, 163, 184, 0.12) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
-  background-size: 120px 120px;
-  filter: drop-shadow(0 0 16px rgba(15, 23, 42, 0.6));
-}
-
-body.safe-mode .stage-map-grid {
-  background-image: linear-gradient(rgba(248, 250, 252, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(248, 250, 252, 0.08) 1px, transparent 1px);
-}
-
-.stage-map-connections {
+#stageMapBgCanvas,
+#stageMapContentCanvas {
   pointer-events: none;
 }
 
-.stage-map-connections path {
-  stroke: rgba(100, 116, 139, 0.65);
-  stroke-width: 3.5;
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0.5;
-}
-
-body.safe-mode .stage-map-connections path {
-  stroke: rgba(248, 250, 252, 0.4);
-}
-
-.stage-connection--active {
-  stroke: #fbbf24;
-  opacity: 0.95;
-  filter: drop-shadow(0 0 18px rgba(251, 191, 36, 0.5));
-}
-
-.stage-map-nodes {
-  pointer-events: none;
-}
-
-.stage-map-nodes button {
+#stageMapOverlayCanvas {
   pointer-events: auto;
+  cursor: grab;
 }
 
-.stage-node {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  min-width: 210px;
-  padding: 0.85rem 1.1rem;
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(248, 250, 252, 0.95);
-  color: #0f172a;
-  transform: translate(-50%, -50%);
-  cursor: pointer;
-  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.stage-node:hover {
-  transform: translate(-50%, -50%) scale(1.05);
-  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.45);
-}
-
-.stage-node:focus-visible {
-  outline: 3px solid #38bdf8;
-  outline-offset: 4px;
+#stageMapOverlayCanvas:active {
+  cursor: grabbing;
 }
 
 .stage-node__icon {


### PR DESCRIPTION
## Summary
- redraw the stage map using the infinite lab-style circuit renderer instead of DOM nodes
- describe the updated gate layout and wire routes via a dedicated blueprint and richer renderer features
- refresh the UI to host stacked canvases, zoom/pan controls, and status-aware stage tiles

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de1cf0e8883328510d949c35e45a3)