### PR TITLE
Refactor stage map to canvas layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,15 +107,7 @@
     <!-- 스테이지 맵 화면 -->
     <section id="stageMapScreen" class="stage-map-screen" aria-label="Stage Map">
       <div class="stage-map-surface" id="stageMapSurface">
-        <div
-          class="stage-map-viewport"
-          id="stageMapViewport"
-          style="--map-scale: 1; --map-translate-x: 0px; --map-translate-y: 0px;"
-        >
-          <div class="stage-map-grid" aria-hidden="true"></div>
-          <svg id="stageMapConnections" class="stage-map-connections" role="presentation"></svg>
-          <div id="stageMapNodes" class="stage-map-nodes" role="list"></div>
-        </div>
+        <canvas id="stageMapCanvas" class="stage-map-canvas" role="presentation"></canvas>
         <div class="stage-map-info">
           <div class="stage-map-title">
             <h1>🧠 Bitwiser</h1>

--- a/src/modules/stageMapLayout.js
+++ b/src/modules/stageMapLayout.js
@@ -1,116 +1,78 @@
-const BASE_OFFSET_X = 120;
-const BASE_OFFSET_Y = 120;
+import { CELL, GAP } from '../canvas/model.js';
+
+export const GRID_UNIT = CELL + GAP;
+
+export const STAGE_NODE_LEVEL_MAP = {
+  bit_solver: null,
+  tutorial: null,
+  not: 1,
+  nand: 5,
+  nor: 4,
+  or: 2,
+  and: 3,
+  fixed_xor: null,
+  xor: 6,
+  crossroad: null,
+  bit_wiser: null,
+  story: null,
+  leaderboard: null,
+  credits: null,
+  lab: null,
+  user_created_stages: null,
+  three_bit_shifter: null,
+  parity_checker: 8,
+  decoder_2to4: 11,
+  fixed_decoder_2to4: null,
+  enable_gate_left_bottom: null,
+  majority_gate: 7,
+  enable_gate_center: null,
+  mux_4to1: 12,
+  two_bit_max_selector: 16,
+  bit_master: null,
+  half_adder: 9,
+  full_adder: 10,
+  overflow_detector: null,
+  mod3_remainder: 18,
+  two_bit_comparator: 13,
+  two_bit_subtractor: 15,
+  two_bit_multiplier: 17,
+  two_bit_adder: 14,
+  twos_complement: null
+};
 
 export const STAGE_TYPE_META = {
-  primitive_gate: {
-    labelKey: 'stageTypePrimitive',
-    className: 'stage-node--primitive',
-    icon: '🔹'
-  },
-  logic_stage: {
+  stage: {
     labelKey: 'stageTypeLogic',
-    className: 'stage-node--logic',
-    icon: '🧩'
+    color: '#38bdf8',
+    accent: '#0ea5e9'
   },
-  arith_stage: {
-    labelKey: 'stageTypeArithmetic',
-    className: 'stage-node--arithmetic',
-    icon: '➗'
+  rank: {
+    labelKey: 'stageTypeTitle',
+    color: '#f59e0b',
+    accent: '#f97316'
+  },
+  feature: {
+    labelKey: 'stageTypeMode',
+    color: '#a855f7',
+    accent: '#8b5cf6'
   },
   mode: {
     labelKey: 'stageTypeMode',
-    className: 'stage-node--mode',
-    icon: '🚪'
-  },
-  title: {
-    labelKey: 'stageTypeTitle',
-    className: 'stage-node--title',
-    icon: '🏅'
+    color: '#22c55e',
+    accent: '#16a34a'
   }
 };
 
-function nodePosition(x, y) {
-  return [BASE_OFFSET_X + x, BASE_OFFSET_Y + y];
+export function gridToWorldPoint({ x, y }) {
+  return {
+    x: GAP + x * GRID_UNIT,
+    y: GAP + y * GRID_UNIT
+  };
 }
 
-export const STAGE_GRAPH = {
-  nodes: [
-    { id: 'UserCreated', label: 'User Created', type: 'mode', position: nodePosition(280, 0), icon: '🧩', mode: 'userProblems' },
-    { id: 'Lab', label: 'Lab', type: 'mode', position: nodePosition(420, 0), icon: '🔬', mode: 'lab' },
-    { id: 'BitWiser', label: 'Bit Wiser', type: 'title', position: nodePosition(600, 0), icon: '🧠', autoClear: true },
-
-    { id: 'NOT', label: 'NOT', type: 'primitive_gate', level: 1, position: nodePosition(0, 200), icon: '¬' },
-    { id: 'OR', label: 'OR', type: 'primitive_gate', level: 2, position: nodePosition(160, 200) },
-    { id: 'AND', label: 'AND', type: 'primitive_gate', level: 3, position: nodePosition(320, 200) },
-    { id: 'XOR', label: 'XOR', type: 'primitive_gate', level: 6, position: nodePosition(480, 200) },
-    { id: 'FixedXOR', label: 'Fixed XOR', type: 'primitive_gate', position: nodePosition(640, 200), comingSoon: true, autoClear: true },
-    { id: 'NOR', label: 'NOR', type: 'primitive_gate', level: 4, position: nodePosition(160, 360) },
-    { id: 'NAND', label: 'NAND', type: 'primitive_gate', level: 5, position: nodePosition(320, 360) },
-
-    { id: 'MajorityGate', label: 'Majority Gate', type: 'logic_stage', level: 7, position: nodePosition(600, 360) },
-    { id: 'ParityChecker', label: 'Parity Checker', type: 'logic_stage', level: 8, position: nodePosition(760, 360) },
-    { id: 'Decoder2to4', label: '2-to-4 Decoder', type: 'logic_stage', level: 11, position: nodePosition(920, 360) },
-    { id: 'FixedDecoder', label: 'Fixed Decoder', type: 'logic_stage', position: nodePosition(920, 520), comingSoon: true, autoClear: true },
-    { id: 'MaxSelector2bit', label: '2-bit Max Selector', type: 'logic_stage', level: 16, position: nodePosition(1080, 360) },
-    { id: 'Shifter3bit', label: '3-bit Shifter', type: 'logic_stage', position: nodePosition(760, 520), comingSoon: true, autoClear: true },
-    { id: 'Crossroad', label: 'Crossroad', type: 'logic_stage', position: nodePosition(1080, 520), comingSoon: true, autoClear: true },
-    { id: 'MUX4to1', label: '4-to-1 MUX', type: 'logic_stage', level: 12, position: nodePosition(1240, 360) },
-    { id: 'AbsoluteValue', label: 'Absolute Value', type: 'logic_stage', position: nodePosition(1400, 360), comingSoon: true, autoClear: true },
-
-    { id: 'HalfAdder', label: 'Half Adder', type: 'arith_stage', level: 9, position: nodePosition(600, 520) },
-    { id: 'FullAdder', label: 'Full Adder', type: 'arith_stage', level: 10, position: nodePosition(600, 680) },
-    { id: 'OverflowDetector', label: 'Overflow Detector', type: 'arith_stage', position: nodePosition(760, 680), comingSoon: true, autoClear: true },
-    { id: 'Comparator2bit', label: '2-bit Comparator', type: 'arith_stage', level: 13, position: nodePosition(920, 680) },
-    { id: 'Adder2bit', label: '2-bit Adder', type: 'arith_stage', level: 14, position: nodePosition(1080, 680) },
-    { id: 'TwosComplement', label: "2's Complement", type: 'arith_stage', position: nodePosition(1240, 680), comingSoon: true, autoClear: true },
-    { id: 'Subtractor2bit', label: '2-bit Subtractor', type: 'arith_stage', level: 15, position: nodePosition(1400, 680) },
-    { id: 'Multiplier2bit', label: '2-bit Multiplier', type: 'arith_stage', level: 17, position: nodePosition(1240, 520) },
-    { id: 'Mod3Remainder', label: 'Mod 3 Remainder', type: 'arith_stage', level: 18, position: nodePosition(1560, 680) },
-
-    { id: 'BitMaster', label: 'Bit Master', type: 'title', position: nodePosition(1560, 520), icon: '🏆', autoClear: true }
-  ],
-  edges: [
-    { from: 'NOT', to: 'OR' },
-    { from: 'OR', to: 'AND' },
-    { from: 'AND', to: 'XOR' },
-    { from: 'OR', to: 'NOR' },
-    { from: 'AND', to: 'NAND' },
-    { from: 'XOR', to: 'FixedXOR' },
-    { from: 'XOR', to: 'BitWiser' },
-
-    { from: 'UserCreated', to: 'BitWiser' },
-    { from: 'Lab', to: 'BitWiser' },
-
-    { from: 'BitWiser', to: 'MajorityGate' },
-    { from: 'BitWiser', to: 'HalfAdder' },
-
-    { from: 'MajorityGate', to: 'ParityChecker' },
-    { from: 'ParityChecker', to: 'Decoder2to4' },
-    { from: 'ParityChecker', to: 'Shifter3bit' },
-
-    { from: 'Decoder2to4', to: 'FixedDecoder' },
-    { from: 'Decoder2to4', to: 'MaxSelector2bit' },
-    { from: 'MaxSelector2bit', to: 'MUX4to1' },
-    { from: 'MaxSelector2bit', to: 'Crossroad' },
-
-    { from: 'Shifter3bit', to: 'Crossroad' },
-    { from: 'Crossroad', to: 'TwosComplement' },
-
-    { from: 'MUX4to1', to: 'AbsoluteValue' },
-    { from: 'AbsoluteValue', to: 'BitMaster' },
-
-    { from: 'HalfAdder', to: 'FullAdder' },
-    { from: 'FullAdder', to: 'OverflowDetector' },
-    { from: 'OverflowDetector', to: 'Comparator2bit' },
-
-    { from: 'Comparator2bit', to: 'Adder2bit' },
-    { from: 'Adder2bit', to: 'Multiplier2bit' },
-    { from: 'Adder2bit', to: 'TwosComplement' },
-
-    { from: 'TwosComplement', to: 'Subtractor2bit' },
-    { from: 'Subtractor2bit', to: 'Mod3Remainder' },
-
-    { from: 'Mod3Remainder', to: 'BitMaster' },
-    { from: 'Multiplier2bit', to: 'BitMaster' }
-  ]
-};
+export function gridSizeToWorldSize({ w, h }) {
+  return {
+    width: w * GRID_UNIT - GAP,
+    height: h * GRID_UNIT - GAP
+  };
+}

--- a/style.css
+++ b/style.css
@@ -49,68 +49,14 @@ body.safe-mode .stage-map-surface {
   box-shadow: 0 20px 40px rgba(2, 6, 23, 0.8);
 }
 
-.stage-map-viewport {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: var(--map-width, 1800px);
-  height: var(--map-height, 1100px);
-  transform-origin: center;
-  transform: translate3d(calc(-50% + var(--map-translate-x, 0px)), calc(-50% + var(--map-translate-y, 0px)), 0)
-    scale(var(--map-scale, 1));
-  transition: transform 0.15s ease-out;
-}
 
-.stage-map-grid,
-.stage-map-connections,
-.stage-map-nodes {
+.stage-map-canvas {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-}
-
-.stage-map-grid {
-  background-image: linear-gradient(rgba(148, 163, 184, 0.12) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
-  background-size: 120px 120px;
-  filter: drop-shadow(0 0 16px rgba(15, 23, 42, 0.6));
-}
-
-body.safe-mode .stage-map-grid {
-  background-image: linear-gradient(rgba(248, 250, 252, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(248, 250, 252, 0.08) 1px, transparent 1px);
-}
-
-.stage-map-connections {
-  pointer-events: none;
-}
-
-.stage-map-connections path {
-  stroke: rgba(100, 116, 139, 0.65);
-  stroke-width: 3.5;
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0.5;
-}
-
-body.safe-mode .stage-map-connections path {
-  stroke: rgba(248, 250, 252, 0.4);
-}
-
-.stage-connection--active {
-  stroke: #fbbf24;
-  opacity: 0.95;
-  filter: drop-shadow(0 0 18px rgba(251, 191, 36, 0.5));
-}
-
-.stage-map-nodes {
-  pointer-events: none;
-}
-
-.stage-map-nodes button {
-  pointer-events: auto;
+  display: block;
+  background: transparent;
 }
 
 .stage-node {


### PR DESCRIPTION
## Summary
- render the stage map on a canvas using the stage_map.json layout with pan/zoom controls and infinite grid styling
- parse stage metadata into world coordinates with status evaluation for modes, ranks, and stages
- simplify the stage map markup and styles around the new canvas surface

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692166b828548332a0343f27bbac1b5c)