### PR TITLE
Add guided tutorial stage with mission overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,6 +610,12 @@
     </div>
     <!-- 게임 화면 -->
     <div id="gameScreen" style="display:none">
+      <div id="tutorialMissionPanel" class="tutorial-missions" style="display:none;">
+        <div class="tutorial-missions__title">튜토리얼 미션 / Tutorial missions</div>
+        <ol id="tutorialMissionList" class="tutorial-missions__list"></ol>
+        <div id="tutorialMissionDetail" class="tutorial-missions__detail"></div>
+      </div>
+      <div id="tutorialCalloutLayer" aria-hidden="true"></div>
       <div id="gameArea">
 
         <!-- 전체 게임 영역: 좌측 메뉴 + 중앙 그리드 + 우측 안내 -->

--- a/levels.json
+++ b/levels.json
@@ -1,25 +1,27 @@
 {
   "levelTitles": {
-  "1": "NOT gate",
-  "2": "OR gate",
-  "3": "AND gate",
-  "4": "NOR gate",
-  "5": "NAND gate",
-  "6": "XOR gate",
-  "7": "Majority gate",
-  "8": "Parity checker",
-  "9": "Half Adder",
-  "10": "Full Adder",
-  "11": "2-to-4 Decoder",
-  "12": "4-to-1 MUX",
-  "13": "2-bit Comparator",
-  "14": "2-bit Adder",
-  "15": "2-bit Mod 4 Subtractor",
-  "16": "2-bit Max Selector",
-  "17": "2-bit Multiplier",
-  "18": "4-bit Mod 3 Remainder"
-},
+    "0": "튜토리얼: 첫 회로",
+    "1": "NOT gate",
+    "2": "OR gate",
+    "3": "AND gate",
+    "4": "NOR gate",
+    "5": "NAND gate",
+    "6": "XOR gate",
+    "7": "Majority gate",
+    "8": "Parity checker",
+    "9": "Half Adder",
+    "10": "Full Adder",
+    "11": "2-to-4 Decoder",
+    "12": "4-to-1 MUX",
+    "13": "2-bit Comparator",
+    "14": "2-bit Adder",
+    "15": "2-bit Mod 4 Subtractor",
+    "16": "2-bit Max Selector",
+    "17": "2-bit Multiplier",
+    "18": "4-bit Mod 3 Remainder"
+  },
   "levelGridSizes": {
+    "0": [6, 6],
     "1": [6, 6],
     "2": [6, 6],
     "3": [6, 6],
@@ -40,6 +42,13 @@
     "18": [15, 15]
   },
   "levelBlockSets": {
+    "0": [
+      { "type": "INPUT", "name": "IN1" },
+      { "type": "INPUT", "name": "IN2" },
+      { "type": "OUTPUT", "name": "OUT1" },
+      { "type": "NOT" },
+      { "type": "AND" }
+    ],
     "1": [
       { "type": "INPUT", "name": "IN1" },
       { "type": "OUTPUT", "name": "OUT1" },
@@ -223,6 +232,12 @@
   },
   "chapterData": [
     {
+      "id": "tutorial",
+      "name": "튜토리얼",
+      "desc": "블록 배치, 배선, 채점 흐름을 익혀요.",
+      "stages": [0]
+    },
+    {
       "id": "basic",
       "name": "기초 논리 게이트",
       "desc": "NOT, AND, OR 등 기본 게이트를 연습합니다.",
@@ -242,6 +257,12 @@
     }
   ],
   "levelAnswers": {
+    "0": [
+      { "inputs": { "IN1": 0, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 0, "IN2": 1 }, "expected": { "OUT1": 1 } },
+      { "inputs": { "IN1": 1, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 1, "IN2": 1 }, "expected": { "OUT1": 0 } }
+    ],
     "1": [
       { "inputs": { "IN1": 0 }, "expected": { "OUT1": 1 } },
       { "inputs": { "IN1": 1 }, "expected": { "OUT1": 0 } }
@@ -1269,6 +1290,16 @@
 
   },
   "levelDescriptions": {
+    "0": {
+      "title": "Stage 0: 튜토리얼 - 첫 회로",
+      "desc": "IN1을 반전해 AND 게이트로 IN2와 결합한 뒤 OUT1으로 보내는 회로를 따라 만들어 보세요.",
+      "table": [
+        { "IN1": 0, "IN2": 0, "OUT1": 0 },
+        { "IN1": 0, "IN2": 1, "OUT1": 1 },
+        { "IN1": 1, "IN2": 0, "OUT1": 0 },
+        { "IN1": 1, "IN2": 1, "OUT1": 0 }
+      ]
+    },
     "1": {
       "title": "Stage 1: NOT 게이트",
       "desc": "NOT 게이트는 입력이 1이면 출력이 0, 입력이 0이면 출력이 1이 됩니다.",

--- a/levels_en.json
+++ b/levels_en.json
@@ -1,25 +1,27 @@
 {
   "levelTitles": {
-  "1": "NOT gate",
-  "2": "OR gate",
-  "3": "AND gate",
-  "4": "NOR gate",
-  "5": "NAND gate",
-  "6": "XOR gate",
-  "7": "Majority gate",
-  "8": "Parity checker",
-  "9": "Half Adder",
-  "10": "Full Adder",
-  "11": "2-to-4 Decoder",
-  "12": "4-to-1 MUX",
-  "13": "2-bit Comparator",
-  "14": "2-bit Adder",
-  "15": "2-bit Mod 4 Subtractor",
-  "16": "2-bit Max Selector",
-  "17": "2-bit Multiplier",
-  "18": "4-bit Mod 3 Remainder"
-},
+    "0": "Tutorial: First Circuit",
+    "1": "NOT gate",
+    "2": "OR gate",
+    "3": "AND gate",
+    "4": "NOR gate",
+    "5": "NAND gate",
+    "6": "XOR gate",
+    "7": "Majority gate",
+    "8": "Parity checker",
+    "9": "Half Adder",
+    "10": "Full Adder",
+    "11": "2-to-4 Decoder",
+    "12": "4-to-1 MUX",
+    "13": "2-bit Comparator",
+    "14": "2-bit Adder",
+    "15": "2-bit Mod 4 Subtractor",
+    "16": "2-bit Max Selector",
+    "17": "2-bit Multiplier",
+    "18": "4-bit Mod 3 Remainder"
+  },
   "levelGridSizes": {
+    "0": [6, 6],
     "1": [6, 6],
     "2": [6, 6],
     "3": [6, 6],
@@ -40,6 +42,13 @@
     "18": [15, 15]
   },
   "levelBlockSets": {
+    "0": [
+      { "type": "INPUT", "name": "IN1" },
+      { "type": "INPUT", "name": "IN2" },
+      { "type": "OUTPUT", "name": "OUT1" },
+      { "type": "NOT" },
+      { "type": "AND" }
+    ],
     "1": [
       { "type": "INPUT", "name": "IN1" },
       { "type": "OUTPUT", "name": "OUT1" },
@@ -223,6 +232,12 @@
   },
   "chapterData": [
     {
+      "id": "tutorial",
+      "name": "Tutorial",
+      "desc": "Learn how to place blocks, draw wires, and grade.",
+      "stages": [0]
+    },
+    {
       "id": "basic",
       "name": "Basic Logic Gates",
       "desc": "Practice basic gates such as NOT, AND, and OR.",
@@ -242,6 +257,12 @@
     }
   ],
   "levelAnswers": {
+    "0": [
+      { "inputs": { "IN1": 0, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 0, "IN2": 1 }, "expected": { "OUT1": 1 } },
+      { "inputs": { "IN1": 1, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 1, "IN2": 1 }, "expected": { "OUT1": 0 } }
+    ],
     "1": [
       { "inputs": { "IN1": 0 }, "expected": { "OUT1": 1 } },
       { "inputs": { "IN1": 1 }, "expected": { "OUT1": 0 } }
@@ -1269,6 +1290,16 @@
 
   },
   "levelDescriptions": {
+    "0": {
+      "title": "Stage 0: Tutorial - First Circuit",
+      "desc": "Follow the guide to invert IN1, merge it with IN2 through an AND gate, and send the result to OUT1.",
+      "table": [
+        { "IN1": 0, "IN2": 0, "OUT1": 0 },
+        { "IN1": 0, "IN2": 1, "OUT1": 1 },
+        { "IN1": 1, "IN2": 0, "OUT1": 0 },
+        { "IN1": 1, "IN2": 1, "OUT1": 0 }
+      ]
+    },
     "1": {
       "title": "Stage 1: NOT Gate",
       "desc": "The NOT gate outputs 0 when the input is 1 and outputs 1 when the input is 0.",

--- a/src/main.js
+++ b/src/main.js
@@ -27,12 +27,14 @@ import {
   getPlayController,
   getProblemCircuit,
   getProblemController,
+  getGridDimensions,
   destroyProblemContext
 } from './modules/grid.js';
 import * as levelsModule from './modules/levels.js';
 import * as uiModule from './modules/ui.js';
 import { openHintModal, initializeHintUI } from './modules/hints.js';
 import { initializeTutorials } from './modules/tutorials.js';
+import { createGuidedTutorial } from './modules/guidedTutorial.js';
 import { createGradingController } from './modules/grading.js';
 import {
   initializeCircuitShare,
@@ -451,8 +453,10 @@ function setupKeyToggles() {
 
 const gameScreen = document.getElementById("gameScreen");
 const stageMapScreen = document.getElementById('stageMapScreen');
+let guidedTutorial;
 
 document.getElementById("backToLevelsBtn").onclick = async () => {
+  guidedTutorial?.stop?.();
   await returnToLevels({
     isCustomProblemActive: Boolean(getActiveCustomProblem()),
     onClearCustomProblem: clearActiveCustomProblem
@@ -664,6 +668,17 @@ if (gradeButton) {
   });
 }
 
+guidedTutorial = createGuidedTutorial({
+  lang: typeof currentLang !== 'undefined' ? currentLang : 'en',
+  missionPanel: document.getElementById('tutorialMissionPanel'),
+  missionList: document.getElementById('tutorialMissionList'),
+  missionDetail: document.getElementById('tutorialMissionDetail'),
+  calloutLayer: document.getElementById('tutorialCalloutLayer'),
+  gradeButton,
+  getPlayCircuit,
+  getGridDimensions
+});
+
 initializeRankingUI({
   viewRankingButtonSelector: '#viewRankingBtn',
   rankingListSelector: '#rankingList',
@@ -676,8 +691,10 @@ initializeRankingUI({
 });
 
 configureLevelModule({
-  onLevelIntroComplete: () =>
-    collapseMenuBarForMobile({ onAfterCollapse: updatePadding })
+  onLevelIntroComplete: () => {
+    collapseMenuBarForMobile({ onAfterCollapse: updatePadding });
+    guidedTutorial?.handleLevelStart?.(getCurrentLevel());
+  }
 });
 
 function parseColorToRgb(color) {

--- a/src/modules/guidedTutorial.js
+++ b/src/modules/guidedTutorial.js
@@ -1,0 +1,416 @@
+import { onCircuitModified } from './grid.js';
+
+export const TUTORIAL_LEVEL = 0;
+
+const TARGET_LAYOUT = {
+  IN1: { r: 1, c: 0 },
+  NOT: { r: 1, c: 2 },
+  IN2: { r: 3, c: 0 },
+  AND: { r: 2, c: 4 },
+  OUT1: { r: 2, c: 5 }
+};
+
+const CONNECTIONS = [
+  ['IN1', 'NOT'],
+  ['NOT', 'AND'],
+  ['IN2', 'AND'],
+  ['AND', 'OUT1']
+];
+
+function formatCellKo(pos) {
+  return `${pos.r + 1}행 ${pos.c + 1}열`;
+}
+
+function formatCellEn(pos) {
+  return `row ${pos.r + 1}, col ${pos.c + 1}`;
+}
+
+function createBilingualLine({ ko, en }) {
+  const line = document.createElement('div');
+  line.className = 'tutorial-bilingual-line';
+  const koSpan = document.createElement('span');
+  koSpan.textContent = ko;
+  const enSpan = document.createElement('span');
+  enSpan.className = 'tutorial-english';
+  enSpan.textContent = en;
+  line.appendChild(koSpan);
+  line.appendChild(enSpan);
+  return line;
+}
+
+function matchesTarget(key, block, target) {
+  if (!block || !block.pos || block.pos.r !== target.r || block.pos.c !== target.c) {
+    return false;
+  }
+  if (key === 'IN1' || key === 'IN2') {
+    return block.type === 'INPUT' && block.name === key;
+  }
+  if (key === 'OUT1') {
+    return block.type === 'OUTPUT' && block.name === 'OUT1';
+  }
+  if (key === 'NOT') {
+    return block.type === 'NOT';
+  }
+  if (key === 'AND') {
+    return block.type === 'AND';
+  }
+  return false;
+}
+
+export function createGuidedTutorial({
+  lang = 'en',
+  missionPanel,
+  missionList,
+  missionDetail,
+  calloutLayer,
+  gradeButton,
+  getPlayCircuit = () => null,
+  getGridDimensions = () => [6, 6]
+} = {}) {
+  let active = false;
+  let currentStepIndex = 0;
+  let unsubscribeCircuit = null;
+
+  const steps = [
+    {
+      id: 'place',
+      titleKo: '블록 배치하기',
+      titleEn: 'Place the blocks'
+    },
+    {
+      id: 'wire',
+      titleKo: '도선 그리기',
+      titleEn: 'Draw the wires'
+    },
+    {
+      id: 'grade',
+      titleKo: '채점 버튼 누르기',
+      titleEn: 'Press the grade button'
+    }
+  ];
+
+  const blockPlacementLines = [
+    {
+      ko: `IN1 입력을 ${formatCellKo(TARGET_LAYOUT.IN1)}에 놓아요.`,
+      en: `Drop IN1 at ${formatCellEn(TARGET_LAYOUT.IN1)}.`
+    },
+    {
+      ko: `IN2 입력을 ${formatCellKo(TARGET_LAYOUT.IN2)}에 놓아요.`,
+      en: `Place IN2 at ${formatCellEn(TARGET_LAYOUT.IN2)}.`
+    },
+    {
+      ko: `NOT 게이트를 ${formatCellKo(TARGET_LAYOUT.NOT)}에 배치해요.`,
+      en: `Position the NOT gate at ${formatCellEn(TARGET_LAYOUT.NOT)}.`
+    },
+    {
+      ko: `AND 게이트는 ${formatCellKo(TARGET_LAYOUT.AND)}에 둡니다.`,
+      en: `Set the AND gate at ${formatCellEn(TARGET_LAYOUT.AND)}.`
+    },
+    {
+      ko: `OUT1 출력은 ${formatCellKo(TARGET_LAYOUT.OUT1)} 칸에 놓아주세요.`,
+      en: `Drop OUT1 at ${formatCellEn(TARGET_LAYOUT.OUT1)}.`
+    }
+  ];
+
+  const wireLines = [
+    {
+      ko: `${formatCellKo(TARGET_LAYOUT.IN1)}의 IN1에서 ${formatCellKo(TARGET_LAYOUT.NOT)}의 NOT까지 Ctrl/Cmd를 누른 채 드래그해 연결해요.`,
+      en: `Hold Ctrl/Cmd and drag from IN1 (${formatCellEn(TARGET_LAYOUT.IN1)}) to NOT (${formatCellEn(TARGET_LAYOUT.NOT)}).`
+    },
+    {
+      ko: `${formatCellKo(TARGET_LAYOUT.NOT)}의 NOT에서 ${formatCellKo(TARGET_LAYOUT.AND)}의 AND까지 같은 방식으로 이어요.`,
+      en: `Drag from NOT (${formatCellEn(TARGET_LAYOUT.NOT)}) to AND (${formatCellEn(TARGET_LAYOUT.AND)}).`
+    },
+    {
+      ko: `${formatCellKo(TARGET_LAYOUT.IN2)}의 IN2를 ${formatCellKo(TARGET_LAYOUT.AND)}의 AND 입력으로 연결해요.`,
+      en: `Connect IN2 (${formatCellEn(TARGET_LAYOUT.IN2)}) to the AND gate (${formatCellEn(TARGET_LAYOUT.AND)}).`
+    },
+    {
+      ko: `${formatCellKo(TARGET_LAYOUT.AND)}의 AND에서 ${formatCellKo(TARGET_LAYOUT.OUT1)}의 OUT1까지 선을 마무리해요.`,
+      en: `Finish the path from AND (${formatCellEn(TARGET_LAYOUT.AND)}) to OUT1 (${formatCellEn(TARGET_LAYOUT.OUT1)}).`
+    }
+  ];
+
+  const gradeLines = [
+    {
+      ko: "오른쪽 상단 '채점하기' 버튼을 클릭해 테스트를 실행해요.",
+      en: "Click the 'Grade' button on the right to run the checks."
+    },
+    {
+      ko: '회로도가 IN1 → NOT → AND → OUT1 (IN2는 AND로) 형태인지 다시 한 번 확인해요.',
+      en: 'Confirm the circuit is IN1 → NOT → AND → OUT1 with IN2 feeding the AND gate.'
+    }
+  ];
+
+  function isTutorialLevel(level) {
+    return Number(level) === TUTORIAL_LEVEL;
+  }
+
+  function clearCallouts() {
+    if (calloutLayer) {
+      calloutLayer.innerHTML = '';
+    }
+  }
+
+  function locateTargetBlocks() {
+    const circuit = getPlayCircuit?.();
+    const map = {};
+    if (!circuit || !circuit.blocks) {
+      return { complete: false, map };
+    }
+    const entries = Object.entries(circuit.blocks);
+    let complete = true;
+    Object.entries(TARGET_LAYOUT).forEach(([key, target]) => {
+      const match = entries.find(([, block]) => matchesTarget(key, block, target));
+      if (match) {
+        map[key] = match[0];
+      } else {
+        complete = false;
+      }
+    });
+    cachedTargets = map;
+    return { complete, map };
+  }
+
+  function blocksPlaced() {
+    return locateTargetBlocks().complete;
+  }
+
+  function connectionsCompleted() {
+    const circuit = getPlayCircuit?.();
+    if (!circuit || !circuit.wires) return false;
+    const { complete, map } = locateTargetBlocks();
+    if (!complete) return false;
+    const wires = Object.values(circuit.wires);
+    return CONNECTIONS.every(([from, to]) =>
+      wires.some(wire => wire.startBlockId === map[from] && wire.endBlockId === map[to])
+    );
+  }
+
+  function setPanelVisible(visible) {
+    if (missionPanel) {
+      missionPanel.style.display = visible ? 'flex' : 'none';
+    }
+    if (calloutLayer) {
+      calloutLayer.style.display = visible ? 'block' : 'none';
+    }
+  }
+
+  function renderMissionList() {
+    if (!missionList) return;
+    missionList.innerHTML = '';
+    steps.forEach((step, index) => {
+      const item = document.createElement('li');
+      item.className = 'tutorial-mission-item';
+      if (index < currentStepIndex) {
+        item.classList.add('tutorial-mission-item--done');
+      } else if (index === currentStepIndex) {
+        item.classList.add('tutorial-mission-item--active');
+      }
+      const title = document.createElement('div');
+      title.className = 'tutorial-mission-title';
+      title.textContent = `${index + 1}. ${step.titleKo} / ${step.titleEn}`;
+      item.appendChild(title);
+      missionList.appendChild(item);
+    });
+  }
+
+  function renderDetail() {
+    if (!missionDetail) return;
+    missionDetail.innerHTML = '';
+    if (currentStepIndex >= steps.length) {
+      const doneLine = createBilingualLine({
+        ko: '튜토리얼을 모두 완료했어요! 채점 결과 창에서 성공을 확인해보세요.',
+        en: 'Tutorial steps are complete! Check the grading results to confirm your success.'
+      });
+      missionDetail.appendChild(doneLine);
+      return;
+    }
+
+    const step = steps[currentStepIndex];
+    const introLine = createBilingualLine({
+      ko: '목표 회로: IN1 → NOT → AND → OUT1 (IN2는 AND 입력으로)',
+      en: 'Target circuit: IN1 → NOT → AND → OUT1 (IN2 feeds the AND gate)'
+    });
+    missionDetail.appendChild(introLine);
+
+    let lines = [];
+    if (step.id === 'place') {
+      lines = blockPlacementLines;
+    } else if (step.id === 'wire') {
+      lines = wireLines;
+    } else if (step.id === 'grade') {
+      lines = gradeLines;
+    }
+    lines.forEach(line => missionDetail.appendChild(createBilingualLine(line)));
+  }
+
+  function getCellCenter(pos) {
+    const overlayCanvas = document.getElementById('overlayCanvas');
+    const container = document.getElementById('gameScreen');
+    if (!overlayCanvas || !container) return null;
+    const rect = overlayCanvas.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const panelWidth = Number.parseFloat(overlayCanvas.dataset?.panelWidth || '0');
+    const [rows, cols] = getGridDimensions?.() || [];
+    if (!rows || !cols) return null;
+    const cellWidth = (rect.width - panelWidth) / cols;
+    const cellHeight = rect.height / rows;
+    return {
+      x: rect.left - containerRect.left + panelWidth + cellWidth * (pos.c + 0.5),
+      y: rect.top - containerRect.top + cellHeight * (pos.r + 0.5)
+    };
+  }
+
+  function calloutForButton(btn, label) {
+    if (!btn || !calloutLayer) return null;
+    const rect = btn.getBoundingClientRect();
+    const layerRect = calloutLayer.getBoundingClientRect();
+    return {
+      x: rect.left - layerRect.left + rect.width / 2,
+      y: rect.top - layerRect.top + rect.height / 2,
+      label,
+      pulse: true
+    };
+  }
+
+  function buildCallouts() {
+    if (!calloutLayer || currentStepIndex >= steps.length) return [];
+    const step = steps[currentStepIndex];
+    const layerRect = calloutLayer.getBoundingClientRect();
+    if (!layerRect.width || !layerRect.height) return [];
+
+    if (step.id === 'grade') {
+      return [
+        calloutForButton(gradeButton, "'채점하기' / 'Grade'")
+      ].filter(Boolean);
+    }
+
+    if (step.id === 'place') {
+      return Object.entries(TARGET_LAYOUT)
+        .map(([key, pos]) => {
+          const center = getCellCenter(pos);
+          if (!center) return null;
+          return {
+            x: center.x,
+            y: center.y,
+            label: `${key}`,
+            pulse: key === 'AND' || key === 'NOT'
+          };
+        })
+        .filter(Boolean);
+    }
+
+    if (step.id === 'wire') {
+      return CONNECTIONS.map(([from, to]) => {
+        const start = getCellCenter(TARGET_LAYOUT[from]);
+        const end = getCellCenter(TARGET_LAYOUT[to]);
+        if (!start || !end) return null;
+        return {
+          x: (start.x + end.x) / 2,
+          y: (start.y + end.y) / 2,
+          label: `${from} → ${to}`,
+          pulse: true
+        };
+      }).filter(Boolean);
+    }
+
+    return [];
+  }
+
+  function renderCallouts() {
+    if (!calloutLayer) return;
+    calloutLayer.innerHTML = '';
+    if (!active || currentStepIndex > steps.length - 1) return;
+    const layerRect = calloutLayer.getBoundingClientRect();
+    const callouts = buildCallouts();
+    callouts.forEach(callout => {
+      const marker = document.createElement('div');
+      marker.className = 'tutorial-callout';
+      if (callout.pulse) {
+        marker.classList.add('tutorial-callout--pulse');
+      }
+      marker.style.left = `${callout.x}px`;
+      marker.style.top = `${callout.y}px`;
+      const label = document.createElement('div');
+      label.className = 'tutorial-callout__label';
+      label.textContent = callout.label;
+      marker.appendChild(label);
+      calloutLayer.appendChild(marker);
+    });
+  }
+
+  function render() {
+    if (!active) return;
+    setPanelVisible(true);
+    renderMissionList();
+    renderDetail();
+    renderCallouts();
+  }
+
+  function maybeAdvance() {
+    if (!active || currentStepIndex >= steps.length) return;
+    const step = steps[currentStepIndex];
+    if (step.id === 'place' && blocksPlaced()) {
+      currentStepIndex += 1;
+      render();
+    } else if (step.id === 'wire' && connectionsCompleted()) {
+      currentStepIndex += 1;
+      render();
+    }
+  }
+
+  function handleGradeClick() {
+    if (!active) return;
+    if (currentStepIndex >= steps.length) return;
+    const step = steps[currentStepIndex];
+    if (step.id === 'grade') {
+      currentStepIndex += 1;
+      render();
+    }
+  }
+
+  function start(level) {
+    if (!isTutorialLevel(level)) {
+      stop();
+      return;
+    }
+    active = true;
+    currentStepIndex = 0;
+    setPanelVisible(true);
+    if (!unsubscribeCircuit) {
+      unsubscribeCircuit = onCircuitModified(() => {
+        maybeAdvance();
+        renderCallouts();
+      });
+    }
+    if (gradeButton) {
+      gradeButton.addEventListener('click', handleGradeClick);
+    }
+    window.addEventListener('resize', renderCallouts);
+    render();
+    maybeAdvance();
+  }
+
+  function stop() {
+    active = false;
+    currentStepIndex = 0;
+    if (unsubscribeCircuit) {
+      unsubscribeCircuit();
+      unsubscribeCircuit = null;
+    }
+    if (gradeButton) {
+      gradeButton.removeEventListener('click', handleGradeClick);
+    }
+    window.removeEventListener('resize', renderCallouts);
+    setPanelVisible(false);
+    clearCallouts();
+  }
+
+  return {
+    handleLevelStart(level) {
+      start(level);
+    },
+    stop
+  };
+}

--- a/src/modules/stageMapLayout.js
+++ b/src/modules/stageMapLayout.js
@@ -4,7 +4,7 @@ export const GRID_UNIT = CELL + GAP;
 
 export const STAGE_NODE_LEVEL_MAP = {
   bit_solver: null,
-  tutorial: null,
+  tutorial: 0,
   not: 1,
   nand: 5,
   nor: 4,

--- a/style.css
+++ b/style.css
@@ -587,6 +587,7 @@ html, body {
     /* 혹시 기본 마진 있으면 제거 */
     overflow-x: auto;
     width: 100%;
+    position: relative;
   }
 
   #gameLayout {
@@ -3783,4 +3784,126 @@ body.lab-mode-active {
 
 #settingsModal .modal-buttons {
   margin-top: 1.5rem;
+}
+
+/* Guided tutorial overlays */
+.tutorial-missions {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: min(360px, 92vw);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 14px;
+  color: #e2e8f0;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  z-index: 1200;
+}
+
+.tutorial-missions__title {
+  font-weight: 800;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tutorial-missions__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tutorial-mission-item {
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.04);
+  color: #cbd5e1;
+}
+
+.tutorial-mission-item--active {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.45);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.14), rgba(14, 165, 233, 0.1));
+}
+
+.tutorial-mission-item--done {
+  border-color: rgba(34, 197, 94, 0.6);
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.12), rgba(16, 185, 129, 0.08));
+  color: #dcfce7;
+}
+
+.tutorial-mission-title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.tutorial-missions__detail {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  color: #e2e8f0;
+}
+
+.tutorial-bilingual-line {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 4px 0;
+  line-height: 1.45;
+}
+
+.tutorial-bilingual-line:last-child {
+  margin-bottom: 0;
+}
+
+.tutorial-english {
+  color: #cbd5e1;
+  font-size: 0.9em;
+}
+
+#tutorialCalloutLayer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1100;
+}
+
+.tutorial-callout {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  background: rgba(14, 165, 233, 0.14);
+  border: 2px solid rgba(14, 165, 233, 0.8);
+  color: #e0f2fe;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+  white-space: nowrap;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.tutorial-callout__label {
+  font-size: 0.9rem;
+}
+
+.tutorial-callout--pulse {
+  animation: tutorial-callout-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes tutorial-callout-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(14, 165, 233, 0.45); }
+  70% { box-shadow: 0 0 0 16px rgba(14, 165, 233, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(14, 165, 233, 0); }
 }


### PR DESCRIPTION
## Summary
- connect the Tutorial node on the stage map to a new introductory level with assets and answers in both language files
- add a guided tutorial controller that drives mission steps for placing blocks, wiring the sample circuit, and grading the result
- style and embed a mission/callout overlay so tutorial guidance appears on the game screen instead of deprecated modals

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924586ecefc833296e37f5615cee796)