### PR TITLE
Add guided tutorial stage with in-game missions

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,6 +610,39 @@
     </div>
     <!-- 게임 화면 -->
     <div id="gameScreen" style="display:none">
+      <div id="tutorialMissionPanel" class="tutorial-mission-panel" hidden>
+        <div class="tutorial-mission__header">
+          <p id="tutorialMissionEyebrow" class="tutorial-mission__eyebrow"></p>
+          <h3 id="tutorialMissionTitle" class="tutorial-mission__title"></h3>
+          <p id="tutorialMissionSubtitle" class="tutorial-mission__subtitle"></p>
+        </div>
+        <ol class="tutorial-mission__list">
+          <li class="tutorial-mission__item" data-step="place">
+            <div class="tutorial-mission__status" aria-hidden="true"></div>
+            <div class="tutorial-mission__content">
+              <p id="tutorialStepPlaceTitle" class="tutorial-mission__heading"></p>
+              <p id="tutorialStepPlaceBody" class="tutorial-mission__body"></p>
+              <p id="tutorialStepPlaceHint" class="tutorial-mission__hint"></p>
+            </div>
+          </li>
+          <li class="tutorial-mission__item" data-step="wire">
+            <div class="tutorial-mission__status" aria-hidden="true"></div>
+            <div class="tutorial-mission__content">
+              <p id="tutorialStepWireTitle" class="tutorial-mission__heading"></p>
+              <p id="tutorialStepWireBody" class="tutorial-mission__body"></p>
+              <p id="tutorialStepWireHint" class="tutorial-mission__hint"></p>
+            </div>
+          </li>
+          <li class="tutorial-mission__item" data-step="grade">
+            <div class="tutorial-mission__status" aria-hidden="true"></div>
+            <div class="tutorial-mission__content">
+              <p id="tutorialStepGradeTitle" class="tutorial-mission__heading"></p>
+              <p id="tutorialStepGradeBody" class="tutorial-mission__body"></p>
+              <p id="tutorialStepGradeHint" class="tutorial-mission__hint"></p>
+            </div>
+          </li>
+        </ol>
+      </div>
       <div id="gameArea">
 
         <!-- 전체 게임 영역: 좌측 메뉴 + 중앙 그리드 + 우측 안내 -->

--- a/lang.js
+++ b/lang.js
@@ -328,6 +328,18 @@ const translations = {
     loginCancel: {text: "제 계정이 아닙니다"},
     authUnknownError: {text: "알 수 없는 오류가 발생했습니다."},
     usernameRegistering: {text: "닉네임 등록"},
+    tutorialMissionEyebrow: {text: "가이드"},
+    tutorialMissionTitle: {text: "튜토리얼 미션"},
+    tutorialMissionSubtitle: {text: "좌상단 안내를 따라 블록 배치 → 도선 → 채점 순서로 진행해보세요."},
+    tutorialMissionPlaceTitle: {text: "1) 블록 배치하기"},
+    tutorialMissionPlaceBody: {text: "왼쪽 팔레트에서 IN1, IN2, NOT, AND, OUT1을 끌어 원하는 칸에 놓으세요. 추천 좌표에 두면 배선이 편해요."},
+    tutorialMissionPositionLine: {text: "IN1: 행2 열2 · IN2: 행4 열2 · NOT: 행2 열4 · AND: 행3 열5 · OUT1: 행3 열6"},
+    tutorialMissionWireTitle: {text: "2) 도선 설치"},
+    tutorialMissionWireBody: {text: "Ctrl/Cmd를 누른 채 출발 블록에서 도착 블록까지 드래그해 선을 이어주세요."},
+    tutorialMissionWireLine: {text: "IN1→NOT, NOT→AND, IN2→AND, AND→OUT1"},
+    tutorialMissionGradeTitle: {text: "3) 채점 버튼 누르기"},
+    tutorialMissionGradeBody: {text: "우측의 ‘채점하기’ 버튼을 눌러 테스트 입력을 실행하고 결과를 확인하세요."},
+    tutorialMissionGradeHint: {text: "배선을 모두 잇고 나서 버튼을 클릭하면 다음 단계로 넘어갑니다."},
     rankOverall: {text: "전체"}
   },
   en: {
@@ -659,6 +671,18 @@ const translations = {
     loginCancel: {text: "Not my account"},
     authUnknownError: {text: "An unknown error occurred."},
     usernameRegistering: {text: "Register nickname"},
+    tutorialMissionEyebrow: {text: "Guide"},
+    tutorialMissionTitle: {text: "Tutorial missions"},
+    tutorialMissionSubtitle: {text: "Follow the top-left guide: place blocks → draw wires → grade."},
+    tutorialMissionPlaceTitle: {text: "1) Place blocks"},
+    tutorialMissionPlaceBody: {text: "Drag IN1, IN2, NOT, AND, and OUT1 from the left palette onto the grid. Using the suggested cells makes wiring easier."},
+    tutorialMissionPositionLine: {text: "IN1: r2 c2 · IN2: r4 c2 · NOT: r2 c4 · AND: r3 c5 · OUT1: r3 c6"},
+    tutorialMissionWireTitle: {text: "2) Draw wires"},
+    tutorialMissionWireBody: {text: "Hold Ctrl/Cmd and drag from the start block to the destination block to connect them."},
+    tutorialMissionWireLine: {text: "IN1→NOT, NOT→AND, IN2→AND, AND→OUT1"},
+    tutorialMissionGradeTitle: {text: "3) Press grade"},
+    tutorialMissionGradeBody: {text: "Press the 'Grade' button on the right to run the test inputs and check the result."},
+    tutorialMissionGradeHint: {text: "After all wires are connected, click the button to move to the final step."},
     rankOverall: {text: "All"}
   }
 };

--- a/levels.json
+++ b/levels.json
@@ -1,6 +1,7 @@
 {
   "levelTitles": {
-  "1": "NOT gate",
+    "0": "튜토리얼: NOT-AND 입문",
+    "1": "NOT gate",
   "2": "OR gate",
   "3": "AND gate",
   "4": "NOR gate",
@@ -20,6 +21,7 @@
   "18": "4-bit Mod 3 Remainder"
 },
   "levelGridSizes": {
+    "0": [6, 6],
     "1": [6, 6],
     "2": [6, 6],
     "3": [6, 6],
@@ -40,6 +42,13 @@
     "18": [15, 15]
   },
   "levelBlockSets": {
+    "0": [
+      { "type": "INPUT", "name": "IN1" },
+      { "type": "INPUT", "name": "IN2" },
+      { "type": "OUTPUT", "name": "OUT1" },
+      { "type": "NOT" },
+      { "type": "AND" }
+    ],
     "1": [
       { "type": "INPUT", "name": "IN1" },
       { "type": "OUTPUT", "name": "OUT1" },
@@ -223,6 +232,12 @@
   },
   "chapterData": [
     {
+      "id": "tutorial",
+      "name": "튜토리얼",
+      "desc": "블록 배치, 배선, 채점 과정을 단계별로 익혀요.",
+      "stages": [0]
+    },
+    {
       "id": "basic",
       "name": "기초 논리 게이트",
       "desc": "NOT, AND, OR 등 기본 게이트를 연습합니다.",
@@ -242,6 +257,12 @@
     }
   ],
   "levelAnswers": {
+    "0": [
+      { "inputs": { "IN1": 0, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 0, "IN2": 1 }, "expected": { "OUT1": 1 } },
+      { "inputs": { "IN1": 1, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 1, "IN2": 1 }, "expected": { "OUT1": 0 } }
+    ],
     "1": [
       { "inputs": { "IN1": 0 }, "expected": { "OUT1": 1 } },
       { "inputs": { "IN1": 1 }, "expected": { "OUT1": 0 } }
@@ -1269,6 +1290,16 @@
 
   },
   "levelDescriptions": {
+    "0": {
+      "title": "튜토리얼: 반전 후 AND",
+      "desc": "IN1을 NOT으로 뒤집은 뒤 IN2와 AND로 묶어야 OUT1이 1이 됩니다. 아래 진리표대로 동작하도록 회로를 완성해보세요.",
+      "table": [
+        { "IN1": 0, "IN2": 0, "OUT1": 0 },
+        { "IN1": 0, "IN2": 1, "OUT1": 1 },
+        { "IN1": 1, "IN2": 0, "OUT1": 0 },
+        { "IN1": 1, "IN2": 1, "OUT1": 0 }
+      ]
+    },
     "1": {
       "title": "Stage 1: NOT 게이트",
       "desc": "NOT 게이트는 입력이 1이면 출력이 0, 입력이 0이면 출력이 1이 됩니다.",

--- a/levels_en.json
+++ b/levels_en.json
@@ -1,6 +1,7 @@
 {
   "levelTitles": {
-  "1": "NOT gate",
+    "0": "Tutorial: NOT + AND",
+    "1": "NOT gate",
   "2": "OR gate",
   "3": "AND gate",
   "4": "NOR gate",
@@ -20,6 +21,7 @@
   "18": "4-bit Mod 3 Remainder"
 },
   "levelGridSizes": {
+    "0": [6, 6],
     "1": [6, 6],
     "2": [6, 6],
     "3": [6, 6],
@@ -40,6 +42,13 @@
     "18": [15, 15]
   },
   "levelBlockSets": {
+    "0": [
+      { "type": "INPUT", "name": "IN1" },
+      { "type": "INPUT", "name": "IN2" },
+      { "type": "OUTPUT", "name": "OUT1" },
+      { "type": "NOT" },
+      { "type": "AND" }
+    ],
     "1": [
       { "type": "INPUT", "name": "IN1" },
       { "type": "OUTPUT", "name": "OUT1" },
@@ -223,6 +232,12 @@
   },
   "chapterData": [
     {
+      "id": "tutorial",
+      "name": "Tutorial",
+      "desc": "Learn how to place blocks, draw wires, and grade circuits.",
+      "stages": [0]
+    },
+    {
       "id": "basic",
       "name": "Basic Logic Gates",
       "desc": "Practice basic gates such as NOT, AND, and OR.",
@@ -242,6 +257,12 @@
     }
   ],
   "levelAnswers": {
+    "0": [
+      { "inputs": { "IN1": 0, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 0, "IN2": 1 }, "expected": { "OUT1": 1 } },
+      { "inputs": { "IN1": 1, "IN2": 0 }, "expected": { "OUT1": 0 } },
+      { "inputs": { "IN1": 1, "IN2": 1 }, "expected": { "OUT1": 0 } }
+    ],
     "1": [
       { "inputs": { "IN1": 0 }, "expected": { "OUT1": 1 } },
       { "inputs": { "IN1": 1 }, "expected": { "OUT1": 0 } }
@@ -1269,6 +1290,16 @@
 
   },
   "levelDescriptions": {
+    "0": {
+      "title": "Tutorial: invert then AND",
+      "desc": "Flip IN1 with a NOT gate, then feed it into AND along with IN2 so OUT1 only turns on when IN1 is 0 and IN2 is 1.",
+      "table": [
+        { "IN1": 0, "IN2": 0, "OUT1": 0 },
+        { "IN1": 0, "IN2": 1, "OUT1": 1 },
+        { "IN1": 1, "IN2": 0, "OUT1": 0 },
+        { "IN1": 1, "IN2": 1, "OUT1": 0 }
+      ]
+    },
     "1": {
       "title": "Stage 1: NOT Gate",
       "desc": "The NOT gate outputs 0 when the input is 1 and outputs 1 when the input is 0.",

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ import * as uiModule from './modules/ui.js';
 import { openHintModal, initializeHintUI } from './modules/hints.js';
 import { initializeTutorials } from './modules/tutorials.js';
 import { createGradingController } from './modules/grading.js';
+import { createTutorialStageGuide } from './modules/tutorialStageGuide.js';
 import {
   initializeCircuitShare,
   initializeStatusShare,
@@ -124,6 +125,13 @@ onCircuitModified(context => {
 });
 
 const translate = typeof t === 'function' ? t : key => key;
+
+const tutorialGuide = createTutorialStageGuide({
+  translate,
+  getCurrentLevel,
+  getPlayCircuit,
+  onCircuitModified
+});
 
 const toastContainer = document.getElementById('toastContainer') ?? (() => {
   const el = document.createElement('div');
@@ -453,6 +461,7 @@ const gameScreen = document.getElementById("gameScreen");
 const stageMapScreen = document.getElementById('stageMapScreen');
 
 document.getElementById("backToLevelsBtn").onclick = async () => {
+  tutorialGuide.deactivate();
   await returnToLevels({
     isCustomProblemActive: Boolean(getActiveCustomProblem()),
     onClearCustomProblem: clearActiveCustomProblem
@@ -655,6 +664,7 @@ configureLevelModule({
 
 const gradeButton = document.getElementById('gradeButton');
 if (gradeButton) {
+  tutorialGuide.bindGradeButton(gradeButton);
   gradeButton.addEventListener('click', () => {
     if (circuitHasError) {
       alert(translate('circuitErrorAlert'));
@@ -676,8 +686,11 @@ initializeRankingUI({
 });
 
 configureLevelModule({
-  onLevelIntroComplete: () =>
-    collapseMenuBarForMobile({ onAfterCollapse: updatePadding })
+  onLevelIntroComplete: () => {
+    collapseMenuBarForMobile({ onAfterCollapse: updatePadding });
+    tutorialGuide.handleLevelIntroComplete();
+  },
+  onLevelStarted: tutorialGuide.handleLevelStarted
 });
 
 function parseColorToRgb(color) {

--- a/src/modules/levels.js
+++ b/src/modules/levels.js
@@ -26,7 +26,8 @@ const dependencies = {
   showStageTutorial: null,
   showOverallRanking: null,
   setIsScoring: null,
-  onLevelIntroComplete: null
+  onLevelIntroComplete: null,
+  onLevelStarted: null
 };
 
 export function configureLevelModule(options = {}) {
@@ -138,6 +139,10 @@ export async function startLevel(level, { onIntroComplete } = {}) {
     createPaletteForLevel(level),
     { enableCopyPaste: level >= 7 }
   );
+
+  if (typeof dependencies.onLevelStarted === 'function') {
+    dependencies.onLevelStarted(currentLevel);
+  }
 
   showLevelIntro(level, () => {
     if (typeof onIntroComplete === 'function') {

--- a/src/modules/stageMap.js
+++ b/src/modules/stageMap.js
@@ -274,8 +274,9 @@ function buildNode(node, nodeTypes, getLevelTitle) {
   const rectSize = gridSizeToWorldSize(size);
   const rect = { x: rectOrigin.x, y: rectOrigin.y, w: rectSize.width, h: rectSize.height };
   const level = STAGE_NODE_LEVEL_MAP[node.id] ?? null;
-  const title = level ? (getLevelTitle?.(level) ?? node.label) : node.label;
-  const comingSoon = node.nodeType === 'stage' && level == null;
+  const hasLevel = level !== null && level !== undefined;
+  const title = hasLevel ? (getLevelTitle?.(level) ?? node.label) : node.label;
+  const comingSoon = node.nodeType === 'stage' && !hasLevel;
   return {
     ...node,
     level,
@@ -722,7 +723,9 @@ export function initializeStageMap({
     let displayCleared = false;
     let progressCleared = false;
 
-    if (node.level) {
+    const hasLevel = node.level !== null && node.level !== undefined;
+
+    if (hasLevel) {
       // Stage nodes unlock purely from stage_map edge requirements.
       if (typeof isLevelUnlocked === 'function') {
         // Preserve legacy side effects without letting the callback gate access.

--- a/src/modules/stageMapLayout.js
+++ b/src/modules/stageMapLayout.js
@@ -4,7 +4,7 @@ export const GRID_UNIT = CELL + GAP;
 
 export const STAGE_NODE_LEVEL_MAP = {
   bit_solver: null,
-  tutorial: null,
+  tutorial: 0,
   not: 1,
   nand: 5,
   nor: 4,

--- a/src/modules/tutorialStageGuide.js
+++ b/src/modules/tutorialStageGuide.js
@@ -1,0 +1,262 @@
+const TUTORIAL_LEVEL = 0;
+
+const REQUIRED_BLOCKS = [
+  { type: 'INPUT', name: 'IN1' },
+  { type: 'INPUT', name: 'IN2' },
+  { type: 'NOT' },
+  { type: 'AND' },
+  { type: 'OUTPUT', name: 'OUT1' }
+];
+
+const RECOMMENDED_POSITIONS = {
+  IN1: { r: 2, c: 2 },
+  IN2: { r: 4, c: 2 },
+  NOT: { r: 2, c: 4 },
+  AND: { r: 3, c: 5 },
+  OUT1: { r: 3, c: 6 }
+};
+
+const WIRE_TARGETS = [
+  ['IN1', 'NOT'],
+  ['NOT', 'AND'],
+  ['IN2', 'AND'],
+  ['AND', 'OUT1']
+];
+
+function safeTranslate(translate, key, fallback) {
+  if (typeof translate === 'function') {
+    const value = translate(key);
+    if (typeof value === 'string' && value !== key) return value;
+  }
+  return fallback || key;
+}
+
+function formatPosition({ r, c }) {
+  return `r${r} · c${c}`;
+}
+
+function createLocationsLine(translate) {
+  const parts = [
+    `IN1: ${formatPosition(RECOMMENDED_POSITIONS.IN1)}`,
+    `IN2: ${formatPosition(RECOMMENDED_POSITIONS.IN2)}`,
+    `NOT: ${formatPosition(RECOMMENDED_POSITIONS.NOT)}`,
+    `AND: ${formatPosition(RECOMMENDED_POSITIONS.AND)}`,
+    `OUT1: ${formatPosition(RECOMMENDED_POSITIONS.OUT1)}`
+  ];
+  return safeTranslate(translate, 'tutorialMissionPositionLine', parts.join(' · '));
+}
+
+function createWireLine(translate) {
+  const sequence = ['IN1→NOT', 'NOT→AND', 'IN2→AND', 'AND→OUT1'];
+  return safeTranslate(translate, 'tutorialMissionWireLine', sequence.join(', '));
+}
+
+export function createTutorialStageGuide({
+  translate,
+  getCurrentLevel,
+  getPlayCircuit,
+  onCircuitModified,
+  gradeButton
+} = {}) {
+  const t = key => safeTranslate(translate, key, key);
+
+  const panel = document.getElementById('tutorialMissionPanel');
+  const eyebrowEl = document.getElementById('tutorialMissionEyebrow');
+  const titleEl = document.getElementById('tutorialMissionTitle');
+  const subtitleEl = document.getElementById('tutorialMissionSubtitle');
+
+  const placeTitleEl = document.getElementById('tutorialStepPlaceTitle');
+  const placeBodyEl = document.getElementById('tutorialStepPlaceBody');
+  const placeHintEl = document.getElementById('tutorialStepPlaceHint');
+
+  const wireTitleEl = document.getElementById('tutorialStepWireTitle');
+  const wireBodyEl = document.getElementById('tutorialStepWireBody');
+  const wireHintEl = document.getElementById('tutorialStepWireHint');
+
+  const gradeTitleEl = document.getElementById('tutorialStepGradeTitle');
+  const gradeBodyEl = document.getElementById('tutorialStepGradeBody');
+  const gradeHintEl = document.getElementById('tutorialStepGradeHint');
+
+  const statusLabels = {
+    blocks: document.querySelector('[data-step="place"]'),
+    wires: document.querySelector('[data-step="wire"]'),
+    grade: document.querySelector('[data-step="grade"]')
+  };
+
+  let active = false;
+  let state = { blocks: false, wires: false, gradeClicked: false };
+  let detachCircuitListener = null;
+  let gradeListener = null;
+  let boundGradeButton = gradeButton;
+
+  function renderCopy() {
+    if (!panel) return;
+    if (eyebrowEl) eyebrowEl.textContent = t('tutorialMissionEyebrow');
+    if (titleEl) titleEl.textContent = t('tutorialMissionTitle');
+    if (subtitleEl) subtitleEl.textContent = t('tutorialMissionSubtitle');
+
+    if (placeTitleEl) placeTitleEl.textContent = t('tutorialMissionPlaceTitle');
+    if (placeBodyEl) placeBodyEl.textContent = t('tutorialMissionPlaceBody');
+    if (placeHintEl) placeHintEl.textContent = createLocationsLine(t);
+
+    if (wireTitleEl) wireTitleEl.textContent = t('tutorialMissionWireTitle');
+    if (wireBodyEl) wireBodyEl.textContent = t('tutorialMissionWireBody');
+    if (wireHintEl) wireHintEl.textContent = createWireLine(t);
+
+    if (gradeTitleEl) gradeTitleEl.textContent = t('tutorialMissionGradeTitle');
+    if (gradeBodyEl) gradeBodyEl.textContent = t('tutorialMissionGradeBody');
+    if (gradeHintEl) gradeHintEl.textContent = t('tutorialMissionGradeHint');
+  }
+
+  function updateClasses() {
+    const gradeDone = state.gradeClicked && state.wires;
+    const steps = [
+      ['place', state.blocks],
+      ['wire', state.wires],
+      ['grade', gradeDone]
+    ];
+    let activeAssigned = false;
+
+    steps.forEach(([step, done]) => {
+      const item = statusLabels[step];
+      if (!item) return;
+      const isActive = !done && !activeAssigned && active;
+      if (!done && !activeAssigned) {
+        activeAssigned = true;
+      }
+      item.classList.toggle('is-complete', done);
+      item.classList.toggle('is-active', isActive);
+    });
+  }
+
+  function getBlocksByName(circuit) {
+    const blocks = Object.values(circuit?.blocks || {});
+    const byName = new Map();
+    REQUIRED_BLOCKS.forEach(req => {
+      const found = blocks.find(block => {
+        if (block.type !== req.type) return false;
+        if (req.name && block.name !== req.name) return false;
+        return true;
+      });
+      if (found) {
+        const key = req.name || req.type;
+        byName.set(key, found);
+      }
+    });
+    return byName;
+  }
+
+  function hasRequiredBlocks(circuit) {
+    const byName = getBlocksByName(circuit);
+    return REQUIRED_BLOCKS.every(req => {
+      const key = req.name || req.type;
+      return byName.has(key);
+    });
+  }
+
+  function hasRequiredWires(circuit) {
+    const byName = getBlocksByName(circuit);
+    const wires = Object.values(circuit?.wires || {});
+
+    return WIRE_TARGETS.every(([fromKey, toKey]) => {
+      const from = byName.get(fromKey);
+      const to = byName.get(toKey);
+      if (!from || !to) return false;
+      return wires.some(w =>
+        (w.startBlockId === from.id && w.endBlockId === to.id) ||
+        (w.startBlockId === to.id && w.endBlockId === from.id)
+      );
+    });
+  }
+
+  function evaluateProgress() {
+    if (!active) return;
+    const circuit = typeof getPlayCircuit === 'function' ? getPlayCircuit() : null;
+    if (!circuit) return;
+
+    state.blocks = hasRequiredBlocks(circuit);
+    state.wires = state.blocks && hasRequiredWires(circuit);
+    updateClasses();
+  }
+
+  function attachCircuitListener() {
+    if (typeof onCircuitModified !== 'function') return;
+    detachCircuitListener = onCircuitModified(() => evaluateProgress());
+  }
+
+  function detachListeners() {
+    if (typeof detachCircuitListener === 'function') {
+      detachCircuitListener();
+      detachCircuitListener = null;
+    }
+    if (boundGradeButton && gradeListener) {
+      boundGradeButton.removeEventListener('click', gradeListener);
+      gradeListener = null;
+    }
+  }
+
+  function ensureGradeListener() {
+    if (!boundGradeButton || gradeListener) return;
+    gradeListener = () => {
+      if (!active || !state.wires) return;
+      state.gradeClicked = true;
+      updateClasses();
+    };
+    boundGradeButton.addEventListener('click', gradeListener);
+  }
+
+  function activate() {
+    if (active) return;
+    active = true;
+    state = { blocks: false, wires: false, gradeClicked: false };
+    renderCopy();
+    if (panel) panel.hidden = false;
+    attachCircuitListener();
+    ensureGradeListener();
+    evaluateProgress();
+    updateClasses();
+  }
+
+  function deactivate() {
+    if (!active) return;
+    active = false;
+    state = { blocks: false, wires: false, gradeClicked: false };
+    detachListeners();
+    if (panel) panel.hidden = true;
+    updateClasses();
+  }
+
+  function handleLevelStarted(level) {
+    const numericLevel = Number(level);
+    if (Number.isFinite(numericLevel) && numericLevel === TUTORIAL_LEVEL) {
+      activate();
+    } else {
+      deactivate();
+    }
+  }
+
+  function handleLevelIntroComplete() {
+    if (!active) return;
+    if (panel) {
+      panel.classList.add('tutorial-mission-panel--visible');
+    }
+    evaluateProgress();
+    updateClasses();
+  }
+
+  function bindGradeButton(button) {
+    if (button === boundGradeButton) return;
+    detachListeners();
+    boundGradeButton = button;
+    if (active) {
+      ensureGradeListener();
+    }
+  }
+
+  return {
+    handleLevelStarted,
+    handleLevelIntroComplete,
+    bindGradeButton,
+    deactivate
+  };
+}

--- a/style.css
+++ b/style.css
@@ -773,6 +773,124 @@ html, body {
   background-color: #2563eb;
   color: #f8fafc;
 }
+
+.tutorial-mission-panel {
+  position: fixed;
+  top: 14px;
+  left: 14px;
+  z-index: 25;
+  width: min(360px, 92vw);
+  background: rgba(15, 23, 42, 0.92);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 12px;
+  padding: 14px 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(6px);
+}
+
+.tutorial-mission__header {
+  margin-bottom: 8px;
+}
+
+.tutorial-mission__eyebrow {
+  margin: 0 0 4px;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.tutorial-mission__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.tutorial-mission__subtitle {
+  margin: 4px 0 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.tutorial-mission__list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tutorial-mission__item {
+  display: grid;
+  grid-template-columns: 20px 1fr;
+  gap: 8px;
+  padding: 8px 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.tutorial-mission__item:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.tutorial-mission__status {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.8);
+  box-sizing: border-box;
+  margin-top: 4px;
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.tutorial-mission__heading {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #e0f2fe;
+}
+
+.tutorial-mission__body {
+  margin: 4px 0;
+  line-height: 1.35;
+}
+
+.tutorial-mission__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.tutorial-mission__item.is-active .tutorial-mission__status {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.12);
+}
+
+.tutorial-mission__item.is-complete .tutorial-mission__status {
+  background: #22c55e;
+  border-color: #16a34a;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.16);
+}
+
+.tutorial-mission__item.is-complete .tutorial-mission__heading {
+  color: #bbf7d0;
+}
+
+.tutorial-mission__item.is-complete .tutorial-mission__hint {
+  color: rgba(203, 213, 225, 0.8);
+  text-decoration: line-through;
+}
+
+@media (max-width: 640px) {
+  .tutorial-mission-panel {
+    left: 8px;
+    right: 8px;
+    width: auto;
+    top: 8px;
+  }
+}
   .toggle-key {
     display: block;
     margin: 6px 0;


### PR DESCRIPTION
## Summary
- add a dedicated tutorial stage mapped on the stage map with new level data and descriptions
- create an in-game mission overlay that guides block placement, wiring, and grading for the tutorial circuit
- wire tutorial progression into level start flow and translations in both Korean and English

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924586ecefc833296e37f5615cee796)